### PR TITLE
feat: Increase default flush time which will decrease RPS for InfluxDB

### DIFF
--- a/src/influxdbclient/src/Server/Config/InfluxDBWriteOptionUtils.lua
+++ b/src/influxdbclient/src/Server/Config/InfluxDBWriteOptionUtils.lua
@@ -12,7 +12,7 @@ function InfluxDBWriteOptionUtils.getDefaultOptions()
 	return InfluxDBWriteOptionUtils.createWriteOptions({
 		batchSize = 1000;
 		maxBatchBytes = 50_000_000; -- default max batch size in the cloud
-		flushIntervalSeconds = 5;
+		flushIntervalSeconds = 60;
 		-- maxRetries = 5;
 		-- maxRetryTimeSeconds = 180;
 		-- maxBufferLines = 32_000;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/influxdbclient@1.5.0-canary.361.518a7ca.0
  # or 
  yarn add @quenty/influxdbclient@1.5.0-canary.361.518a7ca.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
