### PR TITLE
fix: Fix retrieving key set from datastore

### DIFF
--- a/src/datastore/src/Server/Modules/DataStoreStage.lua
+++ b/src/datastore/src/Server/Modules/DataStoreStage.lua
@@ -378,7 +378,11 @@ end
 ]=]
 function DataStoreStage:PromiseKeySet()
 	return self:PromiseViewUpToDate():Then(function()
-		return Set.fromKeys(self._viewSnapshot)
+		if type(self._viewSnapshot) == "table" then
+			return Set.fromKeys(self._viewSnapshot)
+		else
+			return {}
+		end
 	end)
 end
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/datastore@8.0.1-canary.420.2ec98e4.0
  npm install @quenty/secrets@2.0.2-canary.420.2ec98e4.0
  npm install @quenty/settings-inputkeymap@4.2.1-canary.420.2ec98e4.0
  npm install @quenty/settings@5.1.1-canary.420.2ec98e4.0
  npm install @quenty/softshutdown@4.0.1-canary.420.2ec98e4.0
  # or 
  yarn add @quenty/datastore@8.0.1-canary.420.2ec98e4.0
  yarn add @quenty/secrets@2.0.2-canary.420.2ec98e4.0
  yarn add @quenty/settings-inputkeymap@4.2.1-canary.420.2ec98e4.0
  yarn add @quenty/settings@5.1.1-canary.420.2ec98e4.0
  yarn add @quenty/softshutdown@4.0.1-canary.420.2ec98e4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
