### PR TITLE
feat!: Favoring Lua table methods

### DIFF
--- a/aftman.toml
+++ b/aftman.toml
@@ -5,7 +5,7 @@
 [tools]
 rojo = "quenty/rojo@7.2.1-quenty-npm-canary.5"
 run-in-roblox = "rojo-rbx/run-in-roblox@0.3.0"
-selene = "Kampfkarren/selene@0.23.1"
+selene = "Kampfkarren/selene@0.24.0"
 moonwave-extractor = "UpliftGames/moonwave@0.3.3"
 mantle = "blake-mealey/mantle@0.10.7"
 remodel = "rojo-rbx/remodel@0.9.1"

--- a/games/integration/aftman.toml
+++ b/games/integration/aftman.toml
@@ -2,4 +2,4 @@
 # For more information, see https://github.com/LPGhatguy/aftman
 [tools]
 rojo = "quenty/rojo@7.2.1-quenty-npm-canary.5"
-selene = "Kampfkarren/selene@0.23.1"
+selene = "Kampfkarren/selene@0.24.0"

--- a/src/loader/src/Utils.lua
+++ b/src/loader/src/Utils.lua
@@ -18,13 +18,7 @@ function Utils.readonly(_table)
 	return setmetatable(_table, READ_ONLY_METATABLE)
 end
 
-function Utils.copyTable(target)
-	local new = {}
-	for key, value in pairs(target) do
-		new[key] = value
-	end
-	return new
-end
+Utils.copyTable = table.clone
 
 function Utils.count(_table)
 	local count = 0

--- a/src/loader/src2/Utils.lua
+++ b/src/loader/src2/Utils.lua
@@ -18,13 +18,7 @@ function Utils.readonly(_table)
 	return setmetatable(_table, READ_ONLY_METATABLE)
 end
 
-function Utils.copyTable(target)
-	local new = {}
-	for key, value in pairs(target) do
-		new[key] = value
-	end
-	return new
-end
+Utils.copyTable = table.clone
 
 function Utils.count(_table)
 	local count = 0

--- a/src/raycaster/src/Shared/Raycaster.lua
+++ b/src/raycaster/src/Shared/Raycaster.lua
@@ -63,10 +63,7 @@ end
 function Raycaster:FindPartOnRay(ray)
 	assert(typeof(ray) == "Ray", "Bad ray")
 
-	local ignoreList = {}
-	for key, value in pairs(rawget(self, "_ignoreList")) do
-		ignoreList[key] = value
-	end
+	local ignoreList = table.clone(rawget(self, "_ignoreList"))
 
 	local casts = self.MaxCasts
 	while casts > 0 do

--- a/src/table/src/Shared/Table.lua
+++ b/src/table/src/Shared/Table.lua
@@ -80,16 +80,16 @@ end
 --[=[
 	Shallow merges two lists without modifying either.
 
-	@param orig table -- Original table
-	@param new table -- Result
+	@param a table -- Source table
+	@param b table -- Source table
 	@return table
 ]=]
-function Table.mergeLists(orig, new)
+function Table.mergeLists(a, b)
 	local _table = {}
-	for _, val in pairs(orig) do
+	for _, val in pairs(a) do
 		table.insert(_table, val)
 	end
-	for _, val in pairs(new) do
+	for _, val in pairs(b) do
 		table.insert(_table, val)
 	end
 	return _table

--- a/src/table/src/Shared/Table.lua
+++ b/src/table/src/Shared/Table.lua
@@ -197,16 +197,7 @@ end
 	@return The index of the value, if found
 	@return nil -- if not found
 ]=]
-function Table.getIndex(haystack, needle)
-	assert(needle ~= nil, "Needle cannot be nil")
-
-	for index, item in pairs(haystack) do
-		if needle == item then
-			return index
-		end
-	end
-	return nil
-end
+Table.getIndex = table.find
 
 --[=[
 	Recursively prints the table. Does not handle recursive tables.
@@ -239,13 +230,7 @@ end
 	@return boolean -- `true` if within, `false` otherwise
 ]=]
 function Table.contains(_table, value)
-	for _, item in pairs(_table) do
-		if item == value then
-			return true
-		end
-	end
-
-	return false
+	return table.find(_table, value) ~= nil
 end
 
 --[=[

--- a/src/table/src/Shared/Table.lua
+++ b/src/table/src/Shared/Table.lua
@@ -23,13 +23,13 @@ end
 --[=[
 	Shallow merges two tables without modifying either.
 
-	@param orig table -- Original table
-	@param new table -- Result
+	@param a table -- Table to merge
+	@param b table -- Table to merge
 	@return table
 ]=]
-function Table.merge(orig, new)
-	local result = table.clone(orig)
-	for key, val in pairs(new) do
+function Table.merge(a, b)
+	local result = table.clone(a)
+	for key, val in pairs(b) do
 		result[key] = val
 	end
 	return result

--- a/src/table/src/Shared/Table.lua
+++ b/src/table/src/Shared/Table.lua
@@ -28,10 +28,7 @@ end
 	@return table
 ]=]
 function Table.merge(orig, new)
-	local result = {}
-	for key, val in pairs(orig) do
-		result[key] = val
-	end
+	local result = table.clone(orig)
 	for key, val in pairs(new) do
 		result[key] = val
 	end

--- a/src/time/src/Shared/Time.lua
+++ b/src/time/src/Shared/Time.lua
@@ -24,10 +24,7 @@ local DAYS_OF_WEEK_SHORT = {"Sun",    "Mon",    "Tues",    "Weds",      "Thurs",
 	@return { [number]: number }
 ]=]
 function Time.getDaysMonthTable(year)
-	local copy = {}
-	for key, value in pairs(DAYS_IN_MONTH) do
-		copy[key] = value
-	end
+	local copy = table.clone(DAYS_IN_MONTH)
 
 	if year % 4 == 0 and (year % 100 ~= 0 or year % 400 == 0) then
 		copy[2] = 29

--- a/tools/nevermore-cli/templates/game-template/aftman.toml
+++ b/tools/nevermore-cli/templates/game-template/aftman.toml
@@ -2,4 +2,4 @@
 # For more information, see https://github.com/LPGhatguy/aftman
 [tools]
 rojo = "quenty/rojo@7.2.1-quenty-npm-canary.5"
-selene = "Kampfkarren/selene@0.23.1"
+selene = "Kampfkarren/selene@0.24.0"


### PR DESCRIPTION
Fixes all occurrences of Selene's 'manual_table_clone' lint. Also has slightly better docs.

**BREAKING CHANGE**: This breaks table.getIndex in the metatable scenario of comparison using `==`. Generally this contract should not actually cause any issues but it's important that we identify this as an issue.

This will cause a wide variety of package releases in major version.