### PR TITLE
Fixing inconsistencies in requiring

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Sample:
 --- Documentation goes first
 -- @classmod ClassName
 
-local require = require(game:GetService("ReplicatedStorage"):WaitForChild("NevermoreEngine"))
+local require = require(game:GetService("ReplicatedStorage"):WaitForChild("Nevermore"))
 
 
 ```

--- a/Doc/Examples/SnackbarClientMain.lua
+++ b/Doc/Examples/SnackbarClientMain.lua
@@ -1,4 +1,4 @@
-local require = require(game:GetService("ReplicatedStorage"):WaitForChild("NevermoreEngine"))
+local require = require(game:GetService("ReplicatedStorage"):WaitForChild("Nevermore"))
 
 local Players = game:GetService("Players")
 local UserInputService = game:GetService("UserInputService")

--- a/Doc/Manual/02_usage.md
+++ b/Doc/Manual/02_usage.md
@@ -3,7 +3,7 @@ Here's an example of using Nevermore
 
 ```lua
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local LoadCustomLibrary = require(ReplicatedStorage:WaitForChild("NevermoreEngine"))
+local LoadCustomLibrary = require(ReplicatedStorage:WaitForChild("Nevermore"))
 
 
 -- Do actual things


### PR DESCRIPTION
Some areas of the code were still using `NevermoreEngine` as the module name in ReplicatedStorage when it should have been using just `Nevermore`.