### PR TITLE
feat: Add TintController package for colouring groups of instances

### DIFF
--- a/src/tintcontroller/Client/TintBindersClient.lua
+++ b/src/tintcontroller/Client/TintBindersClient.lua
@@ -1,0 +1,37 @@
+--[=[
+	Initializes the tinting system on the client.
+
+	```lua
+	local TintBindersClient = require("TintBindersClient")
+	local TintControllerUtils = require("TintControllerUtils")
+	local ServiceBag = require("ServiceBag")
+
+	local serviceBag = ServiceBag.new()
+	serviceBag:GetService(TintBindersClient)
+
+	serviceBag:Init()
+	serviceBag:Start()
+
+	-- 'workspace.Model', and all of its descendants tagged with `Tint`, will change color.
+	TintBindersClient:BindClient(workspace.Model)
+	TintControllerUtils.setTint(workspace.Model, Color3.new(1, 1, 1))
+	TintControllerUtils.setTint(workspace.Model, BrickColor.random())
+	TintControllerUtils.setTint(workspace.Model, "Pastel light blue")
+	TintControllerUtils.setTint(workspace.Model, {255, 0, 0})
+	```
+
+	@client
+	@class TintBindersClient
+]=]
+local require = require(script.Parent.loader).load(script)
+
+local BinderProvider = require("BinderProvider")
+local Binder = require("Binder")
+
+return BinderProvider.new(function(self, serviceBag)
+--[=[
+	@prop TintController Binder<TintControllerClient>
+	@within TintBindersClient
+]=]
+	self:Add(Binder.new("TintController", require("TintControllerClient"), serviceBag))
+end)

--- a/src/tintcontroller/Client/TintControllerClient.lua
+++ b/src/tintcontroller/Client/TintControllerClient.lua
@@ -1,0 +1,93 @@
+--[=[
+	Manages tinting a target instance and its tagged descendants.
+	Changing part colors is done on the client to allow modifying the tint locally. Useful for hiding latency (i.e. in a placement system), as we can preview a change before the server replicates it to us.
+
+	@client
+	@class TintControllerClient
+]=]
+
+local require = require(script.Parent.loader).load(script)
+
+local CollectionService = game:GetService("CollectionService")
+
+local AttributeValue = require("AttributeValue")
+local BaseObject = require("BaseObject")
+local Maid = require("Maid")
+local Rx = require("Rx")
+local RxAttributeUtils = require("RxAttributeUtils")
+local TintableInstanceUtils = require("TintableInstanceUtils")
+local TintControllerConstants = require("TintControllerConstants")
+local TintControllerUtils = require("TintControllerUtils")
+
+local TintControllerClient = setmetatable({}, BaseObject)
+TintControllerClient.ClassName = "TintControllerClient"
+TintControllerClient.__index = TintControllerClient
+
+--[=[
+	Construct a new controller.
+	This tints a parent instance and all of its tagged descendants based on a Color3 attribute.
+
+	@param adornee Instance
+	@return TintControllerClient
+]=]
+function TintControllerClient.new(adornee: Instance)
+	local self = setmetatable(BaseObject.new(adornee), TintControllerClient)
+
+	self._color = AttributeValue.new(adornee, TintControllerConstants.ATTRIBUTE_NAME, nil)
+
+	local instanceMaid = Maid.new()
+	self._maid:GiveTask(instanceMaid)
+
+	local function handleInstance(instance: Instance)
+		if self:_canTint(instance) then
+			instanceMaid[instance] = self:_setupInstance(instance)
+		end
+	end
+	local function handleRemoving(instance: Instance)
+		instanceMaid[instance] = nil
+	end
+
+	handleInstance(adornee)
+	for _, v in adornee:GetDescendants() do
+		handleInstance(v)
+	end
+	self._maid:GiveTask(adornee.DescendantAdded:Connect(handleInstance))
+	self._maid:GiveTask(adornee.DescendantRemoving:Connect(handleRemoving))
+
+	return self
+end
+
+--[=[
+	Sets the tint of this controller, and all of its tagged tintable descendants.
+
+	@param tint any
+]=]
+function TintControllerClient:SetTint(tint: any)
+	TintControllerUtils.setTint(self._obj, tint)
+end
+
+function TintControllerClient:_observeTintColor3()
+	-- Cache the value.
+	-- :GetPropertyChangedSignal() is expensive and returns a new signal each call.
+	-- This method also calls :GetAttribute() for each sub, which is very slow!
+	return RxAttributeUtils.observeAttribute(self._obj, TintControllerConstants.ATTRIBUTE_NAME, nil):Pipe({
+		Rx.cache(),
+	})
+end
+
+function TintControllerClient:_setupInstance(instance: Instance)
+	return self:_observeTintColor3():Subscribe(function(color: Color3?)
+		-- Check as we may not always have a tint color; in that case we'll want to leave the defaults.
+		if color then
+			TintableInstanceUtils.setTint(instance, color)
+		end
+	end)
+end
+
+function TintControllerClient:_canTint(instance: Instance)
+	-- We can't use use the util here, as we have the extra constraint of requiring the instance to be tagged.
+	-- Other modules may want to tag instances without worrying about the binders.
+	return CollectionService:HasTag(instance, TintControllerConstants.TAG_NAME) and TintableInstanceUtils.isTintable(instance)
+end
+
+return TintControllerClient

--- a/src/tintcontroller/Server/TintBindersServer.lua
+++ b/src/tintcontroller/Server/TintBindersServer.lua
@@ -1,0 +1,18 @@
+--[=[
+	See [TintBindersClient] for usage.
+
+	@server
+	@class TintBindersServer
+]=]
+local require = require(script.Parent.loader).load(script)
+
+local BinderProvider = require("BinderProvider")
+local Binder = require("Binder")
+
+return BinderProvider.new(function(self, serviceBag)
+--[=[
+	@prop TintController Binder<TintController>
+	@within TintBindersServer
+]=]
+	self:Add(Binder.new("TintController", require("TintController"), serviceBag))
+end)

--- a/src/tintcontroller/Server/TintController.lua
+++ b/src/tintcontroller/Server/TintController.lua
@@ -1,0 +1,39 @@
+--[=[
+	Dummy class providing a convenient wrapper over [TintControllerUtils].
+	All color changing is done on the client, in [TintControllerClient].
+
+	@server
+	@class TintController
+]=]
+
+local require = require(script.Parent.loader).load(script)
+
+local TintControllerUtils = require("TintControllerUtils")
+local BaseObject = require("BaseObject")
+
+local TintController = setmetatable({}, BaseObject)
+TintController.ClassName = "TintController"
+TintController.__index = TintController
+
+--[=[
+	Construct a new controller on the server.
+
+	@param adornee Instance
+	@return TintControllerClient
+]=]
+function TintController.new(adornee: Instance)
+	local self = setmetatable(BaseObject.new(adornee), TintController)
+
+	return self
+end
+
+--[=[
+	Sets the tint of this controller, and all of its tagged tintable descendants.
+
+	@param tint any
+]=]
+function TintController:SetTint(tint: any)
+	TintControllerUtils.setTint(self._obj, tint)
+end
+
+return TintController

--- a/src/tintcontroller/Server/TintController.lua
+++ b/src/tintcontroller/Server/TintController.lua
@@ -36,4 +36,13 @@ function TintController:SetTint(tint: any)
 	TintControllerUtils.setTint(self._obj, tint)
 end
 
+--[=[
+	Sets the blending of this controller's tint. Typically ranges between 0 and 1.
+
+	@param blend number
+]=]
+function TintController:SetTintBlend(blend: number)
+	TintControllerUtils.setTintBlend(self._obj, blend)
+end
+
 return TintController

--- a/src/tintcontroller/Shared/TintControllerConstants.lua
+++ b/src/tintcontroller/Shared/TintControllerConstants.lua
@@ -8,5 +8,6 @@ local Table = require("Table")
 
 return Table.readonly({
 	TAG_NAME = "Tint",
-	ATTRIBUTE_NAME = "Tint",
+	COLOR_ATTRIBUTE_NAME = "TintColor",
+	BLEND_ATTRIBUTE_NAME = "TintBlend",
 })

--- a/src/tintcontroller/Shared/TintControllerConstants.lua
+++ b/src/tintcontroller/Shared/TintControllerConstants.lua
@@ -1,0 +1,12 @@
+--[=[
+	@class TintControllerConstants
+]=]
+
+local require = require(script.Parent.loader).load(script)
+
+local Table = require("Table")
+
+return Table.readonly({
+	TAG_NAME = "Tint",
+	ATTRIBUTE_NAME = "Tint",
+})

--- a/src/tintcontroller/Shared/TintControllerUtils.lua
+++ b/src/tintcontroller/Shared/TintControllerUtils.lua
@@ -51,7 +51,19 @@ function TintControllerUtils.setTint(controller: Instance, color: any)
 	local color3 = convertToColor3(color)
 	assert(color3, "Bad tintColor")
 
-	controller:SetAttribute(TintControllerConstants.ATTRIBUTE_NAME, color3)
+	controller:SetAttribute(TintControllerConstants.COLOR_ATTRIBUTE_NAME, color3)
+end
+
+--[=[
+	Sets the blending opacity of the tint applied by this controller.
+
+	@param controller Instance
+	@param blend number -- Typically between 0 and 1
+]=]
+function TintControllerUtils.setTintBlend(controller: Instance, blend: any)
+	assert(typeof(blend) == "number", "Bad blend value")
+
+	controller:SetAttribute(TintControllerConstants.BLEND_ATTRIBUTE_NAME, blend)
 end
 
 return TintControllerUtils

--- a/src/tintcontroller/Shared/TintControllerUtils.lua
+++ b/src/tintcontroller/Shared/TintControllerUtils.lua
@@ -1,0 +1,57 @@
+--[=[
+	Utilities for working with a [TintController] bound instance. For a generic utility that tints any part, see [TintableInstanceUtils].
+
+	@class TintControllerUtils
+]=]
+
+local require = require(script.Parent.loader).load(script)
+
+local TintControllerConstants = require("TintControllerConstants")
+
+local TintControllerUtils = {}
+
+--[=[
+	Given some arbitrary value, attempt to convert it into a Color3.
+
+	@within TintControllerUtils
+	@private
+	@param color any
+	@return Color3?
+]=]
+local function convertToColor3(color: any): Color3?
+	if typeof(color) == "Color3" then
+		return color
+	elseif typeof(color) == "BrickColor" then
+		return color.Color
+	elseif typeof(color) == "number" or typeof(color) == "string" then
+		-- Assuming that this is a brickcolor swatch.
+		local brickColor = BrickColor.new(color)
+		return brickColor.Color
+	elseif typeof(color) == "table" then
+		if #color == 3 then
+			local r, g, b = table.unpack(color)
+			if typeof(r) == "number" and typeof(g) == "number" and typeof(b) == "number" then
+				if r <= 1 and g <= 1 and b <= 1 then
+					return Color3.new(r, g, b)
+				else
+					return Color3.fromRGB(r, g, b)
+				end
+			end
+		end
+	end
+end
+
+--[=[
+	Sets the tint of this controller, and all of its tagged tintable descendants.
+
+	@param controller Instance
+	@param color any
+]=]
+function TintControllerUtils.setTint(controller: Instance, color: any)
+	local color3 = convertToColor3(color)
+	assert(color3, "Bad tintColor")
+
+	controller:SetAttribute(TintControllerConstants.ATTRIBUTE_NAME, color3)
+end
+
+return TintControllerUtils

--- a/src/tintcontroller/Shared/TintableInstanceUtils.lua
+++ b/src/tintcontroller/Shared/TintableInstanceUtils.lua
@@ -1,0 +1,68 @@
+--[=[
+	Identifies and modifies tintable instances (most instances with a Color3 property).
+	This is a generic utility with no relation to [TintController] or its associated tags.
+
+	@class TintableInstanceUtils
+]=]
+
+local TintableInstanceUtils = {}
+
+--[=[
+	Given an adornee, find the name of a Color3 property we can modify.
+
+	@within TintableInstanceUtils
+	@private
+	@param adornee Instance
+	@return string
+]=]
+local function identifyTintProperty(adornee: Instance)
+	if
+		adornee:IsA("BasePart")
+		or adornee:IsA("WrapTarget")
+		or adornee:IsA("WrapLayer")
+		or adornee:IsA("Constraint")
+	then
+		return "Color"
+	elseif adornee:IsA("Decal") or adornee:IsA("GuiBase3d") then
+		return "Color3"
+	elseif adornee:IsA("ImageLabel") then
+		return "ImageColor3"
+	end
+end
+
+--[=[
+	Given an adornee, find out if we can assign its tint.
+
+	@param adornee Instance
+	@return boolean
+]=]
+function TintableInstanceUtils.isTintable(adornee: Instance)
+	return identifyTintProperty(adornee) ~= nil
+end
+
+--[=[
+	Set an adornee's tint property.
+
+	@param adornee Instance
+]=]
+function TintableInstanceUtils.setTint(adornee: Instance, color: Color3)
+	local property = identifyTintProperty(adornee)
+	assert(property, "Bad tintable")
+
+	adornee[property] = color
+end
+
+--[=[
+	Attempt to get an adornee's tint. Will return `nil` if no tint can be derived.
+
+	@param adornee Instance
+	@return Color3?
+]=]
+function TintableInstanceUtils.getTint(adornee: Instance): Color3?
+	local property = identifyTintProperty(adornee)
+	if property then
+		return adornee[property]
+	end
+end
+
+return TintableInstanceUtils


### PR DESCRIPTION
Provides a class that can be used to colour groups of tagged instances at once. Useful as it supports most useful instances with a Color3 property, like `BasePart` `Texture` `ImageLabel` etc.

I've never written a package before! Please give feedback and changes.