### PR TITLE
fix: Fix flipbook playback on odd row/column scenarios

### DIFF
--- a/src/flipbook/src/Client/Flipbook.lua
+++ b/src/flipbook/src/Client/Flipbook.lua
@@ -37,7 +37,7 @@ function Flipbook.new(data)
 		self:SetFrameCount(data.frameCount)
 	else
 		assert(data.columns, "Bad columns")
-		assert(data.columns, "Bad rows")
+		assert(data.rows, "Bad rows")
 
 		self:SetFrameCount(data.rows*data.columns)
 	end
@@ -48,10 +48,10 @@ function Flipbook.new(data)
 
 	do
 		local image = assert(data.image, "Bad image")
-		local rows = assert(data.rows, "Bad rows")
+		local columns = assert(data.columns, "Bad columns")
 		local imageRectSize = assert(data.imageRectSize, "Bad imageRectSize")
 
-		self:_loadFrames(image, rows, imageRectSize)
+		self:_loadFrames(image, columns, imageRectSize)
 	end
 
 	return self
@@ -61,15 +61,15 @@ function Flipbook.isFlipbook(value)
 	return type(value) == "table" and getmetatable(value) == Flipbook
 end
 
-function Flipbook:_loadFrames(image, rows, imageRectSize)
-	assert(type(rows) == "number", "Bad rows")
+function Flipbook:_loadFrames(image, columns, imageRectSize)
+	assert(type(columns) == "number", "Bad columns")
 	assert(typeof(imageRectSize) == "Vector2", "Bad imageRectSize")
 
 	self:SetImageRectSize(imageRectSize)
 
 	for i=0, self._frameCount do
-		local x = i % rows
-		local y = math.floor(i / rows)
+		local x = i % columns
+		local y = math.floor(i / columns)
 		local position = imageRectSize*Vector2.new(x, y)
 
 		local index = i + 1

--- a/src/flipbook/src/Client/Player/FlipbookPlayer.story.lua
+++ b/src/flipbook/src/Client/Player/FlipbookPlayer.story.lua
@@ -111,19 +111,21 @@ return function(target)
 
 	makeLabel(maid, Flipbook.new({
 		image = "rbxassetid://9234616869";
-		rows = 6;
-		columns = 6;
+		rows = 10;
+		columns = 10;
+		frameCount = 92;
 		imageRectSize = Vector2.new(102, 102);
 		frameRate = 50;
-	}), container, true)
+	}), container, false)
 
 	makeButton(maid, Flipbook.new({
 		image = "rbxassetid://9234616869";
-		rows = 6;
-		columns = 6;
+		rows = 10;
+		columns = 10;
+		frameCount = 92;
 		imageRectSize = Vector2.new(102, 102);
 		frameRate = 60;
-	}), container, true)
+	}), container, false)
 
 	makeButton(maid, Flipbook.new({
 		image = "rbxassetid://5085366281";
@@ -133,6 +135,33 @@ return function(target)
 		imageRectSize = Vector2.new(85.33333, 85.33333);
 		frameRate = 20;
 	}), container, true)
+
+	makeLabel(maid, Flipbook.new({
+		image = "rbxassetid://9234616869";
+		rows = 10;
+		columns = 10;
+		frameCount = 92;
+		imageRectSize = Vector2.new(102, 102);
+		frameRate = 50;
+	}), container, false)
+
+	makeLabel(maid, Flipbook.new({
+		image = "rbxassetid://12273540121";
+		rows = 7;
+		columns = 7;
+		frameCount = 45;
+		imageRectSize = Vector2.new(146, 146);
+		frameRate = 30;
+	}), container, false)
+
+	makeLabel(maid, Flipbook.new({
+		image = "rbxassetid://9234650028";
+		columns = 9;
+		rows = 8;
+		frameCount = 66;
+		imageRectSize = Vector2.new(113, 113);
+		frameRate = 60;
+	}), container, false)
 
 	return function()
 		maid:DoCleaning()


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/flipbook@2.0.2-canary.340.fc60b33.0
  # or 
  yarn add @quenty/flipbook@2.0.2-canary.340.fc60b33.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
