### PR TITLE
Incorrect folder name

### DIFF
--- a/loader/ReplicatedStorage/Nevermore/init.lua
+++ b/loader/ReplicatedStorage/Nevermore/init.lua
@@ -31,7 +31,7 @@ local MyOtherModule = require(script.MyOtherModule)
 local REPLICATION_FOLDER_NAME = "_replicationFolder"
 
 --- Set this value to nil if you don't want to load modules by default
-local SERVER_SCRIPT_SERVICE_MODULES = "Nevermore"
+local SERVER_SCRIPT_SERVICE_MODULES = "NevermoreEngine"
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local RunService = game:GetService("RunService")


### PR DESCRIPTION
When you install Nevermore, it creates a folder called NevermoreEngine, but this has the folder name set to Nevermore, which infinitely yields.