### PR TITLE
Bump license/copyright date

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2021 Quenty
+Copyright (c) 2014-2022 Quenty
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/moonwave.toml
+++ b/moonwave.toml
@@ -12,7 +12,7 @@ label = "Discord"
 position = "right"
 
 [footer]
-copyright = "Copyright © 2014-2021 James Onnen. Made with Moonwave."
+copyright = "Copyright © 2014-2022 James Onnen. Made with Moonwave."
 
 [docusaurus]
 url = "https://quenty.github.io"


### PR DESCRIPTION
Edits made in both [`moonwave.toml`](https://github.com/insyri/NevermoreEngine/commit/ab017723092e2a90014274f854177dbf66e33da4) and [`LICENSE.md`](https://github.com/insyri/NevermoreEngine/commit/2649fef8c1fadc1e4523958cc72e6392ae9ab6c0).

2021 -> 2022