### PR TITLE
Add ./Modules/Shared/Physics/UnitUtils.lua

### DIFF
--- a/Modules/Shared/Physics/UnitUtils.lua
+++ b/Modules/Shared/Physics/UnitUtils.lua
@@ -1,0 +1,35 @@
+-- Library that is capable of converting real world to Roblox units and visa versa.
+-- @module UnitUtils
+
+local UnitUtils = {}
+-- ROBLOX equivalent of 9.81 m/s^2 as derived from the 'Realistic' setting in 'World Settings'
+UnitUtils.NORMAL_GRAVITY = 35
+-- Source: https://devforum.roblox.com/t/studs-to-metre-conversion/555264/2
+UnitUtils.STUDS_IN_METER = 1 / 0.28
+
+function UnitUtils._getRealMeter()
+	-- Make the module work for every workspace.Gravity
+	-- Always take the latest workspace.Gravity
+	local gravityScale = workspace.Gravity / UnitUtils.NORMAL_GRAVITY
+
+	return UnitUtils.STUDS_IN_METER * gravityScale
+end
+
+function UnitUtils.convertKiloGram(value, unitExponent)
+	-- Roblox water has a density of 1, indicating that it is based of the density 1000 kg/m^3
+	-- , so therefore divide by 1000
+	local realKiloGram = UnitUtils._getRealMeter() ^ 3 / 1000
+
+	return value * realKiloGram ^ unitExponent
+end
+
+function UnitUtils.convertMeter(value, unitExponent)
+	return value * UnitUtils._getRealMeter() ^ unitExponent
+end
+
+-- A density of 997 kg/m^3 can be converted like 'UnitUtils.convertMeterAndKiloGram(997, -3, 1)'
+function UnitUtils.convertMeterAndKiloGram(value, meterUnitExponent, kiloGramUnitExponent)
+	return UnitUtils.convertKiloGram(UnitUtils.convertMeter(value, meterUnitExponent), kiloGramUnitExponent)
+end
+
+return UnitUtils


### PR DESCRIPTION
UnitUtils.lua makes converting numbers that have meters and or kilograms as units from the real world to Roblox and visa versa much easier. This can be useful when importing real world numbers like 997 kg/m^3 (which is roughly the density of sea water) to Roblox.

The correctness of UnitUtils can be tested. For instance, you can simulate the buoyancy of a part with a variable size in a medium. The part should have the exact same density as the medium. If the calculations are correct, the part would stay still in the medium.

One limitation of this class is that it only works well when 'workspace.Gravity' is equal to 35. This constant is predefined in the 'Realistic' setting of 'World Settings'. It will still work, but the scale of each meter would be unrealistic.