### PR TITLE
fix: Fix broken initial value of Blend.AccelTween

### DIFF
--- a/src/blend/src/Shared/Blend/Blend.lua
+++ b/src/blend/src/Shared/Blend/Blend.lua
@@ -298,7 +298,13 @@ function Blend.AccelTween(source, acceleration)
 	local accelerationObservable = Blend.toNumberObservable(acceleration)
 
 	local function createAccelTween(maid, initialValue)
-		local accelTween = AccelTween.new(initialValue)
+		local accelTween = AccelTween.new()
+
+		if initialValue then
+			accelTween.p = initialValue
+			accelTween.t = initialValue
+			accelTween.v = 0
+		end
 
 		if accelerationObservable then
 			maid:GiveTask(accelerationObservable:Subscribe(function(value)


### PR DESCRIPTION
Blend was passing the initial value into the constructor of AccelTween, which actually sets its acceleration. This has probably caused lots of spooky behaviour! `Blend.AccelTween` will now use the correct acceleration, and won't always start at zero.