### PR TITLE
feat: Add thread-support for maids

### DIFF
--- a/src/maid/src/Shared/Maid.lua
+++ b/src/maid/src/Shared/Maid.lua
@@ -88,6 +88,7 @@ end
 	```
 	Maid[key] = (function)         Adds a task to perform
 	Maid[key] = (event connection) Manages an event connection
+	Maid[key] = (thread)           Manages a thread
 	Maid[key] = (Maid)             Maids can act as an event connection, allowing a Maid to have other maids to clean up.
 	Maid[key] = (Object)           Maids can cleanup objects with a `Destroy` method
 	Maid[key] = nil                Removes a named task.

--- a/src/maid/src/Shared/Maid.lua
+++ b/src/maid/src/Shared/Maid.lua
@@ -197,6 +197,8 @@ function Maid:DoCleaning()
 		tasks[index] = nil
 		if type(job) == "function" then
 			job()
+		elseif type(job) == "thread" then
+			task.cancel(job)
 		elseif typeof(job) == "RBXScriptConnection" then
 			job:Disconnect()
 		elseif job.Destroy then

--- a/src/maid/src/Shared/MaidTaskUtils.lua
+++ b/src/maid/src/Shared/MaidTaskUtils.lua
@@ -11,7 +11,7 @@
 
 --[=[
 	An object that can be cleaned up
-	@type MaidTask function | Destructable | RBXScriptConnection
+	@type MaidTask function | thread | Destructable | RBXScriptConnection
 	@within MaidTaskUtils
 ]=]
 local MaidTaskUtils = {}
@@ -24,6 +24,7 @@ local MaidTaskUtils = {}
 ]=]
 function MaidTaskUtils.isValidTask(job)
 	return type(job) == "function"
+		or type(job) == "thread"
 		or typeof(job) == "RBXScriptConnection"
 		or type(job) == "table" and type(job.Destroy) == "function"
 		or typeof(job) == "Instance"
@@ -37,6 +38,8 @@ end
 function MaidTaskUtils.doTask(job)
 	if type(job) == "function" then
 		job()
+	elseif type(job) == "thread" then
+		task.cancel(job)
 	elseif typeof(job) == "RBXScriptConnection" then
 		job:Disconnect()
 	elseif type(job) == "table" and type(job.Destroy) == "function" then


### PR DESCRIPTION
Maids should call `task.cancel` on jobs it's given that are threads.