### PR TITLE
Datastore UTF-8 support

### DIFF
--- a/src/datastore/src/Server/Modules/DataStoreStage.lua
+++ b/src/datastore/src/Server/Modules/DataStoreStage.lua
@@ -17,6 +17,7 @@ local Promise = require("Promise")
 local PromiseUtils = require("PromiseUtils")
 local Signal = require("Signal")
 local Table = require("Table")
+local ValueObject = require("ValueObject")
 
 local DataStoreStage = setmetatable({}, BaseObject)
 DataStoreStage.ClassName = "DataStoreStage"
@@ -245,7 +246,7 @@ end
 ]=]
 function DataStoreStage:StoreOnValueChange(name, valueObj)
 	assert(type(name) == "string", "Bad name")
-	assert(typeof(valueObj) == "Instance", "Bad valueObj")
+	assert(typeof(valueObj) == "Instance" or ValueObject.isValueObject(valueObj), "Bad valueObj")
 
 	if self._takenKeys[name] then
 		error(("[DataStoreStage] - Already have a writer for %q"):format(name))


### PR DESCRIPTION
Nevermore's datastore API is awesome, but a limitation I've found is that it requires you to pass a `ValueBase` into `:StoreOnValueChange(...)`. The problem with this is that `StringValue`s can't hold UTF-8 data, which rules out using libraries like [MessagePack](https://github.com/cipharius/msgpack-luau).

As a quick fix I allowed passing a ValueObject into DataStoreStage, but I don't think it's a good solution as then you could pass in all manner of unserializable tables or instances. Maybe this method should check that the value is always a string before saving? Unsure.