### PR TITLE
fix: Singleton uses rawget/rawset to query stuff

### DIFF
--- a/src/singleton/src/Shared/Singleton.lua
+++ b/src/singleton/src/Shared/Singleton.lua
@@ -27,9 +27,9 @@ function Singleton:Init(serviceBag)
 	local object = self._constructor(serviceBag)
 	assert(type(object) == "table", "Bad object")
 
-	object.ServiceName = self.ServiceName
+	rawset(object, "ServiceName", self.ServiceName)
 
-	if object.Init then
+	if rawget(object, "Init") then
 		object:Init(serviceBag)
 	end
 


### PR DESCRIPTION
This should make it play nicer with things like InputModeTypeSelectors.