### PR TITLE
fix: Fix localization not swapping in soft shutdown if locale swaps

### DIFF
--- a/src/clienttranslator/src/Client/JSONTranslator.lua
+++ b/src/clienttranslator/src/Client/JSONTranslator.lua
@@ -44,6 +44,13 @@ JSONTranslator.__index = JSONTranslator
 	})
 
 	print(translator:FormatByKey("actions.respawn"), { playerName = "Quenty"}) --> Respawn Quenty
+
+	-- Observing is preferred
+	maid:GiveTask(translator:ObserveFormatByKey("actions.respawn", {
+		playerName = RxInstanceUtils.observeProperty(player, "DisplayName");
+	}):Subscribe(function(text)
+		print(text) --> "Respawn Quenty"
+	end)
 	```
 
 	```lua

--- a/src/softshutdown/src/Client/SoftShutdownServiceClient.lua
+++ b/src/softshutdown/src/Client/SoftShutdownServiceClient.lua
@@ -143,13 +143,13 @@ function SoftShutdownServiceClient:_showSoftShutdownUI(titleKey, subtitleKey, do
 
 	self:_hideCoreGuiUI(renderMaid, screenGui)
 
-	maid:GivePromise(self._translator:PromiseFormatByKey(subtitleKey)):Then(function(subtitle)
+	maid:GiveTask(self._translator:ObserveFormatByKey(subtitleKey):Subscribe(function(subtitle)
 		softShutdownUI:SetSubtitle(subtitle)
-	end)
+	end))
 
-	maid:GivePromise(self._translator:PromiseFormatByKey(titleKey)):Then(function(title)
+	maid:GiveTask(self._translator:ObserveFormatByKey(titleKey):Subscribe(function(title)
 		softShutdownUI:SetTitle(title)
-	end)
+	end))
 
 	softShutdownUI:Show(doNotAnimateShow)
 

--- a/src/softshutdown/src/Client/SoftShutdownUI.story.lua
+++ b/src/softshutdown/src/Client/SoftShutdownUI.story.lua
@@ -19,13 +19,13 @@ return function(target)
 	local softShutdownUI = SoftShutdownUI.new()
 	maid:GiveTask(softShutdownUI)
 
-	maid:GivePromise(translator:PromiseFormatByKey("shutdown.lobby.title")):Then(function(text)
+	maid:GiveTask(translator:ObserveFormatByKey("shutdown.lobby.title"):Subscribe(function(text)
 		softShutdownUI:SetTitle(text)
-	end)
+	end))
 
-	maid:GivePromise(translator:PromiseFormatByKey("shutdown.lobby.subtitle")):Then(function(text)
+	maid:GiveTask(translator:ObserveFormatByKey("shutdown.lobby.subtitle"):Subscribe(function(text)
 		softShutdownUI:SetSubtitle(text)
-	end)
+	end))
 
 	softShutdownUI:Show()
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/clienttranslator@8.13.1-canary.342.ee93043.0
  npm install @quenty/gameconfig@5.17.1-canary.342.ee93043.0
  npm install @quenty/gameproductservice@6.3.1-canary.342.ee93043.0
  npm install @quenty/inputkeymaputils@7.17.1-canary.342.ee93043.0
  npm install @quenty/scoredactionservice@9.17.1-canary.342.ee93043.0
  npm install @quenty/settings-inputkeymap@3.19.1-canary.342.ee93043.0
  npm install @quenty/softshutdown@3.18.2-canary.342.ee93043.0
  # or 
  yarn add @quenty/clienttranslator@8.13.1-canary.342.ee93043.0
  yarn add @quenty/gameconfig@5.17.1-canary.342.ee93043.0
  yarn add @quenty/gameproductservice@6.3.1-canary.342.ee93043.0
  yarn add @quenty/inputkeymaputils@7.17.1-canary.342.ee93043.0
  yarn add @quenty/scoredactionservice@9.17.1-canary.342.ee93043.0
  yarn add @quenty/settings-inputkeymap@3.19.1-canary.342.ee93043.0
  yarn add @quenty/softshutdown@3.18.2-canary.342.ee93043.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
