### PR TITLE
fix: Fix datastore writer copying non-table scenario

### DIFF
--- a/src/datastore/src/Server/Modules/DataStoreWriter.lua
+++ b/src/datastore/src/Server/Modules/DataStoreWriter.lua
@@ -252,7 +252,7 @@ function DataStoreWriter:_writeMergeWriters(original)
 
 	-- Handle empty table scenario..
 	-- This would also imply our original is nil somehow...
-	if next(copy) == nil then
+	if type(copy) == "table" and next(copy) == nil then
 		if type(self._saveDataSnapshot) ~= "table" then
 			return nil
 		end


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/datastore@7.26.1-canary.413.3303b36.0
  npm install @quenty/secrets@1.20.1-canary.413.3303b36.0
  npm install @quenty/settings-inputkeymap@3.43.1-canary.413.3303b36.0
  npm install @quenty/settings@4.39.1-canary.413.3303b36.0
  npm install @quenty/softshutdown@3.41.1-canary.413.3303b36.0
  # or 
  yarn add @quenty/datastore@7.26.1-canary.413.3303b36.0
  yarn add @quenty/secrets@1.20.1-canary.413.3303b36.0
  yarn add @quenty/settings-inputkeymap@3.43.1-canary.413.3303b36.0
  yarn add @quenty/settings@4.39.1-canary.413.3303b36.0
  yarn add @quenty/softshutdown@3.41.1-canary.413.3303b36.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
