### PR TITLE
Update CollectionServiceUtils.lua

### DIFF
--- a/Modules/Shared/CollectionService/CollectionServiceUtils.lua
+++ b/Modules/Shared/CollectionService/CollectionServiceUtils.lua
@@ -19,21 +19,20 @@ function CollectionServiceUtils.findFirstAncestor(tagName, child)
 	return nil
 end
 
-function CollectionServiceUtils.findNearestPartWithTag(tagName, basePart)
+function CollectionServiceUtils.findNearestPartWithTag(tagName, position)
 	assert(type(tagName) == "string")
-	assert(typeof(basePart) == "Instance" and basePart:IsA("BasePart"))
+	assert(typeof(position) == "Vector3")
 
 	local taggedInstances = CollectionService:GetTagged(tagName)
 	local length = #taggedInstances
 	if length > 0 then
 		local currentDistance = math.huge
 		local foundPart = nil
-		local basePosition = basePart.Position
 
 		for index = 1, length do
 			local child = taggedInstances[index]
 			if child:IsA("BasePart") then
-				local magnitude = (child.Position - basePosition).Magnitude
+				local magnitude = (child.Position - position).Magnitude
 				if magnitude < currentDistance then
 					currentDistance = magnitude
 					foundPart = child

--- a/Modules/Shared/CollectionService/CollectionServiceUtils.lua
+++ b/Modules/Shared/CollectionService/CollectionServiceUtils.lua
@@ -19,5 +19,33 @@ function CollectionServiceUtils.findFirstAncestor(tagName, child)
 	return nil
 end
 
+function CollectionServiceUtils.findNearestPartWithTag(tagName, basePart)
+	assert(type(tagName) == "string")
+	assert(typeof(basePart) == "Instance" and basePart:IsA("BasePart"))
+
+	local taggedInstances = CollectionService:GetTagged(tagName)
+	local length = #taggedInstances
+	if length > 0 then
+		local currentDistance = math.huge
+		local foundPart = nil
+		local basePosition = basePart.Position
+
+		for index = 1, length do
+			local child = taggedInstances[index]
+			if child:IsA("BasePart") then
+				local magnitude = (child.Position - basePosition).Magnitude
+				if magnitude < currentDistance then
+					currentDistance = magnitude
+					foundPart = child
+				end
+			end
+		end
+
+		return foundPart
+	else
+		warn(("Nothing has the tag %s"):format(tagName))
+		return nil
+	end
+end
 
 return CollectionServiceUtils


### PR DESCRIPTION
Added `findNearestPartWithTag`. Used for searching around a given BasePart to find what part with the given tag is nearest to it.

Sorry if the code is inconsistent with your style, it's my best attempt at mocking the preexisting code.