### PR TITLE
feat: Add github workflow to nevermore init command

### DIFF
--- a/tools/nevermore-cli/package-lock.json
+++ b/tools/nevermore-cli/package-lock.json
@@ -33,7 +33,8 @@
       }
     },
     "../cli-output-helpers": {
-      "version": "1.1.0",
+      "name": "@quenty/cli-output-helpers",
+      "version": "1.2.0",
       "license": "UNLICENSED",
       "dependencies": {
         "chalk": "^4.1.2"
@@ -48,7 +49,8 @@
       }
     },
     "../nevermore-template-helpers": {
-      "version": "1.1.0",
+      "name": "@quenty/nevermore-template-helpers",
+      "version": "1.2.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@quenty/cli-output-helpers": "file:../cli-output-helpers",

--- a/tools/nevermore-cli/templates/game-template/.github/workflows/build.yml
+++ b/tools/nevermore-cli/templates/game-template/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: build
+on: [push]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Aftman
+        uses: ok-nick/setup-aftman@v0.3.0
+        with:
+          version: 'v0.2.7'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate standard library
+        run: selene generate-roblox-std
+
+      - name: Run Selene
+        run: selene src
+
+      - name: Run moonwave-extractor
+        if: success() || failure()
+        run: moonwave-extractor extract src

--- a/tools/nevermore-cli/templates/game-template/aftman.toml
+++ b/tools/nevermore-cli/templates/game-template/aftman.toml
@@ -3,3 +3,4 @@
 [tools]
 rojo = "quenty/rojo@7.2.1-quenty-npm-canary.5"
 selene = "Kampfkarren/selene@0.23.1"
+moonwave-extractor = "UpliftGames/moonwave@0.3.3"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/nevermore-cli@1.5.0-canary.329.8369044.0
  # or 
  yarn add @quenty/nevermore-cli@1.5.0-canary.329.8369044.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
