### PR TITLE
fix: Fix binder args failing in no-arg non-service-provided interface

### DIFF
--- a/src/binder/src/Shared/Binder.lua
+++ b/src/binder/src/Shared/Binder.lua
@@ -133,6 +133,9 @@ function Binder:Init(...)
 		elseif not self:_argsMatch(...) then
 			warn("[Binder.Init] - Non-matching args from :Init() and .new()")
 		end
+	elseif not self._args then
+		-- Binder.new() would have captured args if we had them
+		self._args = {}
 	end
 
 	self._maid._warning = task.delay(5, function()


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/binder@8.18.1-canary.375.36f3417.0
  npm install @quenty/boundlinkutils@8.18.1-canary.375.36f3417.0
  npm install @quenty/cooldown@5.23.1-canary.375.36f3417.0
  npm install @quenty/deathreport@3.21.1-canary.375.36f3417.0
  npm install @quenty/gameconfig@5.29.1-canary.375.36f3417.0
  npm install @quenty/gameproductservice@7.7.1-canary.375.36f3417.0
  npm install @quenty/hide@5.20.1-canary.375.36f3417.0
  npm install @quenty/humanoidspeed@5.23.1-canary.375.36f3417.0
  npm install @quenty/idleservice@7.27.2-canary.375.36f3417.0
  npm install @quenty/ik@9.28.2-canary.375.36f3417.0
  npm install @quenty/motor6d@1.24.1-canary.375.36f3417.0
  npm install @quenty/parttouchingcalculator@8.18.1-canary.375.36f3417.0
  npm install @quenty/playerbinder@8.18.1-canary.375.36f3417.0
  npm install @quenty/playerhumanoidbinder@8.18.1-canary.375.36f3417.0
  npm install @quenty/ragdoll@9.27.2-canary.375.36f3417.0
  npm install @quenty/rogue-humanoid@3.23.1-canary.375.36f3417.0
  npm install @quenty/rogue-properties@4.21.1-canary.375.36f3417.0
  npm install @quenty/rxbinderutils@8.19.1-canary.375.36f3417.0
  npm install @quenty/settings-inputkeymap@3.31.1-canary.375.36f3417.0
  npm install @quenty/settings@4.28.1-canary.375.36f3417.0
  npm install @quenty/spawning@4.23.1-canary.375.36f3417.0
  # or 
  yarn add @quenty/binder@8.18.1-canary.375.36f3417.0
  yarn add @quenty/boundlinkutils@8.18.1-canary.375.36f3417.0
  yarn add @quenty/cooldown@5.23.1-canary.375.36f3417.0
  yarn add @quenty/deathreport@3.21.1-canary.375.36f3417.0
  yarn add @quenty/gameconfig@5.29.1-canary.375.36f3417.0
  yarn add @quenty/gameproductservice@7.7.1-canary.375.36f3417.0
  yarn add @quenty/hide@5.20.1-canary.375.36f3417.0
  yarn add @quenty/humanoidspeed@5.23.1-canary.375.36f3417.0
  yarn add @quenty/idleservice@7.27.2-canary.375.36f3417.0
  yarn add @quenty/ik@9.28.2-canary.375.36f3417.0
  yarn add @quenty/motor6d@1.24.1-canary.375.36f3417.0
  yarn add @quenty/parttouchingcalculator@8.18.1-canary.375.36f3417.0
  yarn add @quenty/playerbinder@8.18.1-canary.375.36f3417.0
  yarn add @quenty/playerhumanoidbinder@8.18.1-canary.375.36f3417.0
  yarn add @quenty/ragdoll@9.27.2-canary.375.36f3417.0
  yarn add @quenty/rogue-humanoid@3.23.1-canary.375.36f3417.0
  yarn add @quenty/rogue-properties@4.21.1-canary.375.36f3417.0
  yarn add @quenty/rxbinderutils@8.19.1-canary.375.36f3417.0
  yarn add @quenty/settings-inputkeymap@3.31.1-canary.375.36f3417.0
  yarn add @quenty/settings@4.28.1-canary.375.36f3417.0
  yarn add @quenty/spawning@4.23.1-canary.375.36f3417.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
