### PR TITLE
Update ClientTranslator.lua

### DIFF
--- a/Modules/Client/Localization/ClientTranslator.lua
+++ b/Modules/Client/Localization/ClientTranslator.lua
@@ -12,8 +12,6 @@ local JsonToLocalizationTable = require("JsonToLocalizationTable")
 local PseudoLocalize = require("PseudoLocalize")
 local Promise = require("Promise")
 
-assert(RunService:IsClient(), "ClientTranslator can only be required on client")
-
 local ClientTranslatorFacade = {}
 
 --- Initializes a new instance of the ClientTranslatorFacade


### PR DESCRIPTION
```lua
assert(RunService:IsClient(), "ClientTranslator can only be required on client")
```
is not needed because the <a href="https://github.com/Quenty/NevermoreEngine/blob/version2/loader/ReplicatedStorage/Nevermore/init.lua">module loader</a> already prevents serverscripts from accessing client modules