### PR TITLE
fix: Upgrade to cmdr 1.12.0 to patch security vulnerability

### DIFF
--- a/src/cmdrservice/package.json
+++ b/src/cmdrservice/package.json
@@ -33,7 +33,7 @@
     "@quenty/servicebag": "file:../servicebag",
     "@quenty/string": "file:../string",
     "@quenty/templateprovider": "file:../templateprovider",
-    "@quentystudios/cmdr": "^1.9.0-quenty.1"
+    "@quentystudios/cmdr": "^1.12.0-quenty.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes this security advisory. See evaera/Cmdr#279.

This upgrades this version to explicitly use this new version. Older versions should still include this patch depending on how the upstream npm registry is configured. 

# Summary
> Initialisation scripts enable for users to save commands which can then be executed whenever they join. This may be useful for things like setting preferences, giving tools to themselves when joining, etc. depending on the game.
>
> Until v1.12.0, Cmdr also supported global initialisation scripts; this allowed any user (with access to the var= command) to set commands that would be ran when any player with access to the var command would join. These commands would run as that user, including with any permissions held.
>
> The impact of this vulnerability depends on your game and the type of commands you have. Imagine a game with a give_players_money command only accessible to administrators, but the var commands locked to moderators. A rogue moderator could set the initialisation script to give_players_money * 1000000 giving all players six figures of money whenever an administrator joins.

Security advisory: https://github.com/evaera/Cmdr/security/advisories/GHSA-4vh6-p9hm-qwrr