### PR TITLE
Update HashProcessor for upcoming ROBLOX API changes

### DIFF
--- a/Modules/Utility/HashProcessor.lua
+++ b/Modules/Utility/HashProcessor.lua
@@ -1,4 +1,4 @@
-local RenderStepped = game:GetService("RunService").RenderStepped
+local Heartbeat = game:GetService("RunService").Heartbeat
 
 local HashProcessor = {}
 HashProcessor.__index = HashProcessor
@@ -7,7 +7,7 @@ HashProcessor.__index = HashProcessor
 -- @author Quenty
 
 function HashProcessor.new(OnProcess, OnAddition, OnRemoval)
-	-- Processes at the speed of RenderStep
+	-- Processes at the speed of Heartbeat
 	-- OnAddition and OnRemoval are optional
 		-- function(HashProcessor, Index, Item)
 
@@ -23,7 +23,7 @@ function HashProcessor.new(OnProcess, OnAddition, OnRemoval)
 	self.ProcessCoroutine = coroutine.create(function()
 		while true do
 			repeat
-				RenderStepped:wait()
+				Heartbeat:wait()
 			until self:Process() <= 0
 
 			self.Processing = false


### PR DESCRIPTION
Changed RenderStepped to Heartbeat because the hash processor is not dependant on frame rate.
Please refer to the following article:
http://devforum.roblox.com/t/runservice-heartbeat-switching-to-variable-frequency/23509