### PR TITLE
feat!: Remove GuiVisibleManager:SetPreferredTheme() support

### DIFF
--- a/src/guivisiblemanager/src/Client/GuiVisibleManager.lua
+++ b/src/guivisiblemanager/src/Client/GuiVisibleManager.lua
@@ -25,10 +25,6 @@ function GuiVisibleManager.new(promiseNewPane, maxHideTime)
 	self._paneVisible.Value = false
 	self._maid:GiveTask(self._paneVisible)
 
-	self._theme = Instance.new("StringValue")
-	self._theme.Value = "Light"
-	self._maid:GiveTask(self._theme)
-
 	self._showHandles = {}
 
 	self._maid:GiveTask(self._paneVisible.Changed:Connect(function()
@@ -62,12 +58,6 @@ function GuiVisibleManager:BindToBoolValue(boolValue)
 	if self._boundBoolValue.Value then
 		self._maid._boundShowHandle = self:CreateShowHandle()
 	end
-end
-
-function GuiVisibleManager:SetPreferredTheme(theme)
-	assert(theme == "Light" or theme == "Dark", "Bad theme")
-
-	self._theme.Value = theme
 end
 
 function GuiVisibleManager:CreateShowHandle()
@@ -125,14 +115,6 @@ function GuiVisibleManager:_handleNewPane(maid, pane)
 	assert(self._maid._paneMaid == maid, "Bad maid")
 
 	maid:GiveTask(pane)
-
-	if pane.SetPreferredTheme then
-		-- Theming
-		pane:SetPreferredTheme(self._theme.Value)
-		maid:GiveTask(self._theme.Changed:Connect(function()
-			pane:SetPreferredTheme(self._theme.Value)
-		end))
-	end
 
 	local function updateVisible()
 		if self._paneVisible.Value then


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/guivisiblemanager@4.0.0-canary.236.5d9a2f6.0
  # or 
  yarn add @quenty/guivisiblemanager@4.0.0-canary.236.5d9a2f6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
