### PR TITLE
Make obvious which funcs are class constructors

### DIFF
--- a/Modules/Gui/RoundedBacking/RoundedBackingBuilder.lua
+++ b/Modules/Gui/RoundedBacking/RoundedBackingBuilder.lua
@@ -2,23 +2,22 @@
 -- @classmod RoundedBackingBuilder
 
 local RoundedBackingBuilder = {}
-RoundedBackingBuilder.__index = RoundedBackingBuilder
-RoundedBackingBuilder.ClassName = "RoundedBackingBuilder"
+RoundedBackingBuilder.__index = {
+	ClassName = "RoundedBackingBuilder";
+}
 
 function RoundedBackingBuilder.new()
-	local self = setmetatable({}, RoundedBackingBuilder)
-
-	return self
+	return setmetatable({}, RoundedBackingBuilder)
 end
 
-function RoundedBackingBuilder:Create(gui)
+function RoundedBackingBuilder.__index:Create(gui)
 	local backing = self:CreateBacking(gui)
 	self:CreateShadow(backing)
 
 	return backing
 end
 
-function RoundedBackingBuilder:CreateBacking(gui)
+function RoundedBackingBuilder.__index:CreateBacking(gui)
 	local backing = Instance.new("ImageLabel")
 	backing.Name = "Backing"
 	backing.Size = UDim2.new(1, 0, 1, 0)
@@ -36,7 +35,7 @@ function RoundedBackingBuilder:CreateBacking(gui)
 end
 
 --- Only top two corners are rounded
-function RoundedBackingBuilder:CreateTopBacking(gui)
+function RoundedBackingBuilder.__index:CreateTopBacking(gui)
 	local backing = self:CreateBacking(gui)
 	backing.ImageRectSize = Vector2.new(20, 16)
 	backing.SliceCenter = Rect.new(4, 4, 16, 16)
@@ -44,7 +43,7 @@ function RoundedBackingBuilder:CreateTopBacking(gui)
 	return backing
 end
 
-function RoundedBackingBuilder:CreateLeftBacking(gui)
+function RoundedBackingBuilder.__index:CreateLeftBacking(gui)
 	local backing = self:CreateBacking(gui)
 	backing.ImageRectSize = Vector2.new(16, 20)
 	backing.SliceCenter = Rect.new(4, 4, 16, 16)
@@ -52,7 +51,7 @@ function RoundedBackingBuilder:CreateLeftBacking(gui)
 	return backing
 end
 
-function RoundedBackingBuilder:CreateRightBacking(gui)
+function RoundedBackingBuilder.__index:CreateRightBacking(gui)
 	local backing = self:CreateBacking(gui)
 	backing.ImageRectSize = Vector2.new(16, 20)
 	backing.SliceCenter = Rect.new(4, 4, 16, 16)
@@ -62,7 +61,7 @@ function RoundedBackingBuilder:CreateRightBacking(gui)
 end
 
 --- Only bottom two corners are rounded
-function RoundedBackingBuilder:CreateBottomBacking(gui)
+function RoundedBackingBuilder.__index:CreateBottomBacking(gui)
 	local backing = self:CreateBacking(gui)
 	backing.ImageRectSize = Vector2.new(20, 16)
 	backing.ImageRectOffset = Vector2.new(0, 4)
@@ -71,7 +70,7 @@ function RoundedBackingBuilder:CreateBottomBacking(gui)
 	return backing
 end
 
-function RoundedBackingBuilder:CreateTopShadow(backing)
+function RoundedBackingBuilder.__index:CreateTopShadow(backing)
 	local shadow = self:CreateShadow(backing)
 	shadow.ImageRectSize = Vector2.new(80, 64)
 	shadow.SliceCenter = Rect.new(16, 16, 64, 64)
@@ -79,7 +78,7 @@ function RoundedBackingBuilder:CreateTopShadow(backing)
 	return shadow
 end
 
-function RoundedBackingBuilder:CreateShadow(backing)
+function RoundedBackingBuilder.__index:CreateShadow(backing)
 	local shadow = Instance.new("ImageLabel")
 	shadow.Name = "Shadow"
 	shadow.Size = UDim2.new(1, 6, 1, 6)


### PR DESCRIPTION
For someone less adept in Lua, it can be unobvious which of these functions are constructors, because they all look constructor-like:
```lua
-- Given ScreenGui ScreenGui
-- The previous code made it unobvious that Create is a method of an already-constructed object

local RoundedBackingBuilder = RoundedBackingBuilder:Create(ScreenGui)

-- If I only need a Shadow, might I think this is possible?
local RoundedBackingShadow = RoundedBackingBuilder:CreateShadow(ScreenGui)
```

I believe that standardizing the syntax contained within this pull request or something like it will make undocumented classes much easier to read and understand.