### PR TITLE
feat: Make CmdrService allow dynamically binding commands

### DIFF
--- a/src/cmdrservice/package.json
+++ b/src/cmdrservice/package.json
@@ -29,7 +29,8 @@
     "@quenty/permissionprovider": "file:../permissionprovider",
     "@quenty/promise": "file:../promise",
     "@quenty/remoting": "file:../remoting",
-    "@quenty/servicebag": "file:../servicebag"
+    "@quenty/servicebag": "file:../servicebag",
+    "@quenty/templateprovider": "file:../templateprovider"
   },
   "peerDependencies": {
     "@quentystudios/cmdr": "^1.8.4-quenty.1"

--- a/src/cmdrservice/src/Client/CmdrServiceClient.lua
+++ b/src/cmdrservice/src/Client/CmdrServiceClient.lua
@@ -28,7 +28,11 @@ function CmdrServiceClient:Start()
 	})
 	:Then(function(cmdr, isAdmin)
 		if isAdmin then
+			cmdr:SetActivationUnlocksMouse(true)
 			cmdr:SetActivationKeys({ Enum.KeyCode.F2 })
+
+			-- Default blink for debugging purposes
+			cmdr.Dispatcher:Run("bind", Enum.KeyCode.G.Name, "blink")
 		else
 			cmdr:SetActivationKeys({})
 		end

--- a/src/cmdrservice/src/Server/CmdrService.lua
+++ b/src/cmdrservice/src/Server/CmdrService.lua
@@ -4,18 +4,29 @@
 
 local require = require(script.Parent.loader).load(script)
 
+local HttpService = game:GetService("HttpService")
+
 local PermissionService = require("PermissionService")
+local CmdrTemplateProviderServer = require("CmdrTemplateProviderServer")
 local Promise = require("Promise")
 
 local CmdrService = {}
 
+local GLOBAL_REGISTRY = setmetatable({}, {__mode = "kv"})
+
 function CmdrService:Init(serviceBag)
 	assert(not self._cmdr, "Already initialized")
 
+	self._serviceBag = assert(serviceBag, "No serviceBag")
+	self._cmdrTemplateProviderServer = self._serviceBag:GetService(CmdrTemplateProviderServer)
+
+	self._serviceId = HttpService:GenerateGUID(false)
 	self._cmdr = require("Cmdr")
-	self._cmdr:RegisterDefaultCommands()
 
 	self._permissionService = serviceBag:GetService(PermissionService)
+
+	self._definitionData = {}
+	self._executeData = {}
 
 	self._cmdr.Registry:RegisterHook("BeforeRun", function(context)
 		local providerPromise = self._permissionService:PromisePermissionProvider()
@@ -32,12 +43,77 @@ function CmdrService:Init(serviceBag)
 			return "You don't have permission to run this command"
 		end
 	end)
+
+	GLOBAL_REGISTRY[self._serviceId] = self
+end
+
+function CmdrService:Start()
+	self._cmdr:RegisterDefaultCommands()
 end
 
 function CmdrService:PromiseCmdr()
 	assert(self._cmdr, "Not initialized")
 
 	return Promise.resolved(self._cmdr)
+end
+
+function CmdrService:RegisterCommand(commandData, execute)
+	assert(self._cmdr, "Not initialized")
+	assert(commandData, "No commandData")
+	assert(commandData.Name, "No commandData.Name")
+	assert(execute, "No execute")
+
+	local commandId = ("%s_%s"):format(commandData.Name, HttpService:GenerateGUID(false))
+
+	self._definitionData[commandId] = commandData
+	self._executeData[commandId] = execute
+
+	local commandServerScript = self._cmdrTemplateProviderServer:Clone("CmdrExecutionTemplate")
+	commandServerScript.Name = ("%sServer"):format(commandId)
+
+	local cmdrServiceTarget = Instance.new("ObjectValue")
+	cmdrServiceTarget.Name = "CmdrServiceTarget"
+	cmdrServiceTarget.Value = script
+	cmdrServiceTarget.Parent = commandServerScript
+
+	local cmdrServiceId = Instance.new("StringValue")
+	cmdrServiceId.Name = "CmdrServiceId"
+	cmdrServiceId.Value = self._serviceId
+	cmdrServiceId.Parent = commandServerScript
+
+	local cmdrCommandId = Instance.new("StringValue")
+	cmdrCommandId.Name = "CmdrCommandId"
+	cmdrCommandId.Value = commandId
+	cmdrCommandId.Parent = commandServerScript
+
+	local commandScript = self._cmdrTemplateProviderServer:Clone("CmdrCommandDefinitionTemplate")
+	commandScript.Name = commandId
+
+	local cmdrJsonCommandData = Instance.new("StringValue")
+	cmdrJsonCommandData.Value = HttpService:JSONEncode(commandData)
+	cmdrJsonCommandData.Name = "CmdrJsonCommandData"
+	cmdrJsonCommandData.Parent = commandScript
+
+	self._cmdr.Registry:RegisterCommand(commandScript, commandServerScript)
+end
+
+function CmdrService:__ExecuteCommand(id, ...)
+	assert(type(id) == "string", "Bad serviceId")
+	assert(self._cmdr, "Not initialized")
+
+	local execute = self._executeData[id]
+	if not execute then
+		error(("[CmdrService] - No command definition for id %q"):format(tostring(id)))
+	end
+
+	return execute(...)
+end
+
+-- Global, but only intended for internal use
+function CmdrService:__GetServiceFromId(id)
+	assert(type(id) == "string", "Bad serviceId")
+
+	return GLOBAL_REGISTRY[id]
 end
 
 return CmdrService

--- a/src/cmdrservice/src/Server/CmdrTemplateProviderServer/CmdrCommandDefinitionTemplate.lua
+++ b/src/cmdrservice/src/Server/CmdrTemplateProviderServer/CmdrCommandDefinitionTemplate.lua
@@ -1,0 +1,7 @@
+--- Generic command definition template
+-- @module CmdrCommandDefinitionTemplate
+
+local HttpService = game:GetService("HttpService")
+
+local value = script:WaitForChild("CmdrJsonCommandData")
+return HttpService:JSONDecode(value.Value)

--- a/src/cmdrservice/src/Server/CmdrTemplateProviderServer/CmdrExecutionTemplate.lua
+++ b/src/cmdrservice/src/Server/CmdrTemplateProviderServer/CmdrExecutionTemplate.lua
@@ -1,0 +1,20 @@
+--- Generic command definition template
+-- @module CmdrCommandDefinitionTemplate
+
+local function waitForValue(objectValue)
+	local value = objectValue.Value
+	if value then
+		return value
+	end
+
+	return objectValue.Changed:Wait()
+end
+
+local cmdrServiceId = waitForValue(script:WaitForChild("CmdrServiceId"))
+local cmdrCommandId = waitForValue(script:WaitForChild("CmdrCommandId"))
+local commandServiceDefinition = require(waitForValue(script:WaitForChild("CmdrServiceTarget")))
+local cmdrService = commandServiceDefinition:__GetServiceFromId(cmdrServiceId)
+
+return function(...)
+	return cmdrService:__ExecuteCommand(cmdrCommandId, ...)
+end

--- a/src/cmdrservice/src/Server/CmdrTemplateProviderServer/init.lua
+++ b/src/cmdrservice/src/Server/CmdrTemplateProviderServer/init.lua
@@ -1,0 +1,9 @@
+--- Retrieves CmdrTemplateProviderServer
+-- @module CmdrTemplateProviderServer
+-- @author Quenty
+
+local require = require(script.Parent.loader).load(script)
+
+local TemplateProvider = require("TemplateProvider")
+
+return TemplateProvider.new(script)

--- a/src/cmdrservice/test/default.project.json
+++ b/src/cmdrservice/test/default.project.json
@@ -1,12 +1,7 @@
 {
-  "name": "cmdrservicetest",
+  "name": "CmdrServiceTest",
   "tree": {
     "$className": "DataModel",
-    "ReplicatedStorage": {
-      "Nevermore": {
-        "$path": "../node_modules/@quenty/loader"
-      }
-    },
     "ServerScriptService": {
       "cmdrservice": {
         "$path": ".."

--- a/src/cmdrservice/test/scripts/Server/ServerMain.server.lua
+++ b/src/cmdrservice/test/scripts/Server/ServerMain.server.lua
@@ -17,3 +17,29 @@ serviceBag:GetService(require(serverFolder.CmdrService))
 
 serviceBag:Init()
 serviceBag:Start()
+
+serviceBag:GetService(require(serverFolder.CmdrService)):RegisterCommand({
+	Name = "explode";
+	Aliases = { "boom" };
+	Description = "Makes players explode";
+	Group = "Admin";
+	Args = {
+		{
+			Type = "players";
+			Name = "players";
+			Description = "Victims";
+		},
+	};
+}, function(_context, players)
+	for _, player in pairs(players) do
+		local humanoid = player.Character and player.Character:FindFirstChildWhichIsA("Humanoid")
+		local humanoidRootPart = humanoid and humanoid.RootPart
+		if humanoidRootPart then
+			local explosion = Instance.new("Explosion")
+			explosion.Position = humanoidRootPart.Position
+			explosion.Parent = humanoidRootPart
+		end
+	end
+
+	return "Exploded!"
+end)


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/cmdrservice@3.4.0-canary.231.1897e2a.0
  # or 
  yarn add @quenty/cmdrservice@3.4.0-canary.231.1897e2a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
