### PR TITLE
Fix `DataStoreStringUtils.isValidUTF8` not detecting invalid strings

### DIFF
--- a/src/datastore/src/Shared/Utility/DataStoreStringUtils.lua
+++ b/src/datastore/src/Shared/Utility/DataStoreStringUtils.lua
@@ -17,8 +17,8 @@ function DataStoreStringUtils.isValidUTF8(str)
 		return false, "Not a string"
 	end
 
-	-- https://gist.github.com/TheGreatSageEqualToHeaven/e0e1dc2698307c93f6013b9825705899?permalink_comment_id=4334757#gistcomment-4334757
-	if utf8.len(str) == nil then
+	-- https://gist.github.com/TheGreatSageEqualToHeaven/e0e1dc2698307c93f6013b9825705899#patch-1
+	if string.match(input, "[^\0-\127]") then
 		return false, "Invalid string"
 	end
 


### PR DESCRIPTION
[Example 2.b](https://gist.github.com/TheGreatSageEqualToHeaven/e0e1dc2698307c93f6013b9825705899#example-2b)