### PR TITLE
Update fastSpawn.lua

### DIFF
--- a/Modules/Shared/Utility/fastSpawn.lua
+++ b/Modules/Shared/Utility/fastSpawn.lua
@@ -1,18 +1,12 @@
 --- An expensive way to spawn a function. However, unlike spawn(), it executes on the same frame, and
 -- unlike coroutines, does not obscure errors
 -- @module fastSpawn
+local bindable = Instance.new('BindableEvent')
+
+bindable.Event:Connect(function(func, ...) func(...) end)
 
 return function(func, ...)
-	assert(type(func) == "function")
+	assert(type(func) == 'function')
 
-	local args = {...}
-	local count = select("#", ...)
-
-	local bindable = Instance.new("BindableEvent")
-	bindable.Event:Connect(function()
-		func(unpack(args, 1, count))
-	end)
-
-	bindable:Fire()
-	bindable:Destroy()
+	bindable:Fire(func, ...)
 end


### PR DESCRIPTION
Function can be simplified. Use of a single BindableEvent greatly reduces overhead.