### PR TITLE
feat: Add ScreenshotHudService which allows the screenshot HUD to be manipulated

### DIFF
--- a/src/screenshothudservice/README.md
+++ b/src/screenshothudservice/README.md
@@ -1,0 +1,23 @@
+## ScreenshotHudService
+
+<div align="center">
+  <a href="http://quenty.github.io/NevermoreEngine/">
+    <img src="https://github.com/Quenty/NevermoreEngine/actions/workflows/docs.yml/badge.svg" alt="Documentation status" />
+  </a>
+  <a href="https://discord.gg/mhtGUS8">
+    <img src="https://img.shields.io/discord/385151591524597761?color=5865F2&label=discord&logo=discord&logoColor=white" alt="Discord" />
+  </a>
+  <a href="https://github.com/Quenty/NevermoreEngine/actions">
+    <img src="https://github.com/Quenty/NevermoreEngine/actions/workflows/build.yml/badge.svg" alt="Build and release status" />
+  </a>
+</div>
+
+Provides centralized API surface for screenshot hud API
+
+<div align="center"><a href="https://quenty.github.io/NevermoreEngine/api/ScreenshotHudServiceUtils">View docs →</a></div>
+
+## Installation
+
+```
+npm install @quenty/screenshothudservice --save
+```

--- a/src/screenshothudservice/default.project.json
+++ b/src/screenshothudservice/default.project.json
@@ -1,0 +1,6 @@
+{
+  "name": "screenshothudservice",
+  "tree": {
+    "$path": "src"
+  }
+}

--- a/src/screenshothudservice/package.json
+++ b/src/screenshothudservice/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@quenty/screenshothudservice",
+  "version": "1.0.0",
+  "description": "Provides centralized API surface for screenshot hud API",
+  "keywords": [
+    "Roblox",
+    "Nevermore",
+    "Lua",
+    "screenshothudservice"
+  ],
+  "bugs": {
+    "url": "https://github.com/Quenty/NevermoreEngine/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Quenty/NevermoreEngine.git",
+    "directory": "src/screenshothudservice/"
+  },
+  "funding": {
+    "type": "patreon",
+    "url": "https://www.patreon.com/quenty"
+  },
+  "license": "MIT",
+  "contributors": [
+    "Quenty"
+  ],
+  "dependencies": {
+    "@quenty/baseobject": "file:../baseobject",
+    "@quenty/brio": "file:../brio",
+    "@quenty/instanceutils": "file:../instanceutils",
+    "@quenty/loader": "file:../loader",
+    "@quenty/maid": "file:../maid",
+    "@quenty/promise": "file:../promise",
+    "@quenty/rx": "file:../rx",
+    "@quenty/servicebag": "file:../servicebag",
+    "@quenty/signal": "file:../signal",
+    "@quenty/statestack": "file:../statestack",
+    "@quenty/valueobject": "file:../valueobject"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/src/screenshothudservice/src/Client/ScreenshotHudModel.lua
+++ b/src/screenshothudservice/src/Client/ScreenshotHudModel.lua
@@ -1,0 +1,284 @@
+--[=[
+	@class ScreenshotHudModel
+]=]
+
+local require = require(script.Parent.loader).load(script)
+
+local BaseObject = require("BaseObject")
+local ValueObject = require("ValueObject")
+local RxInstanceUtils = require("RxInstanceUtils")
+local Signal = require("Signal")
+
+local ScreenshotHudModel = setmetatable({}, BaseObject)
+ScreenshotHudModel.ClassName = "ScreenshotHudModel"
+ScreenshotHudModel.__index = ScreenshotHudModel
+
+function ScreenshotHudModel.new()
+	local self = setmetatable(BaseObject.new(), ScreenshotHudModel)
+
+	self._cameraButtonIcon = Instance.new("StringValue")
+	self._cameraButtonIcon.Value = ""
+	self._maid:GiveTask(self._cameraButtonIcon)
+
+	self._cameraButtonPosition = ValueObject.new(UDim2.new(0, 0, 0, 0))
+	self._maid:GiveTask(self._cameraButtonPosition)
+
+	self._closeButtonPosition = ValueObject.new(UDim2.new(0, 0, 0, 0))
+	self._maid:GiveTask(self._closeButtonPosition)
+
+	self._closeWhenScreenshotTaken = Instance.new("BoolValue")
+	self._closeWhenScreenshotTaken.Value = false
+	self._maid:GiveTask(self._closeWhenScreenshotTaken)
+
+	self._experienceNameOverlayEnabled = Instance.new("BoolValue")
+	self._experienceNameOverlayEnabled.Value = false
+	self._maid:GiveTask(self._experienceNameOverlayEnabled)
+
+	self._overlayFont = ValueObject.new(Enum.Font.SourceSans)
+	self._maid:GiveTask(self._overlayFont)
+
+	self._usernameOverlayEnabled = Instance.new("BoolValue")
+	self._usernameOverlayEnabled.Value = false
+	self._maid:GiveTask(self._usernameOverlayEnabled)
+
+	self._visible = Instance.new("BoolValue")
+	self._visible.Value = false
+	self._maid:GiveTask(self._visible)
+
+	self._cameraButtonVisible = Instance.new("BoolValue")
+	self._cameraButtonVisible.Value = true
+	self._maid:GiveTask(self._cameraButtonVisible)
+
+	self._closeButtonVisible = Instance.new("BoolValue")
+	self._closeButtonVisible.Value = false
+	self._maid:GiveTask(self._closeButtonVisible)
+
+	self._keepOpen = Instance.new("BoolValue")
+	self._keepOpen.Value = true
+	self._maid:GiveTask(self._keepOpen)
+
+	self.CloseRequested = Signal.new()
+	self._maid:GiveTask(self.CloseRequested)
+
+	return self
+end
+
+--[=[
+	Sets whether the close button is visible
+	@param closeButtonVisible boolean
+]=]
+function ScreenshotHudModel:SetCloseButtonVisible(closeButtonVisible)
+	assert(typeof(closeButtonVisible) == "boolean", "Bad closeButtonVisible")
+
+	self._closeButtonVisible.Value = closeButtonVisible
+end
+
+--[=[
+	Observes close button visiblity
+	@return Observable<boolean>
+]=]
+function ScreenshotHudModel:ObserveCloseButtonVisible()
+	return RxInstanceUtils.observeProperty(self._closeButtonVisible, "Value")
+end
+
+--[=[
+	Sets whether the camera button is visible
+	@param cameraButtonVisible boolean
+]=]
+function ScreenshotHudModel:SetCameraButtonVisible(cameraButtonVisible)
+	assert(typeof(cameraButtonVisible) == "boolean", "Bad cameraButtonVisible")
+
+	self._cameraButtonVisible.Value = cameraButtonVisible
+end
+
+--[=[
+	Observes camera button visiblity
+	@return Observable<boolean>
+]=]
+function ScreenshotHudModel:ObserveCameraButtonVisible()
+	return RxInstanceUtils.observeProperty(self._cameraButtonVisible, "Value")
+end
+
+--[=[
+	Sets whether we should try to keep the UI open
+	@param keepOpen boolean
+]=]
+function ScreenshotHudModel:SetKeepOpen(keepOpen)
+	assert(typeof(keepOpen) == "boolean", "Bad keepOpen")
+
+	self._keepOpen.Value = keepOpen
+end
+
+--[=[
+	Gets whether we should try to keep the UI open
+	@return boolean
+]=]
+function ScreenshotHudModel:GetKeepOpen()
+	return self._keepOpen.Value
+end
+
+--[=[
+	Sets the close button's position
+	@param visible boolean
+]=]
+function ScreenshotHudModel:SetCloseButtonVisible(visible)
+	assert(type(visible) == "boolean", "Bad visible")
+
+	self._closeButtonPosition.Value = visible
+end
+
+
+--[=[
+	Sets the close button's position
+	@param position UDim2 | nil
+]=]
+function ScreenshotHudModel:SetCloseButtonPosition(position)
+	assert(typeof(position) == "UDim2" or position == nil, "Bad position")
+
+	self._closeButtonPosition.Value = position or UDim2.new(0, 0, 0, 0)
+end
+
+--[=[
+	Observes the close button's position
+	@return Observable<UDim2>
+]=]
+function ScreenshotHudModel:ObserveCloseButtonPosition()
+	return self._closeButtonPosition:Observe()
+end
+
+--[=[
+	Sets the camera button's position
+	@param position UDim2 | nil
+]=]
+function ScreenshotHudModel:SetCameraButtonPosition(position)
+	assert(typeof(position) == "UDim2" or position == nil, "Bad position")
+
+	self._cameraButtonPosition.Value = position or UDim2.new(0, 0, 0, 0)
+end
+
+--[=[
+	Observes the camera button's position
+	@return Observable<UDim2>
+]=]
+function ScreenshotHudModel:ObserveCameraButtonPosition()
+	return self._cameraButtonPosition:Observe()
+end
+
+--[=[
+	Sets the overlay font
+	@param overlayFont Font
+]=]
+function ScreenshotHudModel:SetOverlayFont(overlayFont)
+	assert(typeof(overlayFont) == "EnumItem" or overlayFont == nil, "Bad overlayFont")
+
+	self._overlayFont.Value = overlayFont
+end
+
+--[=[
+	Observes the overlay font
+	@return Observable<Font>
+]=]
+function ScreenshotHudModel:ObserveOverlayFont()
+	return self._overlayFont:Observe()
+end
+
+--[=[
+	Sets the camera button's icon.
+
+	@param icon string | nil
+]=]
+function ScreenshotHudModel:SetCameraButtonIcon(icon)
+	assert(type(icon) == "string" or icon == nil, "Bad icon")
+
+	self._cameraButtonIcon.Value = icon or ""
+end
+
+--[=[
+	Observes the camera button's icon
+
+	@return Observable<string>
+]=]
+function ScreenshotHudModel:ObserveCameraButtonIcon()
+	return RxInstanceUtils.observeProperty(self._cameraButtonIcon, "Value")
+end
+
+--[=[
+	Sets whether to close after a screenshot if taken
+
+	@param closeWhenScreenshotTaken boolean
+]=]
+function ScreenshotHudModel:SetCloseWhenScreenshotTaken(closeWhenScreenshotTaken)
+	assert(type(closeWhenScreenshotTaken) == "boolean", "Bad closeWhenScreenshotTaken")
+
+	self._closeWhenScreenshotTaken.Value = closeWhenScreenshotTaken
+end
+
+--[=[
+	Returns whether the model will try to close if a screenshot is taken
+	@return boolean
+]=]
+function ScreenshotHudModel:GetCloseWhenScreenshotTaken()
+	return self._closeWhenScreenshotTaken.Value
+end
+
+--[=[
+	Observes whether a screenshot is taken
+	@return Observable<boolean>
+]=]
+function ScreenshotHudModel:ObserveCloseWhenScreenshotTaken()
+	return RxInstanceUtils.observeProperty(self._closeWhenScreenshotTaken, "Value")
+end
+
+--[=[
+	Sets whether to experience name overlay should be enabled
+	@param experienceNameOverlayEnabled boolean
+]=]
+function ScreenshotHudModel:SetExperienceNameOverlayEnabled(experienceNameOverlayEnabled)
+	assert(type(experienceNameOverlayEnabled) == "boolean", "Bad experienceNameOverlayEnabled")
+
+	self._experienceNameOverlayEnabled.Value = experienceNameOverlayEnabled
+end
+
+--[=[
+	Observes whether the experience name overlay is enabled
+	@return Observable<boolean>
+]=]
+function ScreenshotHudModel:ObserveExperienceNameOverlayEnabled()
+	return RxInstanceUtils.observeProperty(self._experienceNameOverlayEnabled, "Value")
+end
+
+--[=[
+	Sets whether to username overlay should be enabled
+	@param usernameOverlayEnabled boolean
+]=]
+function ScreenshotHudModel:SetUsernameOverlayEnabled(usernameOverlayEnabled)
+	assert(type(usernameOverlayEnabled) == "boolean", "Bad usernameOverlayEnabled")
+
+	self._usernameOverlayEnabled.Value = usernameOverlayEnabled
+end
+
+--[=[
+	Observes whether the username name overlay is enabled
+	@return Observable<boolean>
+]=]
+function ScreenshotHudModel:ObserveUsernameOverlayEnabled()
+	return RxInstanceUtils.observeProperty(self._usernameOverlayEnabled, "Value")
+end
+
+--[=[
+	Observes whilet he model is visible
+	@return Observable<boolean>
+]=]
+function ScreenshotHudModel:ObserveVisible()
+	return RxInstanceUtils.observeProperty(self._visible, "Value")
+end
+
+function ScreenshotHudModel:InternalNotifyVisible(isVisible)
+	self._visible.Value = isVisible
+end
+
+function ScreenshotHudModel:InternalFireClosedRequested()
+	self.CloseRequested:Fire()
+end
+
+return ScreenshotHudModel

--- a/src/screenshothudservice/src/Client/ScreenshotHudServiceClient.lua
+++ b/src/screenshothudservice/src/Client/ScreenshotHudServiceClient.lua
@@ -1,0 +1,141 @@
+--[=[
+	@class ScreenshotHudServiceClient
+]=]
+
+local require = require(script.Parent.loader).load(script)
+
+local GuiService = game:GetService("GuiService")
+
+local Maid = require("Maid")
+local RxInstanceUtils = require("RxInstanceUtils")
+local StateStack = require("StateStack")
+local Rx = require("Rx")
+local RxBrioUtils = require("RxBrioUtils")
+local ScreenshotHudServiceClient = {}
+ScreenshotHudServiceClient.ServiceName = "ScreenshotHudServiceClient"
+
+function ScreenshotHudServiceClient:Init(serviceBag)
+	assert(not self._serviceBag, "Already initialized")
+	self._serviceBag = assert(serviceBag, "No serviceBag")
+	self._maid = Maid.new()
+
+	self._screenshotHudState = StateStack.new(nil)
+	self._maid:GiveTask(self._screenshotHudState)
+
+	self._maid:GiveTask(RxBrioUtils.flatCombineLatest({
+		model = self._screenshotHudState:Observe();
+		screenshotHUD = self:_observeScreenshotHudBrio();
+	}):Subscribe(function(state)
+		self._maid._current = nil
+		local maid = Maid.new()
+		if state.model and state.screenshotHUD then
+			self:_bindModelToHUD(maid, state.model, state.screenshotHUD)
+			state.screenshotHUD.Visible = true
+		else
+			state.screenshotHUD.Visible = false
+		end
+		self._maid._current = maid
+	end))
+end
+
+--[=[
+	Pushes a new screenshotHudModel to show. This will fire .
+
+	@param screenshotHudModel ScreenshotHudModel
+	@return function -- cleanup code
+]=]
+function ScreenshotHudServiceClient:PushModel(screenshotHudModel)
+	local maid = Maid.new()
+
+	maid:GiveTask(self._screenshotHudState:PushState(screenshotHudModel))
+
+	return function()
+		maid:DoCleaning()
+	end
+end
+
+function ScreenshotHudServiceClient:_bindModelToHUD(maid, model, screenshotHUD)
+	maid:GiveTask(Rx.combineLatest({
+		visible = model:ObserveCloseButtonVisible();
+		position = model:ObserveCloseButtonPosition();
+	}):Subscribe(function(state)
+		if state.visible then
+			screenshotHUD.CloseButtonPosition = state.position
+		else
+			-- Hack to hide the close button
+			screenshotHUD.CloseButtonPosition = UDim2.new(2, 0, 2, 0)
+		end
+	end))
+
+	-- I'm not sure why you would do this, but it's here
+	maid:GiveTask(Rx.combineLatest({
+		visible = model:ObserveCameraButtonVisible();
+		position = model:ObserveCameraButtonPosition();
+	}):Subscribe(function(state)
+		if state.visible then
+			screenshotHUD.CameraButtonPosition = state.position
+		else
+			-- Hack to hide the close button
+			screenshotHUD.CameraButtonPosition = UDim2.new(2, 0, 2, 0)
+		end
+	end))
+
+	maid:GiveTask(model:ObserveCameraButtonIcon():Subscribe(function(cameraButtonIcon)
+		screenshotHUD.CameraButtonIcon = cameraButtonIcon
+	end))
+	maid:GiveTask(model:ObserveCloseWhenScreenshotTaken():Subscribe(function(closeWhenScreenshotTaken)
+		screenshotHUD.CloseWhenScreenshotTaken = closeWhenScreenshotTaken
+	end))
+	maid:GiveTask(model:ObserveExperienceNameOverlayEnabled():Subscribe(function(experienceNameOverlayEnabled)
+		screenshotHUD.ExperienceNameOverlayEnabled = experienceNameOverlayEnabled
+	end))
+	maid:GiveTask(model:ObserveUsernameOverlayEnabled():Subscribe(function(usernameOverlayEnabled)
+		screenshotHUD.UsernameOverlayEnabled = usernameOverlayEnabled
+	end))
+	maid:GiveTask(model:ObserveOverlayFont():Subscribe(function(overlayFont)
+		screenshotHUD.OverlayFont = overlayFont
+	end))
+
+	local alive = true
+	maid:GiveTask(function()
+		alive = false
+	end)
+
+	-- Visibility hiding will be taken care of at the higher level
+	maid:GiveTask(screenshotHUD:GetPropertyChangedSignal("Visible"):Connect(function()
+		if not model.Destroy then
+			return
+		end
+
+		-- Reenable so we have a chance
+		if not screenshotHUD.Visible then
+			model:InternalFireClosedRequested()
+
+			-- Reshow is we ned to
+			task.defer(function()
+				if alive and model.Destroy then
+					if model:GetKeepOpen() then
+						screenshotHUD.Visible = true
+					end
+				end
+			end)
+		end
+	end))
+
+	model:InternalNotifyVisible(true)
+	maid:GiveTask(function()
+		if model.Destroy then
+			model:InternalNotifyVisible(false)
+		end
+	end)
+end
+
+function ScreenshotHudServiceClient:_observeScreenshotHudBrio()
+	return RxInstanceUtils.observeLastNamedChildBrio(GuiService, "ScreenshotHud", "ScreenshotHud")
+end
+
+function ScreenshotHudServiceClient:Destroy()
+	self._maid:DoCleaning()
+end
+
+return ScreenshotHudServiceClient

--- a/src/screenshothudservice/src/node_modules.project.json
+++ b/src/screenshothudservice/src/node_modules.project.json
@@ -1,0 +1,7 @@
+{
+  "name": "node_modules",
+  "globIgnorePaths": [ "**/.package-lock.json" ],
+  "tree": {
+    "$path": { "optional": "../node_modules" }
+  }
+}

--- a/src/screenshothudservice/test/default.project.json
+++ b/src/screenshothudservice/test/default.project.json
@@ -1,0 +1,21 @@
+{
+  "name": "ScreenshotHudServiceTests",
+  "tree": {
+    "$className": "DataModel",
+    "ServerScriptService": {
+      "screenshothudservice": {
+        "$path": ".."
+      },
+      "Script": {
+        "$path": "scripts/Server"
+      }
+    },
+    "StarterPlayer": {
+      "StarterPlayerScripts": {
+        "Main": {
+          "$path": "scripts/Client"
+        }
+      }
+    }
+  }
+}

--- a/src/screenshothudservice/test/scripts/Client/ClientMain.client.lua
+++ b/src/screenshothudservice/test/scripts/Client/ClientMain.client.lua
@@ -1,0 +1,30 @@
+--[[
+	@class ClientMain
+]]
+local packages = game:GetService("ReplicatedStorage"):WaitForChild("Packages")
+
+local serviceBag = require(packages.ServiceBag).new()
+local hudService = serviceBag:GetService(packages.ScreenshotHudServiceClient)
+
+-- Start game
+serviceBag:Init()
+serviceBag:Start()
+
+local Maid = require(packages.Maid)
+local ScreenshotHudModel = require(packages.ScreenshotHudModel)
+
+local maid = Maid.new()
+
+local screenshotHudModel = ScreenshotHudModel.new()
+screenshotHudModel:SetExperienceNameOverlayEnabled(false)
+screenshotHudModel:SetUsernameOverlayEnabled(false)
+screenshotHudModel:SetOverlayFont(Enum.Font.FredokaOne)
+screenshotHudModel:SetCloseButtonVisible(false)
+
+maid:GiveTask(screenshotHudModel)
+
+maid:GiveTask(hudService:PushModel(screenshotHudModel))
+
+maid:GiveTask(screenshotHudModel.CloseRequested:Connect(function()
+	maid:DoCleaning()
+end))

--- a/src/screenshothudservice/test/scripts/Server/ServerMain.server.lua
+++ b/src/screenshothudservice/test/scripts/Server/ServerMain.server.lua
@@ -1,0 +1,9 @@
+--[[
+	@class ServerMain
+]]
+
+local ServerScriptService = game:GetService("ServerScriptService")
+
+local loader = ServerScriptService:FindFirstChild("LoaderUtils", true).Parent
+require(loader).bootstrapGame(ServerScriptService.screenshothudservice)
+


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/screenshothudservice@1.1.0-canary.333.1160373.0
  # or 
  yarn add @quenty/screenshothudservice@1.1.0-canary.333.1160373.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
