### PR TITLE
feat: Add unit tests and other small features

### DIFF
--- a/src/binder/README.md
+++ b/src/binder/README.md
@@ -26,7 +26,7 @@ local MyClass = {}
 MyClass.__index = MyClass
 
 function MyClass.new(robloxInstance)
-	print("New tagged instance of ", robloxInstance")
+	print("New tagged instance of ", robloxInstance)
 	return setmetatable({}, MyClass)
 end
 

--- a/src/binder/package-lock.json
+++ b/src/binder/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@quenty/binder",
-      "version": "2.0.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@quenty/baseobject": "file:../baseobject",
@@ -26,7 +26,7 @@
     },
     "../baseobject": {
       "name": "@quenty/baseobject",
-      "version": "1.2.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@quenty/loader": "file:../loader",
@@ -39,9 +39,10 @@
     },
     "../brio": {
       "name": "@quenty/brio",
-      "version": "1.2.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
+        "@quenty/loader": "file:../loader",
         "@quenty/maid": "file:../maid",
         "@quenty/rx": "file:../rx"
       },
@@ -52,10 +53,11 @@
     },
     "../instanceutils": {
       "name": "@quenty/instanceutils",
-      "version": "1.2.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@quenty/brio": "file:../brio",
+        "@quenty/loader": "file:../loader",
         "@quenty/maid": "file:../maid",
         "@quenty/rx": "file:../rx"
       },
@@ -66,12 +68,13 @@
     },
     "../linkutils": {
       "name": "@quenty/linkutils",
-      "version": "1.2.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@quenty/brio": "file:../brio",
         "@quenty/instanceutils": "file:../instanceutils",
         "@quenty/loader": "file:../loader",
+        "@quenty/maid": "file:../maid",
         "@quenty/promise": "file:../promise",
         "@quenty/rx": "file:../rx"
       },
@@ -82,7 +85,7 @@
     },
     "../loader": {
       "name": "@quenty/loader",
-      "version": "1.2.0",
+      "version": "3.1.0",
       "license": "MIT",
       "funding": {
         "type": "patreon",
@@ -91,7 +94,7 @@
     },
     "../maid": {
       "name": "@quenty/maid",
-      "version": "1.2.0",
+      "version": "2.0.1",
       "license": "MIT",
       "funding": {
         "type": "patreon",
@@ -100,7 +103,7 @@
     },
     "../promise": {
       "name": "@quenty/promise",
-      "version": "1.2.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@quenty/deferred": "file:../deferred",
@@ -114,7 +117,7 @@
     },
     "../signal": {
       "name": "@quenty/signal",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "license": "MIT",
       "funding": {
         "type": "patreon",
@@ -123,10 +126,11 @@
     },
     "../valueobject": {
       "name": "@quenty/valueobject",
-      "version": "1.2.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@quenty/brio": "file:../brio",
+        "@quenty/loader": "file:../loader",
         "@quenty/maid": "file:../maid",
         "@quenty/rx": "file:../rx",
         "@quenty/signal": "file:../signal"
@@ -184,6 +188,7 @@
     "@quenty/brio": {
       "version": "file:../brio",
       "requires": {
+        "@quenty/loader": "file:../loader",
         "@quenty/maid": "file:../maid",
         "@quenty/rx": "file:../rx"
       }
@@ -192,6 +197,7 @@
       "version": "file:../instanceutils",
       "requires": {
         "@quenty/brio": "file:../brio",
+        "@quenty/loader": "file:../loader",
         "@quenty/maid": "file:../maid",
         "@quenty/rx": "file:../rx"
       }
@@ -202,6 +208,7 @@
         "@quenty/brio": "file:../brio",
         "@quenty/instanceutils": "file:../instanceutils",
         "@quenty/loader": "file:../loader",
+        "@quenty/maid": "file:../maid",
         "@quenty/promise": "file:../promise",
         "@quenty/rx": "file:../rx"
       }
@@ -227,6 +234,7 @@
       "version": "file:../valueobject",
       "requires": {
         "@quenty/brio": "file:../brio",
+        "@quenty/loader": "file:../loader",
         "@quenty/maid": "file:../maid",
         "@quenty/rx": "file:../rx",
         "@quenty/signal": "file:../signal"

--- a/src/binder/src/Shared/Binder.lua
+++ b/src/binder/src/Shared/Binder.lua
@@ -18,7 +18,7 @@ local MyClass = {}
 MyClass.__index = MyClass
 
 function MyClass.new(robloxInstance)
-	print("New tagged instance of ", robloxInstance")
+	print("New tagged instance of ", robloxInstance)
 	return setmetatable({}, MyClass)
 end
 

--- a/src/binder/src/Shared/Binder.lua
+++ b/src/binder/src/Shared/Binder.lua
@@ -7,6 +7,7 @@ local RunService = game:GetService("RunService")
 local CollectionService = game:GetService("CollectionService")
 
 local Maid = require("Maid")
+local MaidTaskUtils = require("MaidTaskUtils")
 local Signal = require("Signal")
 local promiseBoundClass = require("promiseBoundClass")
 --[[
@@ -286,13 +287,9 @@ function Binder:_add(inst)
 	end
 
 	self._pendingInstSet[inst] = nil
-
-	if not (type(class) == "table" and type(class.Destroy) == "function") then
-		warn(("[Binder._add] - Bad class constructed for tag %q"):format(self._tagName))
-		return
-	end
-
 	assert(self._instToClass[inst] == nil, "Overwrote")
+
+	class = class or {}
 
 	-- Add to state
 	self._allClassSet[class] = true
@@ -336,12 +333,8 @@ function Binder:_remove(inst)
 		end
 	end
 
-	-- Destroy class
-	if class.Destroy then
-		class:Destroy()
-	else
-		warn(("[Binder._remove] - Class %q no longer has destroy, something destroyed it!")
-			:format(tostring(self._tagName)))
+	if MaidTaskUtils.isValidTask(class) then
+		MaidTaskUtils.doTask(class)
 	end
 end
 

--- a/src/brio/README.md
+++ b/src/brio/README.md
@@ -38,6 +38,14 @@ resources.
 
 Anything may "kill" a brio by calling :Destroy() or :Kill().
 
+## Design philosophy
+
+Brios are designed to solve this issue where we emit an object with a lifetime associated with it from an Observable stream. This resource is only valid for some amount of time (for example, while the object is in the Roblox data model).
+
+In order to know how long we can keep this object/use it, we wrap the object with a Brio, which denotes the lifetime of the object.
+
+Modeling this with pure observables is very tricky because the subscriber will have to also monitor/emit a similar object with less clear conventions. For example  an observable that emits the object, and then nil on death. 
+
 ## API Surface
 
 ### `Brio.isBrio(value)`

--- a/src/brio/src/Shared/BrioUtils.lua
+++ b/src/brio/src/Shared/BrioUtils.lua
@@ -66,8 +66,10 @@ end
 
 function BrioUtils.first(brios, ...)
 	for _, brio in pairs(brios) do
-		if brio:IsDead() then
-			return Brio.DEAD
+		if Brio.isBrio(brio) then
+			if brio:IsDead() then
+				return Brio.DEAD
+			end
 		end
 	end
 
@@ -75,9 +77,11 @@ function BrioUtils.first(brios, ...)
 	local topBrio = Brio.new(...)
 
 	for _, brio in pairs(brios) do
-		maid:GiveTask(brio:GetDiedSignal():Connect(function()
-			topBrio:Kill()
-		end))
+		if Brio.isBrio(brio) then
+			maid:GiveTask(brio:GetDiedSignal():Connect(function()
+				topBrio:Kill()
+			end))
+		end
 	end
 
 	maid:GiveTask(topBrio:GetDiedSignal():Connect(function()

--- a/src/brio/src/Shared/BrioUtils.spec.lua
+++ b/src/brio/src/Shared/BrioUtils.spec.lua
@@ -1,0 +1,74 @@
+---
+-- @module RxBrioUtils.spec.lua
+
+local require = require(game:GetService("ServerScriptService"):FindFirstChild("LoaderUtils", true).Parent).load(script)
+
+local BrioUtils = require("BrioUtils")
+local Brio = require("Brio")
+
+return function()
+	describe("BrioUtils.flatten({})", function()
+		local brio = BrioUtils.flatten({})
+
+		describe("should return a brio that", function()
+			it("is a brio", function()
+				expect(brio).to.be.a("table")
+				expect(Brio.isBrio(brio)).to.equal(true)
+			end)
+
+			it("is alive", function()
+				expect(not brio:IsDead()).to.equal(true)
+			end)
+
+			it("contains a table", function()
+				expect(brio:GetValue()).to.be.a("table")
+			end)
+
+			it("contains a table with nothing in it", function()
+				expect(next(brio:GetValue())).to.equal(nil)
+			end)
+		end)
+	end)
+
+	describe("BrioUtils.flatten with out a brio in it", function()
+		local brio = BrioUtils.flatten({
+			value = 5;
+		})
+
+		describe("should return a brio that", function()
+			it("is a brio", function()
+				expect(brio).to.be.a("table")
+				expect(Brio.isBrio(brio)).to.equal(true)
+			end)
+
+			it("is alive", function()
+				expect(not brio:IsDead()).to.equal(true)
+			end)
+
+			it("contains a table", function()
+				expect(brio:GetValue()).to.be.a("table")
+			end)
+
+			it("contains a table with value", function()
+				expect(brio:GetValue().value).to.equal(5)
+			end)
+		end)
+	end)
+
+	describe("BrioUtils.flatten a dead brio in it", function()
+		local brio = BrioUtils.flatten({
+			value = Brio.DEAD;
+		})
+
+		describe("should return a brio that", function()
+			it("is a brio", function()
+				expect(brio).to.be.a("table")
+				expect(Brio.isBrio(brio)).to.equal(true)
+			end)
+
+			it("is dead", function()
+				expect(brio:IsDead()).to.equal(true)
+			end)
+		end)
+	end)
+end

--- a/src/brio/src/Shared/RxBrioUtils.spec.lua
+++ b/src/brio/src/Shared/RxBrioUtils.spec.lua
@@ -1,0 +1,109 @@
+---
+-- @module RxBrioUtils.spec.lua
+
+local require = require(game:GetService("ServerScriptService"):FindFirstChild("LoaderUtils", true).Parent).load(script)
+
+local RxBrioUtils = require("RxBrioUtils")
+local Brio = require("Brio")
+local Observable = require("Observable")
+
+return function()
+	describe("RxBrioUtils.combineLatest({})", function()
+		it("should execute immediately", function()
+			local observe = RxBrioUtils.combineLatest({})
+			local brio
+			observe:Subscribe(function(result)
+				brio = result
+			end)
+			expect(brio).to.be.ok()
+			expect(Brio.isBrio(brio)).to.equal(true)
+			expect(brio:IsDead()).to.equal(true)
+		end)
+	end)
+
+	describe("RxBrioUtils.combineLatest({ value = Observable(Brio(5)) })", function()
+		it("should execute immediately", function()
+			local observe = RxBrioUtils.combineLatest({
+				value = Observable.new(function(sub)
+					sub:Fire(Brio.new(5));
+				end);
+				otherValue = 25;
+			})
+			local brio
+
+			observe:Subscribe(function(result)
+				brio = result
+			end)
+			expect(brio).to.be.ok()
+			expect(Brio.isBrio(brio)).to.equal(true)
+			expect(not brio:IsDead()).to.equal(true)
+			expect(brio:GetValue()).to.be.a("table")
+			expect(brio:GetValue().value).to.equal(5)
+		end)
+	end)
+
+	describe("RxBrioUtils.flatCombineLatest", function()
+		local doFire
+		local brio = Brio.new(5)
+		local observe = RxBrioUtils.flatCombineLatest({
+			value = Observable.new(function(sub)
+				sub:Fire(brio);
+				doFire = function(...)
+					sub:Fire(...)
+				end
+			end);
+			otherValue = 25;
+		})
+
+		local lastResult = nil
+		local fireCount = 0
+
+		it("should execute immediately", function()
+			observe:Subscribe(function(result)
+				lastResult = result
+				fireCount = fireCount + 1
+			end)
+			expect(fireCount).to.equal(1)
+			expect(lastResult).to.be.a("table")
+			expect(Brio.isBrio(lastResult)).to.equal(false)
+			expect(lastResult.value).to.equal(5)
+			expect(lastResult.otherValue).to.equal(25)
+		end)
+
+		it("should reset when the brio is killed", function()
+			expect(fireCount).to.equal(1)
+
+			brio:Kill()
+
+			expect(fireCount).to.equal(2)
+			expect(lastResult).to.be.a("table")
+			expect(Brio.isBrio(lastResult)).to.equal(false)
+			expect(lastResult.value).to.equal(nil)
+			expect(lastResult.otherValue).to.equal(25)
+		end)
+
+		it("should allow a new value", function()
+			expect(fireCount).to.equal(2)
+
+			doFire(Brio.new(70))
+
+			expect(fireCount).to.equal(3)
+			expect(lastResult).to.be.a("table")
+			expect(Brio.isBrio(lastResult)).to.equal(false)
+			expect(lastResult.value).to.equal(70)
+			expect(lastResult.otherValue).to.equal(25)
+		end)
+
+		it("should only fire once if we replace the value", function()
+			expect(fireCount).to.equal(3)
+
+			doFire(Brio.new(75))
+
+			expect(fireCount).to.equal(4)
+			expect(lastResult).to.be.a("table")
+			expect(Brio.isBrio(lastResult)).to.equal(false)
+			expect(lastResult.value).to.equal(75)
+			expect(lastResult.otherValue).to.equal(25)
+		end)
+	end)
+end

--- a/src/instanceutils/src/Shared/RxInstanceUtils.lua
+++ b/src/instanceutils/src/Shared/RxInstanceUtils.lua
@@ -19,9 +19,9 @@ function RxInstanceUtils.observeProperty(instance, propertyName)
 		local maid = Maid.new()
 
 		maid:GiveTask(instance:GetPropertyChangedSignal(propertyName):Connect(function()
-			sub:Fire(instance[propertyName])
+			sub:Fire(instance[propertyName], instance)
 		end))
-		sub:Fire(instance[propertyName])
+		sub:Fire(instance[propertyName], instance)
 
 		return maid
 	end)
@@ -175,6 +175,5 @@ function RxInstanceUtils.observeDescendants(parent, predicate)
 		return maid
 	end)
 end
-
 
 return RxInstanceUtils

--- a/src/instanceutils/src/Shared/RxInstanceUtils.spec.lua
+++ b/src/instanceutils/src/Shared/RxInstanceUtils.spec.lua
@@ -1,0 +1,22 @@
+---
+-- @module RxInstanceUtils.spec.lua
+
+local require = require(game:GetService("ServerScriptService"):FindFirstChild("LoaderUtils", true).Parent).load(script)
+
+local RxInstanceUtils = require("RxInstanceUtils")
+
+return function()
+	describe("RxInstanceUtils.observeChildrenBrio", function()
+		local part = Instance.new("Part")
+		local observe = RxInstanceUtils.observeChildrenBrio(part)
+		local externalResult = nil
+
+		it("should not emit anything", function()
+			observe:Subscribe(function(result)
+				externalResult = result
+			end)
+
+			expect(externalResult).to.equal(nil)
+		end)
+	end)
+end

--- a/src/rx/src/Shared/Rx.spec.lua
+++ b/src/rx/src/Shared/Rx.spec.lua
@@ -1,0 +1,49 @@
+---
+-- @module Rx.spec.lua
+
+local require = require(game:GetService("ServerScriptService"):FindFirstChild("LoaderUtils", true).Parent).load(script)
+
+local Rx = require("Rx")
+
+return function()
+	describe("Rx.combineLatest({})", function()
+		local observe = Rx.combineLatest({})
+		local externalResult
+
+		it("should execute immediately", function()
+			observe:Subscribe(function(result)
+				externalResult = result
+			end)
+
+			expect(externalResult).to.be.a("table")
+		end)
+	end)
+
+	describe("Rx.combineLatest({ value = 5 })", function()
+		local observe = Rx.combineLatest({ value = 5 })
+		local externalResult
+
+		it("should execute immediately", function()
+			observe:Subscribe(function(result)
+				externalResult = result
+			end)
+
+			expect(externalResult).to.be.a("table")
+			expect(externalResult.value).to.equal(5)
+		end)
+	end)
+
+	describe("Rx.combineLatest({ value = Rx.of(5) })", function()
+		local observe = Rx.combineLatest({ value = Rx.of(5) })
+		local externalResult
+
+		it("should execute immediately", function()
+			observe:Subscribe(function(result)
+				externalResult = result
+			end)
+
+			expect(externalResult).to.be.a("table")
+			expect(externalResult.value).to.equal(5)
+		end)
+	end)
+end


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/actionmanager@3.2.0-canary.221.e58a344.0
  npm install @quenty/attributeutils@3.3.0-canary.221.e58a344.0
  npm install @quenty/binder@4.2.0-canary.221.e58a344.0
  npm install @quenty/boundlinkutils@4.2.0-canary.221.e58a344.0
  npm install @quenty/brio@3.2.0-canary.221.e58a344.0
  npm install @quenty/cooldown@1.2.0-canary.221.e58a344.0
  npm install @quenty/depthoffield@1.2.0-canary.221.e58a344.0
  npm install @quenty/equippedtracker@3.2.0-canary.221.e58a344.0
  npm install @quenty/hide@1.2.0-canary.221.e58a344.0
  npm install @quenty/humanoidspeed@1.2.0-canary.221.e58a344.0
  npm install @quenty/humanoidtracker@3.2.0-canary.221.e58a344.0
  npm install @quenty/idleservice@1.3.0-canary.221.e58a344.0
  npm install @quenty/ik@4.3.0-canary.221.e58a344.0
  npm install @quenty/inputkeymaputils@3.2.0-canary.221.e58a344.0
  npm install @quenty/inputmode@3.2.0-canary.221.e58a344.0
  npm install @quenty/instanceutils@3.2.0-canary.221.e58a344.0
  npm install @quenty/linkutils@3.2.0-canary.221.e58a344.0
  npm install @quenty/parttouchingcalculator@4.2.0-canary.221.e58a344.0
  npm install @quenty/playerbinder@4.2.0-canary.221.e58a344.0
  npm install @quenty/playerhumanoidbinder@4.2.0-canary.221.e58a344.0
  npm install @quenty/r15utils@3.2.0-canary.221.e58a344.0
  npm install @quenty/ragdoll@4.3.0-canary.221.e58a344.0
  npm install @quenty/rx@3.2.0-canary.221.e58a344.0
  npm install @quenty/rxbinderutils@4.3.0-canary.221.e58a344.0
  npm install @quenty/scoredactionservice@4.3.0-canary.221.e58a344.0
  npm install @quenty/teamtracker@3.2.0-canary.221.e58a344.0
  npm install @quenty/valuebaseutils@3.2.0-canary.221.e58a344.0
  npm install @quenty/valueobject@3.2.0-canary.221.e58a344.0
  # or 
  yarn add @quenty/actionmanager@3.2.0-canary.221.e58a344.0
  yarn add @quenty/attributeutils@3.3.0-canary.221.e58a344.0
  yarn add @quenty/binder@4.2.0-canary.221.e58a344.0
  yarn add @quenty/boundlinkutils@4.2.0-canary.221.e58a344.0
  yarn add @quenty/brio@3.2.0-canary.221.e58a344.0
  yarn add @quenty/cooldown@1.2.0-canary.221.e58a344.0
  yarn add @quenty/depthoffield@1.2.0-canary.221.e58a344.0
  yarn add @quenty/equippedtracker@3.2.0-canary.221.e58a344.0
  yarn add @quenty/hide@1.2.0-canary.221.e58a344.0
  yarn add @quenty/humanoidspeed@1.2.0-canary.221.e58a344.0
  yarn add @quenty/humanoidtracker@3.2.0-canary.221.e58a344.0
  yarn add @quenty/idleservice@1.3.0-canary.221.e58a344.0
  yarn add @quenty/ik@4.3.0-canary.221.e58a344.0
  yarn add @quenty/inputkeymaputils@3.2.0-canary.221.e58a344.0
  yarn add @quenty/inputmode@3.2.0-canary.221.e58a344.0
  yarn add @quenty/instanceutils@3.2.0-canary.221.e58a344.0
  yarn add @quenty/linkutils@3.2.0-canary.221.e58a344.0
  yarn add @quenty/parttouchingcalculator@4.2.0-canary.221.e58a344.0
  yarn add @quenty/playerbinder@4.2.0-canary.221.e58a344.0
  yarn add @quenty/playerhumanoidbinder@4.2.0-canary.221.e58a344.0
  yarn add @quenty/r15utils@3.2.0-canary.221.e58a344.0
  yarn add @quenty/ragdoll@4.3.0-canary.221.e58a344.0
  yarn add @quenty/rx@3.2.0-canary.221.e58a344.0
  yarn add @quenty/rxbinderutils@4.3.0-canary.221.e58a344.0
  yarn add @quenty/scoredactionservice@4.3.0-canary.221.e58a344.0
  yarn add @quenty/teamtracker@3.2.0-canary.221.e58a344.0
  yarn add @quenty/valuebaseutils@3.2.0-canary.221.e58a344.0
  yarn add @quenty/valueobject@3.2.0-canary.221.e58a344.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
