### PR TITLE
fix: 'Promise.isPromise' checks metatable over reading ClassName

### DIFF
--- a/src/promise/src/Shared/Promise.lua
+++ b/src/promise/src/Shared/Promise.lua
@@ -22,7 +22,7 @@ Promise.__index = Promise
 	@return boolean
 ]=]
 function Promise.isPromise(value)
-	return type(value) == "table" and value.ClassName == "Promise"
+	return type(value) == "table" and getmetatable(value) == Promise
 end
 
 --[=[


### PR DESCRIPTION
I've been wanting to return `Table.readOnly` tables from inside promises. However I've run into an issue: every value returned from a Promise is checked against `Promise.isPromise` for chaining, which reads `ClassName` directly and causes the `readonly` metatable to throw. My solution is to use `getmetatable` instead, like newer Nevermore classes.