### PR TITLE
fix: Fix missing dependency in gameproductservice

### DIFF
--- a/src/gameproductservice/package.json
+++ b/src/gameproductservice/package.json
@@ -31,6 +31,7 @@
     "@quenty/baseobject": "file:../baseobject",
     "@quenty/binder": "file:../binder",
     "@quenty/gameconfig": "file:../gameconfig",
+    "@quenty/instanceutils": "file:../instanceutils",
     "@quenty/loader": "file:../loader",
     "@quenty/maid": "file:../maid",
     "@quenty/marketplaceutils": "file:../marketplaceutils",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/gameproductservice@7.1.1-canary.355.d6e5583.0
  # or 
  yarn add @quenty/gameproductservice@7.1.1-canary.355.d6e5583.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
