### PR TITLE
replace spawn with coroutine in MasterClock.lua

### DIFF
--- a/Modules/Shared/TimeSync/Clocks/MasterClock.lua
+++ b/Modules/Shared/TimeSync/Clocks/MasterClock.lua
@@ -18,12 +18,13 @@ function MasterClock.new(remoteEvent, remoteFunction)
 		 self._remoteEvent:FireClient(player, self:GetTime())
 	end)
 
-	spawn(function()
+	local syncCoroutine = coroutine.wrap(function()
 		while true do
 			wait(5)
 			self:_forceSync()
 		end
 	end)
+	syncCoroutine()
 
 	return self
 end


### PR DESCRIPTION
replaces spawn with coroutine.wrap for immediate start and future proofing.