### PR TITLE
Update init.lua

### DIFF
--- a/loader/ReplicatedStorage/Nevermore/init.lua
+++ b/loader/ReplicatedStorage/Nevermore/init.lua
@@ -157,7 +157,7 @@ local function replicateRepository(replicationFolder, libCache, topParent)
 
 	-- Remove client-only libraries
 	for _, name in pairs(toRemove) do
-		toRemove[name] = nil
+		libCache[name] = nil
 	end
 end
 


### PR DESCRIPTION
**Specific update:** private method replicateRepository

I'm not quite sure if it's a misunderstanding of mine, but I don't believe the original code actually removed client-only libraries. It simply got names of client-only libraries and placed them into a toRemove table, then set an indice in the toRemove table with the library's name to nil. Perhaps that was meant to set the indice in libCache to nil to actually remove it from the cache?