### PR TITLE
Blend.Single changes

### DIFF
--- a/src/blend/src/Shared/Blend/Blend.lua
+++ b/src/blend/src/Shared/Blend/Blend.lua
@@ -787,14 +787,13 @@ function Blend.Single(observable)
 				local copy = BrioUtils.clone(result)
 				maid._current = copy
 				sub:Fire(copy)
-				return copy
+			elseif result then
+				local current = Brio.new(result)
+				maid._current = current
+				sub:Fire(current)
+			else
+				maid._current = nil
 			end
-
-			local current = Brio.new(result)
-			maid._current = current
-			sub:Fire(current)
-
-			return current
 		end))
 
 		return maid

--- a/src/blend/src/Shared/Blend/Blend.lua
+++ b/src/blend/src/Shared/Blend/Blend.lua
@@ -794,6 +794,10 @@ function Blend.Single(observable)
 			else
 				maid._current = nil
 			end
+		end, function(...)
+			sub:Fail(...)
+		end, function(...)
+			sub:Complete(...)
 		end))
 
 		return maid


### PR DESCRIPTION
* Allow returning `nil` from the observable. We know that it will never evaluate to anything interesting, so there's no point creating a brio (which are not free). (Should also probably skip creating a brio if the passed observable is complete and evaluates to nil, i.e. == `Rx.EMPTY`?).
* Propagate state of passed observable. This has just become a slightly more efficient version of a switchMap + toBrio.
* Returning from a subscription does nothing.