### PR TITLE
Fix: Corrected method call

### DIFF
--- a/src/resetservice/src/Client/ResetServiceClient.lua
+++ b/src/resetservice/src/Client/ResetServiceClient.lua
@@ -54,7 +54,7 @@ function ResetServiceClient:RequestResetCharacter()
 		end
 	end
 
-	self._promiseRemoteEvent():Then(function(remoteEvent)
+	self:_promiseRemoteEvent():Then(function(remoteEvent)
 		remoteEvent:FireServer()
 	end)
 end


### PR DESCRIPTION
`ResetServiceClient:_promiseRemoteEvent()` is actually indexing a property from `self`, which isn't passed when you call a metatable's method with a `.`, you have to use `:` to pass on `self`.