### PR TITLE
fix: Fix value removal function in ObservableMapList

### DIFF
--- a/src/observablecollection/src/Shared/ObservableMapList.lua
+++ b/src/observablecollection/src/Shared/ObservableMapList.lua
@@ -265,8 +265,8 @@ function ObservableMapList:_removeFromList(key, entry)
 		return
 	end
 
-	if list:Contains(entry) then
-		list:Remove(entry)
+	if list:Get(entry) ~= nil then
+		list:RemoveFirst(entry)
 
 		if list:GetCount() == 0 then
 			self:_removeList(key)


### PR DESCRIPTION
Just noticed that the methods called in here don't actually exist in ObservableList at the moment. I probably would have included this in the pull request I made earlier if I had caught this then.