### PR TITLE
Improve performance of ParticleEngineClient

### DIFF
--- a/Modules/Client/Particles/ParticleEngineClient.lua
+++ b/Modules/Client/Particles/ParticleEngineClient.lua
@@ -3,18 +3,11 @@
 
 local require = require(game:GetService("ReplicatedStorage"):WaitForChild("Nevermore"))
 
-local Players = game:GetService("Players")
 local Workspace = game:GetService("Workspace")
+local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
 
 local GetRemoteEvent = require("GetRemoteEvent")
-
-local sin = math.sin
-local sqrt = math.sqrt
-local atan2 = math.atan2
-local v2 = Vector2.new
-local v3 = Vector3.new
-local ud2 = UDim2.new
 
 local ParticleEngineClient = {}
 
@@ -38,21 +31,21 @@ function ParticleEngineClient:Init(screen)
 	self._player = Players.LocalPlayer or error("No LocalPlayer")
 
 	self._remoteEvent.OnClientEvent:Connect(function(...)
-		self:ParticleNew(...)
+		self:Add(...)
 	end)
 
 	self._lastUpdateTime = tick()
 	self._particleCount = 0
 	self._particles = {}
-	self._particleFrames = {}
+	self._particleFrames = table.create(self._maxParticles)
 
 	for i=1, self._maxParticles do
 		self._particleFrames[i] = newFrame("_particle")
 	end
 
-	RunService.Heartbeat:Connect(function()
+	RunService.Heartbeat:Connect(function(dt)
 		debug.profilebegin("ParticleUpdate")
-		self:_update()
+		self:_update(dt)
 		debug.profileend()
 	end)
 
@@ -66,6 +59,11 @@ function ParticleEngineClient:Remove(p)
 		self._particleCount = self._particleCount - 1
 	end
 end
+
+local EMPTY_VECTOR3 = Vector3.new()
+local EMPTY_VECTOR2 = Vector2.new()
+local DEFAULT_SIZE = Vector2.new(0.2, 0.2)
+local WHITE_COLOR3 = Color3.new(1, 1, 1)
 
 -- Adds a new particle
 -- @param p PropertiesTable
@@ -93,12 +91,12 @@ function ParticleEngineClient:Add(p)
 		return
 	end
 
-	p.Position = p.Position or Vector3.new()
-	p.Velocity = p.Velocity or Vector3.new()
-	p.Size = p.Size or v2(0.2,0.2)
-	p.Bloom = p.Bloom or v2()
-	p.Gravity = p.Gravity or Vector3.new()
-	p.Color = p.Color or Color3.new(1,1,1)
+	p.Position = p.Position or EMPTY_VECTOR3
+	p.Velocity = p.Velocity or EMPTY_VECTOR3
+	p.Size = p.Size or DEFAULT_SIZE
+	p.Bloom = p.Bloom or EMPTY_VECTOR2
+	p.Gravity = p.Gravity or EMPTY_VECTOR3
+	p.Color = p.Color or WHITE_COLOR3
 	p.Transparency = p.Transparency or 0.5
 
 	if p.Global then
@@ -128,10 +126,10 @@ end
 -- @param p Position
 local function particleWind(t, p)
 	local xy,yz,zx=p.x+p.y,p.y+p.z,p.z+p.x
-	return v3(
-		(sin(yz+t*2)+sin(yz+t))/2+sin((yz+t)/10)/2,
-		(sin(zx+t*2)+sin(zx+t))/2+sin((zx+t)/10)/2,
-		(sin(xy+t*2)+sin(xy+t))/2+sin((xy+t)/10)/2
+	return Vector3.new(
+		(math.sin(yz+t*2)+math.sin(yz+t))/2+math.sin((yz+t)/10)/2,
+		(math.sin(zx+t*2)+math.sin(zx+t))/2+math.sin((zx+t)/10)/2,
+		(math.sin(xy+t*2)+math.sin(xy+t))/2+math.sin((xy+t)/10)/2
 	)
 end
 
@@ -144,11 +142,15 @@ function ParticleEngineClient:_updatePosVel(p, dt, t)
 	if p.WindResistance then
 		wind = (particleWind(t, p.Position)*self._windSpeed - p.Velocity)*p.WindResistance
 	else
-		wind = v3()
+		wind = EMPTY_VECTOR3
 	end
 
 	p.Velocity = p.Velocity + (p.Gravity + wind)*dt
 end
+
+local renderParams = RaycastParams.new()
+renderParams.IgnoreWater = true
+renderParams.FilterType = Enum.RaycastFilterType.Blacklist
 
 --- Handles both priority and regular particles
 -- @return boolean alive, true if still fine
@@ -175,14 +177,14 @@ function ParticleEngineClient:_updateParticle(particle, t, dt)
 		displacement = displacement * (999/distance)
 	end
 
-	local ray = Ray.new(lastPos, displacement)
-	local hit, position, normal, material = Workspace:FindPartOnRay(ray, self._player.Character, true)
-	if not hit then
+	renderParams.FilterDescendantsInstances = table.create(1, self._player.Character)
+	local raycastResult = Workspace:Raycast(lastPos, displacement, renderParams)
+	if not raycastResult then
 		return true
 	end
 
 	if type(particle.RemoveOnCollision) == "function" then
-		if not particle.RemoveOnCollision(particle, hit, position, normal, material) then
+		if not particle.RemoveOnCollision(particle, raycastResult.Instance, raycastResult.Position, raycastResult.Normal, raycastResult.Material) then
 			return false
 		end
 	else
@@ -192,9 +194,8 @@ function ParticleEngineClient:_updateParticle(particle, t, dt)
 	return true
 end
 
-function ParticleEngineClient:_update()
+function ParticleEngineClient:_update(dt)
 	local t = tick()
-	local dt = t - self._lastUpdateTime
 	self._lastUpdateTime = t
 
 	local toRemove = {}
@@ -219,8 +220,9 @@ function ParticleEngineClient:_updateRender()
 	local camera = Workspace.CurrentCamera
 	self:_updateScreenInfo(camera)
 
-	local cameraInverse = camera.CFrame:inverse()
-	local cameraPosition = camera.CFrame.p
+	local cameraCFrame = camera.CFrame
+	local cameraInverse = cameraCFrame:Inverse()
+	local cameraPosition = cameraCFrame.Position
 
 	local frameIndex, frame = next(self._particleFrames)
 	for particle in pairs(self._particles) do
@@ -264,8 +266,8 @@ function ParticleEngineClient:_particleRender(cameraPosition, cameraInverse, fra
 	local preSizeY = -particle.Size.y/rp.z*self._screenSizeY/self._planeSizeY
 	local sx = -particle.Size.x/rp.z*self._screenSizeY/self._planeSizeY + b.x
 	local rppx,rppy = px-lsp.x,py-lsp.y
-	local sy = preSizeY+sqrt(rppx*rppx+rppy*rppy) + b.y
-	particle._lastScreenPosition = v2(px, py)
+	local sy = preSizeY+math.sqrt(rppx*rppx+rppy*rppy) + b.y
+	particle._lastScreenPosition = Vector2.new(px, py)
 
 	if particle.Occlusion then
 		local vec = particle.Position-cameraPosition
@@ -274,14 +276,15 @@ function ParticleEngineClient:_particleRender(cameraPosition, cameraInverse, fra
 			vec = vec * (999/mag)
 		end
 
-		if Workspace:FindPartOnRay(Ray.new(cameraPosition, vec), self._player.Character, true) then
+		renderParams.FilterDescendantsInstances = table.create(1, self._player.Character)
+		if Workspace:Raycast(cameraPosition, vec, renderParams) then
 			return false
 		end
 	end
 
-	frame.Position = ud2(0, (px+lsp.x-sx)/2, 0, (py+lsp.y-sy)/2)
-	frame.Size = ud2(0, sx, 0,sy)
-	frame.Rotation = 90+atan2(rppy,rppx)*57.295779513082
+	frame.Position = UDim2.new(0, (px+lsp.x-sx)/2, 0, (py+lsp.y-sy)/2)
+	frame.Size = UDim2.new(0, sx, 0, sy)
+	frame.Rotation = 90+math.atan2(rppy,rppx)*57.295779513082
 	frame.BackgroundColor3 = particle.Color
 	frame.BackgroundTransparency = bgt+(1-bgt)*(1 - preSizeY/sy)
 


### PR DESCRIPTION
- Prefer `WorldRoot:Raycast` to `WorldRoot:FindPartOnRay`.
- Use `table.create` where possible.
- Remove cached functions
- Stop using `tick` to calculate DeltaTime and instead use the passed DeltaTime from the Heartbeat function.
- Localize constant userdata.
- Fixed the OnClientEvent function.