### PR TITLE
fix: Player can try to reset while not in game

### DIFF
--- a/src/resetservice/src/Server/ResetService.lua
+++ b/src/resetservice/src/Server/ResetService.lua
@@ -28,6 +28,10 @@ function ResetService:Init()
 end
 
 function ResetService:_resetCharacterYielding(player)
+	if not player:IsDescendantOf(game) then
+		return
+	end
+
 	player:LoadCharacter()
 end
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/resetservice@5.7.1-canary.366.fac28fa.0
  # or 
  yarn add @quenty/resetservice@5.7.1-canary.366.fac28fa.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
