### PR TITLE
Users/quenty/updates

### DIFF
--- a/src/animations/src/Shared/AnimationPromiseUtils.lua
+++ b/src/animations/src/Shared/AnimationPromiseUtils.lua
@@ -9,7 +9,7 @@ local PromiseMaidUtils = require("PromiseMaidUtils")
 
 local AnimationPromiseUtils = {}
 
-function AnimationPromiseUtils.promiseFinished(animationTrack)
+function AnimationPromiseUtils.promiseFinished(animationTrack, endMarkerName)
 	local promise = Promise.new()
 
 	PromiseMaidUtils.whilePromise(promise, function(maid)
@@ -24,6 +24,12 @@ function AnimationPromiseUtils.promiseFinished(animationTrack)
 		maid:GiveTask(animationTrack.Destroying:Connect(function()
 			promise:Resolve()
 		end))
+
+		if endMarkerName then
+			maid:GiveTask(animationTrack:GetMarkerReachedSignal(endMarkerName):Connect(function()
+				promise:Resolve()
+			end))
+		end
 	end)
 
 	return promise

--- a/src/camera/src/Client/Effects/OverrideDefaultCameraToo.lua
+++ b/src/camera/src/Client/Effects/OverrideDefaultCameraToo.lua
@@ -16,6 +16,7 @@
 local require = require(script.Parent.loader).load(script)
 
 local SummedCamera = require("SummedCamera")
+local Vector3Utils = require("Vector3Utils")
 
 local OverrideDefaultCameraToo = {}
 OverrideDefaultCameraToo.ClassName = "OverrideDefaultCameraToo"
@@ -55,7 +56,12 @@ function OverrideDefaultCameraToo:__index(index)
 
 		local predicate = self.Predicate
 		if not predicate or predicate(result) then
-			self.DefaultCamera:SetRobloxCFrame(result.CFrame)
+			local angle = math.abs(Vector3Utils.angleBetweenVectors(result.CFrame:VectorToWorldSpace(Vector3.new(0, 0, -1)), Vector3.new(0, 1, 0)))
+
+			-- If the camera is straight up and down then Roblox breaks
+			if angle >= math.rad(0.1) and angle <= math.rad(179.9) then
+				self.DefaultCamera:SetRobloxCFrame(result.CFrame)
+			end
 		end
 
 		return result

--- a/src/promise/src/Shared/PromiseUtils.lua
+++ b/src/promise/src/Shared/PromiseUtils.lua
@@ -32,6 +32,12 @@ function PromiseUtils.any(promises)
 	return returnPromise
 end
 
+function PromiseUtils.delayed(seconds)
+	return Promise.spawn(function(resolve, _reject)
+		task.delay(seconds, resolve)
+	end)
+end
+
 --[=[
 	Executes all promises. If any fails, the result will be rejected. However, it yields until
 	every promise is complete.

--- a/src/rogue-properties/src/Shared/Modifiers/Multiplier/RogueMultiplierProvider.lua
+++ b/src/rogue-properties/src/Shared/Modifiers/Multiplier/RogueMultiplierProvider.lua
@@ -8,11 +8,12 @@ local RunService = game:GetService("RunService")
 
 local Rx = require("Rx")
 local RxBinderUtils = require("RxBinderUtils")
-local RxBrioUtils = require("RxBrioUtils")
 local RogueBindersShared = require("RogueBindersShared")
 local BinderUtils = require("BinderUtils")
 local RoguePropertyModifierUtils = require("RoguePropertyModifierUtils")
 local RoguePropertyService = require("RoguePropertyService")
+local Observable = require("Observable")
+local Maid = require("Maid")
 
 local RogueMultiplierProvider = {}
 RogueMultiplierProvider.ServiceName = "RogueMultiplierProvider"
@@ -83,17 +84,37 @@ end
 
 function RogueMultiplierProvider:ObserveModifiedVersion(propObj, rogueProperty, observeBaseValue)
 	if rogueProperty:GetDefinition():GetValueType() == "number" then
-		return RxBrioUtils.flatCombineLatest({
-			value = observeBaseValue;
-			multiplier = self:_observeMultipliersBrio(propObj):Pipe({
-				RxBrioUtils.flatMapBrio(function(item)
-					return item:ObserveMultiplier();
-				end); -- this gets us a list of multipliers which should mutate pretty frequently.
-				Rx.defaultsToNil;
-			});
-		}):Pipe({
-			Rx.map(function(state)
-				return self:GetModifiedVersion(propObj, rogueProperty, state.value)
+		return Observable.new(function(sub)
+			local topMaid = Maid.new()
+
+			topMaid:GiveTask(self:_observeMultipliersBrio(propObj):Subscribe(function(brio)
+				if brio:IsDead() then
+					return
+				end
+
+				local maid = brio:ToMaid()
+				local value = brio:GetValue()
+
+				maid:GiveTask(value:ObserveMultiplier():Subscribe(function()
+					sub:Fire()
+				end))
+
+				sub:Fire()
+
+				maid:GiveTask(function()
+					sub:Fire()
+				end)
+			end))
+
+			topMaid:GiveTask(observeBaseValue:Subscribe(function()
+				sub:Fire()
+			end))
+
+			return topMaid
+		end):Pipe({
+			Rx.throttleDefer();
+			Rx.map(function()
+				return self:GetModifiedVersion(propObj, rogueProperty, propObj.Value)
 			end);
 		})
 	else


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/actionmanager@7.20.0-canary.400.ddaf408.0
  npm install @quenty/adorneeboundingbox@1.5.0-canary.400.ddaf408.0
  npm install @quenty/adorneevalue@4.25.0-canary.400.ddaf408.0
  npm install @quenty/animationprovider@7.8.0-canary.400.ddaf408.0
  npm install @quenty/animations@1.2.0-canary.400.ddaf408.0
  npm install @quenty/assetserviceutils@1.5.0-canary.400.ddaf408.0
  npm install @quenty/attributeutils@8.19.0-canary.400.ddaf408.0
  npm install @quenty/avatareditorutils@1.18.0-canary.400.ddaf408.0
  npm install @quenty/badgeutils@6.7.0-canary.400.ddaf408.0
  npm install @quenty/basicpane@7.18.0-canary.400.ddaf408.0
  npm install @quenty/binder@8.23.0-canary.400.ddaf408.0
  npm install @quenty/bindtocloseservice@2.17.0-canary.400.ddaf408.0
  npm install @quenty/blend@6.25.0-canary.400.ddaf408.0
  npm install @quenty/bodycolorsutils@1.15.0-canary.400.ddaf408.0
  npm install @quenty/boundlinkutils@8.23.0-canary.400.ddaf408.0
  npm install @quenty/brio@8.16.0-canary.400.ddaf408.0
  npm install @quenty/buttonhighlightmodel@8.13.0-canary.400.ddaf408.0
  npm install @quenty/camera@9.19.0-canary.400.ddaf408.0
  npm install @quenty/camerastoryutils@6.9.0-canary.400.ddaf408.0
  npm install @quenty/canceltoken@6.8.0-canary.400.ddaf408.0
  npm install @quenty/characterutils@6.12.0-canary.400.ddaf408.0
  npm install @quenty/chatproviderservice@3.8.0-canary.400.ddaf408.0
  npm install @quenty/clienttranslator@8.28.0-canary.400.ddaf408.0
  npm install @quenty/clipcharacters@6.9.0-canary.400.ddaf408.0
  npm install @quenty/cmdrservice@7.20.0-canary.400.ddaf408.0
  npm install @quenty/collectionserviceutils@2.18.0-canary.400.ddaf408.0
  npm install @quenty/color3utils@5.26.0-canary.400.ddaf408.0
  npm install @quenty/colorpalette@4.30.0-canary.400.ddaf408.0
  npm install @quenty/colorpicker@4.27.0-canary.400.ddaf408.0
  npm install @quenty/conditions@4.25.0-canary.400.ddaf408.0
  npm install @quenty/contentproviderutils@6.16.0-canary.400.ddaf408.0
  npm install @quenty/cooldown@5.28.0-canary.400.ddaf408.0
  npm install @quenty/coreguienabler@6.15.0-canary.400.ddaf408.0
  npm install @quenty/coreguiutils@6.7.0-canary.400.ddaf408.0
  npm install @quenty/datastore@7.22.0-canary.400.ddaf408.0
  npm install @quenty/deathreport@3.26.0-canary.400.ddaf408.0
  npm install @quenty/depthoffield@5.20.0-canary.400.ddaf408.0
  npm install @quenty/equippedtracker@7.20.0-canary.400.ddaf408.0
  npm install @quenty/firstpersoncharactertransparency@8.22.0-canary.400.ddaf408.0
  npm install @quenty/flipbook@2.15.0-canary.400.ddaf408.0
  npm install @quenty/friendutils@6.12.0-canary.400.ddaf408.0
  npm install @quenty/gameconfig@5.35.0-canary.400.ddaf408.0
  npm install @quenty/gameproductservice@7.13.0-canary.400.ddaf408.0
  npm install @quenty/gamescalingutils@7.25.0-canary.400.ddaf408.0
  npm install @quenty/genericscreenguiprovider@7.27.0-canary.400.ddaf408.0
  npm install @quenty/grouputils@6.7.0-canary.400.ddaf408.0
  npm install @quenty/hide@5.25.0-canary.400.ddaf408.0
  npm install @quenty/highlight@3.6.0-canary.400.ddaf408.0
  npm install @quenty/hintscoringutils@9.21.0-canary.400.ddaf408.0
  npm install @quenty/httppromise@6.8.0-canary.400.ddaf408.0
  npm install @quenty/humanoiddescriptionutils@6.8.0-canary.400.ddaf408.0
  npm install @quenty/humanoidspeed@5.30.0-canary.400.ddaf408.0
  npm install @quenty/humanoidtracker@7.20.0-canary.400.ddaf408.0
  npm install @quenty/idleservice@7.32.0-canary.400.ddaf408.0
  npm install @quenty/ik@9.34.0-canary.400.ddaf408.0
  npm install @quenty/influxdbclient@1.14.0-canary.400.ddaf408.0
  npm install @quenty/inputkeymaputils@7.35.0-canary.400.ddaf408.0
  npm install @quenty/inputmode@7.26.0-canary.400.ddaf408.0
  npm install @quenty/insertserviceutils@6.7.0-canary.400.ddaf408.0
  npm install @quenty/instanceutils@7.18.0-canary.400.ddaf408.0
  npm install @quenty/jsonutils@6.7.0-canary.400.ddaf408.0
  npm install @quenty/linkutils@7.18.0-canary.400.ddaf408.0
  npm install @quenty/lipsum@8.29.0-canary.400.ddaf408.0
  npm install @quenty/localizedtextutils@6.19.0-canary.400.ddaf408.0
  npm install @quenty/marketplaceutils@6.8.0-canary.400.ddaf408.0
  npm install @quenty/memorystoreutils@2.7.0-canary.400.ddaf408.0
  npm install @quenty/messagingserviceutils@3.8.0-canary.400.ddaf408.0
  npm install @quenty/motor6d@1.29.0-canary.400.ddaf408.0
  npm install @quenty/mouseshiftlockservice@7.7.0-canary.400.ddaf408.0
  npm install @quenty/multipleclickutils@7.14.0-canary.400.ddaf408.0
  npm install @quenty/observablecollection@5.22.0-canary.400.ddaf408.0
  npm install @quenty/pagesutils@1.8.0-canary.400.ddaf408.0
  npm install @quenty/particleengine@7.11.0-canary.400.ddaf408.0
  npm install @quenty/parttouchingcalculator@8.23.0-canary.400.ddaf408.0
  npm install @quenty/pathfindingutils@6.8.0-canary.400.ddaf408.0
  npm install @quenty/permissionprovider@8.18.0-canary.400.ddaf408.0
  npm install @quenty/playerbinder@8.23.0-canary.400.ddaf408.0
  npm install @quenty/playerhumanoidbinder@8.23.0-canary.400.ddaf408.0
  npm install @quenty/playerinputmode@3.28.0-canary.400.ddaf408.0
  npm install @quenty/playersservicepromises@6.7.0-canary.400.ddaf408.0
  npm install @quenty/playerthumbnailutils@6.7.0-canary.400.ddaf408.0
  npm install @quenty/playerutils@2.18.0-canary.400.ddaf408.0
  npm install @quenty/policyserviceutils@2.7.0-canary.400.ddaf408.0
  npm install @quenty/promise@6.7.0-canary.400.ddaf408.0
  npm install @quenty/promisemaid@1.2.0-canary.400.ddaf408.0
  npm install @quenty/propertyvalue@1.3.0-canary.400.ddaf408.0
  npm install @quenty/qframe@6.10.0-canary.400.ddaf408.0
  npm install @quenty/r15utils@7.19.0-canary.400.ddaf408.0
  npm install @quenty/racketingropeconstraint@6.7.0-canary.400.ddaf408.0
  npm install @quenty/radial-image@3.25.0-canary.400.ddaf408.0
  npm install @quenty/ragdoll@9.32.0-canary.400.ddaf408.0
  npm install @quenty/receiptprocessing@1.5.0-canary.400.ddaf408.0
  npm install @quenty/remotefunctionutils@6.8.0-canary.400.ddaf408.0
  npm install @quenty/remoting@6.9.0-canary.400.ddaf408.0
  npm install @quenty/resetservice@5.11.0-canary.400.ddaf408.0
  npm install @quenty/rigbuilderutils@6.12.0-canary.400.ddaf408.0
  npm install @quenty/roblox-api-dump@4.8.0-canary.400.ddaf408.0
  npm install @quenty/rogue-humanoid@3.30.0-canary.400.ddaf408.0
  npm install @quenty/rogue-properties@4.27.0-canary.400.ddaf408.0
  npm install @quenty/rx@7.14.0-canary.400.ddaf408.0
  npm install @quenty/rxbinderutils@8.24.0-canary.400.ddaf408.0
  npm install @quenty/rxsignal@1.2.0-canary.400.ddaf408.0
  npm install @quenty/scoredactionservice@9.35.0-canary.400.ddaf408.0
  npm install @quenty/screenshothudservice@1.16.0-canary.400.ddaf408.0
  npm install @quenty/seatutils@1.17.0-canary.400.ddaf408.0
  npm install @quenty/secrets@1.15.0-canary.400.ddaf408.0
  npm install @quenty/selectionutils@2.21.0-canary.400.ddaf408.0
  npm install @quenty/settings-inputkeymap@3.38.0-canary.400.ddaf408.0
  npm install @quenty/settings@4.34.0-canary.400.ddaf408.0
  npm install @quenty/socialserviceutils@6.8.0-canary.400.ddaf408.0
  npm install @quenty/softshutdown@3.37.0-canary.400.ddaf408.0
  npm install @quenty/sounds@6.9.0-canary.400.ddaf408.0
  npm install @quenty/spawning@4.28.0-canary.400.ddaf408.0
  npm install @quenty/statestack@8.20.0-canary.400.ddaf408.0
  npm install @quenty/streamingutils@6.8.0-canary.400.ddaf408.0
  npm install @quenty/teamtracker@7.20.0-canary.400.ddaf408.0
  npm install @quenty/teamutils@4.19.0-canary.400.ddaf408.0
  npm install @quenty/teleportserviceutils@3.13.0-canary.400.ddaf408.0
  npm install @quenty/templateprovider@7.8.0-canary.400.ddaf408.0
  npm install @quenty/textfilterservice@7.10.0-canary.400.ddaf408.0
  npm install @quenty/textfilterutils@6.7.0-canary.400.ddaf408.0
  npm install @quenty/textserviceutils@7.27.0-canary.400.ddaf408.0
  npm install @quenty/tie@4.25.0-canary.400.ddaf408.0
  npm install @quenty/timesyncservice@7.12.0-canary.400.ddaf408.0
  npm install @quenty/transitionmodel@1.16.0-canary.400.ddaf408.0
  npm install @quenty/undostack@1.19.0-canary.400.ddaf408.0
  npm install @quenty/userserviceutils@3.9.0-canary.400.ddaf408.0
  npm install @quenty/valuebaseutils@7.18.0-canary.400.ddaf408.0
  npm install @quenty/valueobject@7.20.0-canary.400.ddaf408.0
  npm install @quenty/viewport@5.31.0-canary.400.ddaf408.0
  # or 
  yarn add @quenty/actionmanager@7.20.0-canary.400.ddaf408.0
  yarn add @quenty/adorneeboundingbox@1.5.0-canary.400.ddaf408.0
  yarn add @quenty/adorneevalue@4.25.0-canary.400.ddaf408.0
  yarn add @quenty/animationprovider@7.8.0-canary.400.ddaf408.0
  yarn add @quenty/animations@1.2.0-canary.400.ddaf408.0
  yarn add @quenty/assetserviceutils@1.5.0-canary.400.ddaf408.0
  yarn add @quenty/attributeutils@8.19.0-canary.400.ddaf408.0
  yarn add @quenty/avatareditorutils@1.18.0-canary.400.ddaf408.0
  yarn add @quenty/badgeutils@6.7.0-canary.400.ddaf408.0
  yarn add @quenty/basicpane@7.18.0-canary.400.ddaf408.0
  yarn add @quenty/binder@8.23.0-canary.400.ddaf408.0
  yarn add @quenty/bindtocloseservice@2.17.0-canary.400.ddaf408.0
  yarn add @quenty/blend@6.25.0-canary.400.ddaf408.0
  yarn add @quenty/bodycolorsutils@1.15.0-canary.400.ddaf408.0
  yarn add @quenty/boundlinkutils@8.23.0-canary.400.ddaf408.0
  yarn add @quenty/brio@8.16.0-canary.400.ddaf408.0
  yarn add @quenty/buttonhighlightmodel@8.13.0-canary.400.ddaf408.0
  yarn add @quenty/camera@9.19.0-canary.400.ddaf408.0
  yarn add @quenty/camerastoryutils@6.9.0-canary.400.ddaf408.0
  yarn add @quenty/canceltoken@6.8.0-canary.400.ddaf408.0
  yarn add @quenty/characterutils@6.12.0-canary.400.ddaf408.0
  yarn add @quenty/chatproviderservice@3.8.0-canary.400.ddaf408.0
  yarn add @quenty/clienttranslator@8.28.0-canary.400.ddaf408.0
  yarn add @quenty/clipcharacters@6.9.0-canary.400.ddaf408.0
  yarn add @quenty/cmdrservice@7.20.0-canary.400.ddaf408.0
  yarn add @quenty/collectionserviceutils@2.18.0-canary.400.ddaf408.0
  yarn add @quenty/color3utils@5.26.0-canary.400.ddaf408.0
  yarn add @quenty/colorpalette@4.30.0-canary.400.ddaf408.0
  yarn add @quenty/colorpicker@4.27.0-canary.400.ddaf408.0
  yarn add @quenty/conditions@4.25.0-canary.400.ddaf408.0
  yarn add @quenty/contentproviderutils@6.16.0-canary.400.ddaf408.0
  yarn add @quenty/cooldown@5.28.0-canary.400.ddaf408.0
  yarn add @quenty/coreguienabler@6.15.0-canary.400.ddaf408.0
  yarn add @quenty/coreguiutils@6.7.0-canary.400.ddaf408.0
  yarn add @quenty/datastore@7.22.0-canary.400.ddaf408.0
  yarn add @quenty/deathreport@3.26.0-canary.400.ddaf408.0
  yarn add @quenty/depthoffield@5.20.0-canary.400.ddaf408.0
  yarn add @quenty/equippedtracker@7.20.0-canary.400.ddaf408.0
  yarn add @quenty/firstpersoncharactertransparency@8.22.0-canary.400.ddaf408.0
  yarn add @quenty/flipbook@2.15.0-canary.400.ddaf408.0
  yarn add @quenty/friendutils@6.12.0-canary.400.ddaf408.0
  yarn add @quenty/gameconfig@5.35.0-canary.400.ddaf408.0
  yarn add @quenty/gameproductservice@7.13.0-canary.400.ddaf408.0
  yarn add @quenty/gamescalingutils@7.25.0-canary.400.ddaf408.0
  yarn add @quenty/genericscreenguiprovider@7.27.0-canary.400.ddaf408.0
  yarn add @quenty/grouputils@6.7.0-canary.400.ddaf408.0
  yarn add @quenty/hide@5.25.0-canary.400.ddaf408.0
  yarn add @quenty/highlight@3.6.0-canary.400.ddaf408.0
  yarn add @quenty/hintscoringutils@9.21.0-canary.400.ddaf408.0
  yarn add @quenty/httppromise@6.8.0-canary.400.ddaf408.0
  yarn add @quenty/humanoiddescriptionutils@6.8.0-canary.400.ddaf408.0
  yarn add @quenty/humanoidspeed@5.30.0-canary.400.ddaf408.0
  yarn add @quenty/humanoidtracker@7.20.0-canary.400.ddaf408.0
  yarn add @quenty/idleservice@7.32.0-canary.400.ddaf408.0
  yarn add @quenty/ik@9.34.0-canary.400.ddaf408.0
  yarn add @quenty/influxdbclient@1.14.0-canary.400.ddaf408.0
  yarn add @quenty/inputkeymaputils@7.35.0-canary.400.ddaf408.0
  yarn add @quenty/inputmode@7.26.0-canary.400.ddaf408.0
  yarn add @quenty/insertserviceutils@6.7.0-canary.400.ddaf408.0
  yarn add @quenty/instanceutils@7.18.0-canary.400.ddaf408.0
  yarn add @quenty/jsonutils@6.7.0-canary.400.ddaf408.0
  yarn add @quenty/linkutils@7.18.0-canary.400.ddaf408.0
  yarn add @quenty/lipsum@8.29.0-canary.400.ddaf408.0
  yarn add @quenty/localizedtextutils@6.19.0-canary.400.ddaf408.0
  yarn add @quenty/marketplaceutils@6.8.0-canary.400.ddaf408.0
  yarn add @quenty/memorystoreutils@2.7.0-canary.400.ddaf408.0
  yarn add @quenty/messagingserviceutils@3.8.0-canary.400.ddaf408.0
  yarn add @quenty/motor6d@1.29.0-canary.400.ddaf408.0
  yarn add @quenty/mouseshiftlockservice@7.7.0-canary.400.ddaf408.0
  yarn add @quenty/multipleclickutils@7.14.0-canary.400.ddaf408.0
  yarn add @quenty/observablecollection@5.22.0-canary.400.ddaf408.0
  yarn add @quenty/pagesutils@1.8.0-canary.400.ddaf408.0
  yarn add @quenty/particleengine@7.11.0-canary.400.ddaf408.0
  yarn add @quenty/parttouchingcalculator@8.23.0-canary.400.ddaf408.0
  yarn add @quenty/pathfindingutils@6.8.0-canary.400.ddaf408.0
  yarn add @quenty/permissionprovider@8.18.0-canary.400.ddaf408.0
  yarn add @quenty/playerbinder@8.23.0-canary.400.ddaf408.0
  yarn add @quenty/playerhumanoidbinder@8.23.0-canary.400.ddaf408.0
  yarn add @quenty/playerinputmode@3.28.0-canary.400.ddaf408.0
  yarn add @quenty/playersservicepromises@6.7.0-canary.400.ddaf408.0
  yarn add @quenty/playerthumbnailutils@6.7.0-canary.400.ddaf408.0
  yarn add @quenty/playerutils@2.18.0-canary.400.ddaf408.0
  yarn add @quenty/policyserviceutils@2.7.0-canary.400.ddaf408.0
  yarn add @quenty/promise@6.7.0-canary.400.ddaf408.0
  yarn add @quenty/promisemaid@1.2.0-canary.400.ddaf408.0
  yarn add @quenty/propertyvalue@1.3.0-canary.400.ddaf408.0
  yarn add @quenty/qframe@6.10.0-canary.400.ddaf408.0
  yarn add @quenty/r15utils@7.19.0-canary.400.ddaf408.0
  yarn add @quenty/racketingropeconstraint@6.7.0-canary.400.ddaf408.0
  yarn add @quenty/radial-image@3.25.0-canary.400.ddaf408.0
  yarn add @quenty/ragdoll@9.32.0-canary.400.ddaf408.0
  yarn add @quenty/receiptprocessing@1.5.0-canary.400.ddaf408.0
  yarn add @quenty/remotefunctionutils@6.8.0-canary.400.ddaf408.0
  yarn add @quenty/remoting@6.9.0-canary.400.ddaf408.0
  yarn add @quenty/resetservice@5.11.0-canary.400.ddaf408.0
  yarn add @quenty/rigbuilderutils@6.12.0-canary.400.ddaf408.0
  yarn add @quenty/roblox-api-dump@4.8.0-canary.400.ddaf408.0
  yarn add @quenty/rogue-humanoid@3.30.0-canary.400.ddaf408.0
  yarn add @quenty/rogue-properties@4.27.0-canary.400.ddaf408.0
  yarn add @quenty/rx@7.14.0-canary.400.ddaf408.0
  yarn add @quenty/rxbinderutils@8.24.0-canary.400.ddaf408.0
  yarn add @quenty/rxsignal@1.2.0-canary.400.ddaf408.0
  yarn add @quenty/scoredactionservice@9.35.0-canary.400.ddaf408.0
  yarn add @quenty/screenshothudservice@1.16.0-canary.400.ddaf408.0
  yarn add @quenty/seatutils@1.17.0-canary.400.ddaf408.0
  yarn add @quenty/secrets@1.15.0-canary.400.ddaf408.0
  yarn add @quenty/selectionutils@2.21.0-canary.400.ddaf408.0
  yarn add @quenty/settings-inputkeymap@3.38.0-canary.400.ddaf408.0
  yarn add @quenty/settings@4.34.0-canary.400.ddaf408.0
  yarn add @quenty/socialserviceutils@6.8.0-canary.400.ddaf408.0
  yarn add @quenty/softshutdown@3.37.0-canary.400.ddaf408.0
  yarn add @quenty/sounds@6.9.0-canary.400.ddaf408.0
  yarn add @quenty/spawning@4.28.0-canary.400.ddaf408.0
  yarn add @quenty/statestack@8.20.0-canary.400.ddaf408.0
  yarn add @quenty/streamingutils@6.8.0-canary.400.ddaf408.0
  yarn add @quenty/teamtracker@7.20.0-canary.400.ddaf408.0
  yarn add @quenty/teamutils@4.19.0-canary.400.ddaf408.0
  yarn add @quenty/teleportserviceutils@3.13.0-canary.400.ddaf408.0
  yarn add @quenty/templateprovider@7.8.0-canary.400.ddaf408.0
  yarn add @quenty/textfilterservice@7.10.0-canary.400.ddaf408.0
  yarn add @quenty/textfilterutils@6.7.0-canary.400.ddaf408.0
  yarn add @quenty/textserviceutils@7.27.0-canary.400.ddaf408.0
  yarn add @quenty/tie@4.25.0-canary.400.ddaf408.0
  yarn add @quenty/timesyncservice@7.12.0-canary.400.ddaf408.0
  yarn add @quenty/transitionmodel@1.16.0-canary.400.ddaf408.0
  yarn add @quenty/undostack@1.19.0-canary.400.ddaf408.0
  yarn add @quenty/userserviceutils@3.9.0-canary.400.ddaf408.0
  yarn add @quenty/valuebaseutils@7.18.0-canary.400.ddaf408.0
  yarn add @quenty/valueobject@7.20.0-canary.400.ddaf408.0
  yarn add @quenty/viewport@5.31.0-canary.400.ddaf408.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
