### PR TITLE
fix: Don't update ButtonHighlightModel held count post-destruction

### DIFF
--- a/src/buttonhighlightmodel/src/Client/ButtonHighlightModel.lua
+++ b/src/buttonhighlightmodel/src/Client/ButtonHighlightModel.lua
@@ -394,9 +394,11 @@ function ButtonHighlightModel:_trackTouch(inputObject)
 	local maid = Maid.new()
 	self._maid[inputObject] = nil
 
-	self._numFingerDown.Value = self._numFingerDown.Value + 1
+	self._numFingerDown.Value += 1
 	maid:GiveTask(function()
-		self._numFingerDown.Value = self._numFingerDown.Value - 1
+		if self.Destroy then
+			self._numFingerDown.Value -= 1
+		end
 	end)
 	maid:GiveTask(inputObject:GetPropertyChangedSignal("UserInputState"):Connect(function()
 		if inputObject.UserInputState == Enum.UserInputState.End then

--- a/src/buttonhighlightmodel/src/Client/ButtonHighlightModel.lua
+++ b/src/buttonhighlightmodel/src/Client/ButtonHighlightModel.lua
@@ -396,7 +396,7 @@ function ButtonHighlightModel:_trackTouch(inputObject)
 
 	self._numFingerDown.Value += 1
 	maid:GiveTask(function()
-		if self.Destroy then
+		if self._numFingerDown.Value then
 			self._numFingerDown.Value -= 1
 		end
 	end)


### PR DESCRIPTION
Fixes holding down a button as it's destroyed throwing `ButtonHighlightModel:399: attempt to perform arithmetic (sub) on nil and number`. Destruction order is temperamental, sometimes the `_numFingerDown` ValueObject is destroyed before the callback runs.