### PR TITLE
Fix SlerpQuaternions

### DIFF
--- a/src/quaternion/src/Shared/Quaternion.lua
+++ b/src/quaternion/src/Shared/Quaternion.lua
@@ -109,7 +109,7 @@ end
 lib.QuaternionFromCFrame = QuaternionFromCFrame
 
 local function SlerpQuaternions(q0, q1, t)
-	return Qmul(q0, Qpow(Qmul(q1, Qinv(q0)), t))
+	return Qmul(Qpow(Qmul(q1, Qinv(q0)), t), q0)
 end
 lib.SlerpQuaternions = SlerpQuaternions
 


### PR DESCRIPTION
It appears `SlerpQuaternions` was intended to follow either the first or fourth of the following equivalent equations, but the order of the arguments to one of the Qmul calls was switched.
![image](https://user-images.githubusercontent.com/41402526/194777343-c15f39d1-3146-43e2-81dd-f40916eaa0ec.png)
[https://en.wikipedia.org/wiki/Slerp#Quaternion_Slerp](https://en.wikipedia.org/wiki/Slerp#Quaternion_Slerp)
I chose to convert it to the fourth equation.