### PR TITLE
Fixed heartbeatWait.lua

### DIFF
--- a/Modules/Shared/Utility/heartbeatWait.lua
+++ b/Modules/Shared/Utility/heartbeatWait.lua
@@ -10,7 +10,7 @@ return function(waitTime)
 	assert(waitTime > 0)
 
 	local startTime = tick()
-	while (tick() - startTime) >= waitTime do
+	while (tick() - startTime) < waitTime do
 		heartbeat:Wait()
 	end
 


### PR DESCRIPTION
\>= would mean the while loop never actually runs unless the waitTime is a very small number. Fixed by replacing with <