### PR TITLE
feat: Remove loader dependency requirement

### DIFF
--- a/src/richtext/package.json
+++ b/src/richtext/package.json
@@ -24,9 +24,7 @@
   "contributors": [
     "Quenty"
   ],
-  "dependencies": {
-    "@quenty/loader": "file:../loader"
-  },
+  "dependencies": {},
   "publishConfig": {
     "access": "public"
   }

--- a/src/richtext/src/Shared/RichTextUtils.lua
+++ b/src/richtext/src/Shared/RichTextUtils.lua
@@ -4,8 +4,6 @@
 	@class RichTextUtils
 ]=]
 
-local require = require(script.Parent.loader).load(script)
-
 local RichTextUtils = {}
 
 --[=[


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/richtext@1.2.0-canary.364.ed790cd.0
  # or 
  yarn add @quenty/richtext@1.2.0-canary.364.ed790cd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
