### PR TITLE
fix: Fix actual code for data store match

### DIFF
--- a/src/datastore/src/Shared/Utility/DataStoreStringUtils.lua
+++ b/src/datastore/src/Shared/Utility/DataStoreStringUtils.lua
@@ -17,8 +17,12 @@ function DataStoreStringUtils.isValidUTF8(str)
 		return false, "Not a string"
 	end
 
+	if not utf8.len(str) then
+		return false, "Invalid string"
+	end
+
 	-- https://gist.github.com/TheGreatSageEqualToHeaven/e0e1dc2698307c93f6013b9825705899#patch-1
-	if string.match(input, "[^\0-\127]") then
+	if string.match(str, "[^\0-\127]") then
 		return false, "Invalid string"
 	end
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/datastore@7.25.1-canary.409.ed39424.0
  npm install @quenty/secrets@1.18.1-canary.409.ed39424.0
  npm install @quenty/settings-inputkeymap@3.41.1-canary.409.ed39424.0
  npm install @quenty/settings@4.37.1-canary.409.ed39424.0
  npm install @quenty/softshutdown@3.40.1-canary.409.ed39424.0
  # or 
  yarn add @quenty/datastore@7.25.1-canary.409.ed39424.0
  yarn add @quenty/secrets@1.18.1-canary.409.ed39424.0
  yarn add @quenty/settings-inputkeymap@3.41.1-canary.409.ed39424.0
  yarn add @quenty/settings@4.37.1-canary.409.ed39424.0
  yarn add @quenty/softshutdown@3.40.1-canary.409.ed39424.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
