### PR TITLE
Fix invalid module in Binder.lua

### DIFF
--- a/Modules/Utility/Binder.lua
+++ b/Modules/Utility/Binder.lua
@@ -7,7 +7,7 @@ local RunService = game:GetService("RunService")
 local CollectionService = game:GetService("CollectionService")
 
 local Maid = require("Maid")
-local fastSpawn = require("fastSpawn")
+local fastSpawn = require("FastSpawn")
 
 local Binder = {}
 Binder.__index = Binder


### PR DESCRIPTION
The current version of Binder requires “fastSpawn”, however the name has been capitalised in the repository to “FastSpawn”. This just fixes that

I don’t know if you want to change the variable name to FastSpawn - in line with Maid being capitalised.