### PR TITLE
feat: Add AnimationPromiseUtils.promiseLoaded(animationTrack) and other helper calls

### DIFF
--- a/src/animations/src/Shared/AnimationPromiseUtils.lua
+++ b/src/animations/src/Shared/AnimationPromiseUtils.lua
@@ -4,12 +4,23 @@
 
 local require = require(script.Parent.loader).load(script)
 
+local RunService = game:GetService("RunService")
+
 local Promise = require("Promise")
 local PromiseMaidUtils = require("PromiseMaidUtils")
 
 local AnimationPromiseUtils = {}
 
+--[=[
+	Promises that the track is finished
+
+	@param animationTrack AnimationTrack
+	@param endMarkerName string | nil
+	@return Promise
+]=]
 function AnimationPromiseUtils.promiseFinished(animationTrack, endMarkerName)
+	assert(typeof(animationTrack) == "Instance", "Bad animationTrack")
+	assert(type(endMarkerName) == "string" or endMarkerName == nil, "Bad endMarkerName")
 	local promise = Promise.new()
 
 	PromiseMaidUtils.whilePromise(promise, function(maid)
@@ -34,5 +45,84 @@ function AnimationPromiseUtils.promiseFinished(animationTrack, endMarkerName)
 
 	return promise
 end
+
+--[=[
+	Promises that the track has been loaded
+
+	@param animationTrack AnimationTrack
+	@return Promise
+]=]
+function AnimationPromiseUtils.promiseLoaded(animationTrack)
+	assert(typeof(animationTrack) == "Instance", "Bad animationTrack")
+
+	if animationTrack.Length > 0 then
+		return Promise.resolved()
+	end
+
+	local promise = Promise.new()
+
+	PromiseMaidUtils.whilePromise(promise, function(maid)
+		maid:GiveTask(animationTrack:GetPropertyChangedSignal("Length"):Connect(function()
+			if animationTrack.Length > 0 then
+				promise:Resolve()
+			end
+		end))
+
+		maid:GiveTask(RunService.Stepped:Connect(function()
+			if animationTrack.Length > 0 then
+				promise:Resolve()
+			end
+		end))
+
+		maid:GiveTask(animationTrack.Ended:Connect(function()
+			promise:Resolve()
+		end))
+
+		maid:GiveTask(animationTrack.Stopped:Connect(function()
+			promise:Resolve()
+		end))
+
+		maid:GiveTask(animationTrack.Destroying:Connect(function()
+			promise:Resolve()
+		end))
+	end)
+
+	return promise
+end
+
+--[=[
+	Promises that the track reached a keyframe or is finished
+
+	@param animationTrack AnimationTrack
+	@param keyframeName string
+	@return Promise
+]=]
+function AnimationPromiseUtils.promiseKeyframeReached(animationTrack, keyframeName)
+	assert(typeof(animationTrack) == "Instance", "Bad animationTrack")
+	assert(type(keyframeName) == "string", "Bad endMarkerName")
+
+	local promise = Promise.new()
+
+	PromiseMaidUtils.whilePromise(promise, function(maid)
+		maid:GiveTask(animationTrack.Ended:Connect(function()
+			promise:Resolve()
+		end))
+
+		maid:GiveTask(animationTrack.Stopped:Connect(function()
+			promise:Resolve()
+		end))
+
+		maid:GiveTask(animationTrack.Destroying:Connect(function()
+			promise:Resolve()
+		end))
+
+		maid:GiveTask(animationTrack:GetMarkerReachedSignal(keyframeName):Connect(function()
+			promise:Resolve()
+		end))
+	end)
+
+	return promise
+end
+
 
 return AnimationPromiseUtils

--- a/src/animations/src/Shared/AnimationTrackPlayer.lua
+++ b/src/animations/src/Shared/AnimationTrackPlayer.lua
@@ -17,20 +17,12 @@ AnimationTrackPlayer.__index = AnimationTrackPlayer
 function AnimationTrackPlayer.new(animationTarget, animationId)
 	local self = setmetatable(BaseObject.new(), AnimationTrackPlayer)
 
-	self._animationTarget = ValueObject.new(nil)
-	self._maid:GiveTask(self._animationTarget)
+	self._animationTarget = self._maid:Add(ValueObject.new(nil))
+	self._trackId = self._maid:Add(ValueObject.new(nil))
+	self._currentTrack = self._maid:Add(ValueObject.new(nil))
+	self._animationPriority = self._maid:Add(ValueObject.new(nil))
 
-	self._trackId = ValueObject.new(nil)
-	self._maid:GiveTask(self._trackId)
-
-	self._currentTrack = ValueObject.new(nil)
-	self._maid:GiveTask(self._currentTrack)
-
-	self.KeyframeReached = Signal.new()
-	self._maid:GiveTask(self.KeyframeReached)
-
-	self._animationPriority = ValueObject.new(nil)
-	self._maid:GiveTask(self._animationPriority)
+	self.KeyframeReached = self._maid:Add(Signal.new())
 
 	if animationTarget then
 		self:SetAnimationTarget(animationTarget)


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/actionmanager@12.1.0-canary.447.5f743bf.0
  npm install @quenty/adorneeboundingbox@7.1.0-canary.447.5f743bf.0
  npm install @quenty/adorneedata@6.1.0-canary.447.5f743bf.0
  npm install @quenty/adorneevalue@9.1.0-canary.447.5f743bf.0
  npm install @quenty/animationgroup@9.1.0-canary.447.5f743bf.0
  npm install @quenty/animationprovider@10.1.0-canary.447.5f743bf.0
  npm install @quenty/animations@6.1.0-canary.447.5f743bf.0
  npm install @quenty/applytagtotaggedchildren@9.1.0-canary.447.5f743bf.0
  npm install @quenty/assetserviceutils@4.1.0-canary.447.5f743bf.0
  npm install @quenty/attributeutils@13.1.0-canary.447.5f743bf.0
  npm install @quenty/avatareditorutils@6.1.0-canary.447.5f743bf.0
  npm install @quenty/badgeutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/baseobject@9.1.0-canary.447.5f743bf.0
  npm install @quenty/basicpane@12.1.0-canary.447.5f743bf.0
  npm install @quenty/binder@13.1.0-canary.447.5f743bf.0
  npm install @quenty/bindtocloseservice@7.1.0-canary.447.5f743bf.0
  npm install @quenty/blend@11.1.0-canary.447.5f743bf.0
  npm install @quenty/bodycolorsutils@6.1.0-canary.447.5f743bf.0
  npm install @quenty/boundlinkutils@13.1.0-canary.447.5f743bf.0
  npm install @quenty/brio@13.1.0-canary.447.5f743bf.0
  npm install @quenty/buttonhighlightmodel@13.1.0-canary.447.5f743bf.0
  npm install @quenty/camera@13.1.0-canary.447.5f743bf.0
  npm install @quenty/camerastoryutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/canceltoken@10.1.0-canary.447.5f743bf.0
  npm install @quenty/characterutils@11.1.0-canary.447.5f743bf.0
  npm install @quenty/chatproviderservice@8.1.0-canary.447.5f743bf.0
  npm install @quenty/clienttranslator@13.1.0-canary.447.5f743bf.0
  npm install @quenty/clipcharacters@11.1.0-canary.447.5f743bf.0
  npm install @quenty/cmdrservice@12.1.0-canary.447.5f743bf.0
  npm install @quenty/collectionserviceutils@7.1.0-canary.447.5f743bf.0
  npm install @quenty/color3utils@10.1.0-canary.447.5f743bf.0
  npm install @quenty/colorpalette@9.1.0-canary.447.5f743bf.0
  npm install @quenty/colorpicker@9.1.0-canary.447.5f743bf.0
  npm install @quenty/colorsequenceutils@6.1.0-canary.447.5f743bf.0
  npm install @quenty/conditions@9.1.0-canary.447.5f743bf.0
  npm install @quenty/contentproviderutils@11.1.0-canary.447.5f743bf.0
  npm install @quenty/convexhull@3.1.0-canary.447.5f743bf.0
  npm install @quenty/cooldown@10.1.0-canary.447.5f743bf.0
  npm install @quenty/coreguienabler@11.1.0-canary.447.5f743bf.0
  npm install @quenty/coreguiutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/countdowntext@3.1.0-canary.447.5f743bf.0
  npm install @quenty/counter@6.1.0-canary.447.5f743bf.0
  npm install @quenty/cubicspline@9.1.0-canary.447.5f743bf.0
  npm install @quenty/datastore@12.1.0-canary.447.5f743bf.0
  npm install @quenty/deathreport@9.1.0-canary.447.5f743bf.0
  npm install @quenty/depthoffield@10.1.0-canary.447.5f743bf.0
  npm install @quenty/draw@6.1.0-canary.447.5f743bf.0
  npm install @quenty/ducktype@4.1.0-canary.447.5f743bf.0
  npm install @quenty/elo@6.1.0-canary.447.5f743bf.0
  npm install @quenty/enabledmixin@10.1.0-canary.447.5f743bf.0
  npm install @quenty/equippedtracker@12.1.0-canary.447.5f743bf.0
  npm install @quenty/fakeskybox@10.1.0-canary.447.5f743bf.0
  npm install @quenty/firstpersoncharactertransparency@13.1.0-canary.447.5f743bf.0
  npm install @quenty/flipbook@8.1.0-canary.447.5f743bf.0
  npm install @quenty/friendutils@11.1.0-canary.447.5f743bf.0
  npm install @quenty/fzy@4.1.0-canary.447.5f743bf.0
  npm install @quenty/gameconfig@11.1.0-canary.447.5f743bf.0
  npm install @quenty/gameproductservice@13.1.0-canary.447.5f743bf.0
  npm install @quenty/gamescalingutils@12.1.0-canary.447.5f743bf.0
  npm install @quenty/generatewithmixin@10.1.0-canary.447.5f743bf.0
  npm install @quenty/genericscreenguiprovider@12.1.0-canary.447.5f743bf.0
  npm install @quenty/geometryutils@5.1.0-canary.447.5f743bf.0
  npm install @quenty/getgroundplane@9.1.0-canary.447.5f743bf.0
  npm install @quenty/getpercentexposedutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/grouputils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/guivisiblemanager@11.1.0-canary.447.5f743bf.0
  npm install @quenty/hide@10.1.0-canary.447.5f743bf.0
  npm install @quenty/highlight@9.1.0-canary.447.5f743bf.0
  npm install @quenty/hintscoringutils@13.1.0-canary.447.5f743bf.0
  npm install @quenty/httppromise@9.1.0-canary.447.5f743bf.0
  npm install @quenty/humanoiddescriptionutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/humanoidmovedirectionutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/humanoidspeed@10.1.0-canary.447.5f743bf.0
  npm install @quenty/humanoidteleportutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/humanoidtracker@12.1.0-canary.447.5f743bf.0
  npm install @quenty/idleservice@12.1.0-canary.447.5f743bf.0
  npm install @quenty/ik@14.1.0-canary.447.5f743bf.0
  npm install @quenty/influxdbclient@6.1.0-canary.447.5f743bf.0
  npm install @quenty/inputkeymaputils@13.1.0-canary.447.5f743bf.0
  npm install @quenty/inputmode@12.1.0-canary.447.5f743bf.0
  npm install @quenty/insertserviceutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/instanceutils@12.1.0-canary.447.5f743bf.0
  npm install @quenty/jsonutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/linkutils@12.1.0-canary.447.5f743bf.0
  npm install @quenty/lipsum@13.1.0-canary.447.5f743bf.0
  npm install @quenty/loader@9.1.0-canary.447.5f743bf.0
  npm install @quenty/localizedtextutils@11.1.0-canary.447.5f743bf.0
  npm install @quenty/marketplaceutils@10.1.0-canary.447.5f743bf.0
  npm install @quenty/memorystoreutils@5.1.0-canary.447.5f743bf.0
  npm install @quenty/messagingserviceutils@6.1.0-canary.447.5f743bf.0
  npm install @quenty/modelappearance@9.1.0-canary.447.5f743bf.0
  npm install @quenty/modeltransparencyeffect@10.1.0-canary.447.5f743bf.0
  npm install @quenty/motor6d@6.1.0-canary.447.5f743bf.0
  npm install @quenty/mouseovermixin@9.1.0-canary.447.5f743bf.0
  npm install @quenty/mouseshiftlockservice@10.1.0-canary.447.5f743bf.0
  npm install @quenty/multipleclickutils@12.1.0-canary.447.5f743bf.0
  npm install @quenty/networkropeutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/nocollisionconstraintutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/numbersequenceutils@7.1.0-canary.447.5f743bf.0
  npm install @quenty/observablecollection@11.1.0-canary.447.5f743bf.0
  npm install @quenty/octree@9.1.0-canary.447.5f743bf.0
  npm install @quenty/optional@10.1.0-canary.447.5f743bf.0
  npm install @quenty/overriddenproperty@9.1.0-canary.447.5f743bf.0
  npm install @quenty/pagesutils@4.1.0-canary.447.5f743bf.0
  npm install @quenty/particleengine@12.1.0-canary.447.5f743bf.0
  npm install @quenty/particles@4.1.0-canary.447.5f743bf.0
  npm install @quenty/parttouchingcalculator@13.1.0-canary.447.5f743bf.0
  npm install @quenty/pathfindingutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/performanceutils@3.1.0-canary.447.5f743bf.0
  npm install @quenty/permissionprovider@13.1.0-canary.447.5f743bf.0
  npm install @quenty/physicsutils@7.1.0-canary.447.5f743bf.0
  npm install @quenty/pillbacking@9.1.0-canary.447.5f743bf.0
  npm install @quenty/playerbinder@13.1.0-canary.447.5f743bf.0
  npm install @quenty/playerhumanoidbinder@13.1.0-canary.447.5f743bf.0
  npm install @quenty/playerinputmode@8.1.0-canary.447.5f743bf.0
  npm install @quenty/playersservicepromises@9.1.0-canary.447.5f743bf.0
  npm install @quenty/playerthumbnailutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/playerutils@7.1.0-canary.447.5f743bf.0
  npm install @quenty/policyserviceutils@5.1.0-canary.447.5f743bf.0
  npm install @quenty/promise@9.1.0-canary.447.5f743bf.0
  npm install @quenty/promisemaid@4.1.0-canary.447.5f743bf.0
  npm install @quenty/propertyvalue@6.1.0-canary.447.5f743bf.0
  npm install @quenty/qframe@9.1.0-canary.447.5f743bf.0
  npm install @quenty/r15utils@12.1.0-canary.447.5f743bf.0
  npm install @quenty/racketingropeconstraint@11.1.0-canary.447.5f743bf.0
  npm install @quenty/radial-image@8.1.0-canary.447.5f743bf.0
  npm install @quenty/ragdoll@14.1.0-canary.447.5f743bf.0
  npm install @quenty/randomutils@5.1.0-canary.447.5f743bf.0
  npm install @quenty/rbxasset@4.1.0-canary.447.5f743bf.0
  npm install @quenty/rbxthumb@4.1.0-canary.447.5f743bf.0
  npm install @quenty/receiptprocessing@6.1.0-canary.447.5f743bf.0
  npm install @quenty/region3int16utils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/region3utils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/remotefunctionutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/remoting@11.1.0-canary.447.5f743bf.0
  npm install @quenty/resetservice@10.1.0-canary.447.5f743bf.0
  npm install @quenty/rigbuilderutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/roblox-api-dump@7.1.0-canary.447.5f743bf.0
  npm install @quenty/rodux-actions@8.1.0-canary.447.5f743bf.0
  npm install @quenty/rodux-undo@7.1.0-canary.447.5f743bf.0
  npm install @quenty/rogue-humanoid@8.1.0-canary.447.5f743bf.0
  npm install @quenty/rogue-properties@9.1.0-canary.447.5f743bf.0
  npm install @quenty/rotatinglabel@10.1.0-canary.447.5f743bf.0
  npm install @quenty/rx@12.1.0-canary.447.5f743bf.0
  npm install @quenty/rxbinderutils@13.1.0-canary.447.5f743bf.0
  npm install @quenty/rxsignal@6.1.0-canary.447.5f743bf.0
  npm install @quenty/scoredactionservice@15.1.0-canary.447.5f743bf.0
  npm install @quenty/screenshothudservice@6.1.0-canary.447.5f743bf.0
  npm install @quenty/scrollingframe@11.1.0-canary.447.5f743bf.0
  npm install @quenty/seatutils@6.1.0-canary.447.5f743bf.0
  npm install @quenty/secrets@6.1.0-canary.447.5f743bf.0
  npm install @quenty/selectionimageutils@10.1.0-canary.447.5f743bf.0
  npm install @quenty/selectionutils@7.1.0-canary.447.5f743bf.0
  npm install @quenty/servicebag@10.1.0-canary.447.5f743bf.0
  npm install @quenty/setmechanismcframe@9.1.0-canary.447.5f743bf.0
  npm install @quenty/settings@10.1.0-canary.447.5f743bf.0
  npm install @quenty/settings-inputkeymap@9.1.0-canary.447.5f743bf.0
  npm install @quenty/signal@6.1.0-canary.447.5f743bf.0
  npm install @quenty/singleton@5.1.0-canary.447.5f743bf.0
  npm install @quenty/snackbar@10.1.0-canary.447.5f743bf.0
  npm install @quenty/socialserviceutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/softshutdown@8.1.0-canary.447.5f743bf.0
  npm install @quenty/soundplayer@6.1.0-canary.447.5f743bf.0
  npm install @quenty/sounds@9.1.0-canary.447.5f743bf.0
  npm install @quenty/spawning@9.1.0-canary.447.5f743bf.0
  npm install @quenty/spring@9.1.0-canary.447.5f743bf.0
  npm install @quenty/sprites@12.1.0-canary.447.5f743bf.0
  npm install @quenty/statestack@13.1.0-canary.447.5f743bf.0
  npm install @quenty/streamingutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/teamtracker@12.1.0-canary.447.5f743bf.0
  npm install @quenty/teamutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/teleportserviceutils@8.1.0-canary.447.5f743bf.0
  npm install @quenty/templateprovider@10.1.0-canary.447.5f743bf.0
  npm install @quenty/terrainutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/textboxutils@6.1.0-canary.447.5f743bf.0
  npm install @quenty/textfilterservice@12.1.0-canary.447.5f743bf.0
  npm install @quenty/textfilterutils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/textserviceutils@12.1.0-canary.447.5f743bf.0
  npm install @quenty/throttle@9.1.0-canary.447.5f743bf.0
  npm install @quenty/tie@9.1.0-canary.447.5f743bf.0
  npm install @quenty/timedtween@6.1.0-canary.447.5f743bf.0
  npm install @quenty/timesyncservice@12.1.0-canary.447.5f743bf.0
  npm install @quenty/transitionmodel@6.1.0-canary.447.5f743bf.0
  npm install @quenty/transparencyservice@10.1.0-canary.447.5f743bf.0
  npm install @quenty/uiobjectutils@5.1.0-canary.447.5f743bf.0
  npm install @quenty/undostack@6.1.0-canary.447.5f743bf.0
  npm install @quenty/userserviceutils@8.1.0-canary.447.5f743bf.0
  npm install @quenty/valuebaseutils@12.1.0-canary.447.5f743bf.0
  npm install @quenty/valueobject@12.1.0-canary.447.5f743bf.0
  npm install @quenty/vector3utils@9.1.0-canary.447.5f743bf.0
  npm install @quenty/viewport@10.1.0-canary.447.5f743bf.0
  npm install @quenty/voicechat@4.1.0-canary.447.5f743bf.0
  # or 
  yarn add @quenty/actionmanager@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/adorneeboundingbox@7.1.0-canary.447.5f743bf.0
  yarn add @quenty/adorneedata@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/adorneevalue@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/animationgroup@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/animationprovider@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/animations@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/applytagtotaggedchildren@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/assetserviceutils@4.1.0-canary.447.5f743bf.0
  yarn add @quenty/attributeutils@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/avatareditorutils@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/badgeutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/baseobject@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/basicpane@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/binder@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/bindtocloseservice@7.1.0-canary.447.5f743bf.0
  yarn add @quenty/blend@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/bodycolorsutils@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/boundlinkutils@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/brio@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/buttonhighlightmodel@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/camera@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/camerastoryutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/canceltoken@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/characterutils@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/chatproviderservice@8.1.0-canary.447.5f743bf.0
  yarn add @quenty/clienttranslator@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/clipcharacters@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/cmdrservice@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/collectionserviceutils@7.1.0-canary.447.5f743bf.0
  yarn add @quenty/color3utils@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/colorpalette@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/colorpicker@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/colorsequenceutils@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/conditions@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/contentproviderutils@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/convexhull@3.1.0-canary.447.5f743bf.0
  yarn add @quenty/cooldown@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/coreguienabler@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/coreguiutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/countdowntext@3.1.0-canary.447.5f743bf.0
  yarn add @quenty/counter@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/cubicspline@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/datastore@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/deathreport@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/depthoffield@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/draw@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/ducktype@4.1.0-canary.447.5f743bf.0
  yarn add @quenty/elo@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/enabledmixin@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/equippedtracker@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/fakeskybox@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/firstpersoncharactertransparency@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/flipbook@8.1.0-canary.447.5f743bf.0
  yarn add @quenty/friendutils@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/fzy@4.1.0-canary.447.5f743bf.0
  yarn add @quenty/gameconfig@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/gameproductservice@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/gamescalingutils@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/generatewithmixin@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/genericscreenguiprovider@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/geometryutils@5.1.0-canary.447.5f743bf.0
  yarn add @quenty/getgroundplane@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/getpercentexposedutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/grouputils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/guivisiblemanager@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/hide@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/highlight@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/hintscoringutils@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/httppromise@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/humanoiddescriptionutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/humanoidmovedirectionutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/humanoidspeed@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/humanoidteleportutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/humanoidtracker@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/idleservice@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/ik@14.1.0-canary.447.5f743bf.0
  yarn add @quenty/influxdbclient@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/inputkeymaputils@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/inputmode@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/insertserviceutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/instanceutils@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/jsonutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/linkutils@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/lipsum@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/loader@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/localizedtextutils@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/marketplaceutils@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/memorystoreutils@5.1.0-canary.447.5f743bf.0
  yarn add @quenty/messagingserviceutils@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/modelappearance@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/modeltransparencyeffect@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/motor6d@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/mouseovermixin@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/mouseshiftlockservice@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/multipleclickutils@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/networkropeutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/nocollisionconstraintutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/numbersequenceutils@7.1.0-canary.447.5f743bf.0
  yarn add @quenty/observablecollection@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/octree@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/optional@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/overriddenproperty@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/pagesutils@4.1.0-canary.447.5f743bf.0
  yarn add @quenty/particleengine@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/particles@4.1.0-canary.447.5f743bf.0
  yarn add @quenty/parttouchingcalculator@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/pathfindingutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/performanceutils@3.1.0-canary.447.5f743bf.0
  yarn add @quenty/permissionprovider@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/physicsutils@7.1.0-canary.447.5f743bf.0
  yarn add @quenty/pillbacking@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/playerbinder@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/playerhumanoidbinder@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/playerinputmode@8.1.0-canary.447.5f743bf.0
  yarn add @quenty/playersservicepromises@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/playerthumbnailutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/playerutils@7.1.0-canary.447.5f743bf.0
  yarn add @quenty/policyserviceutils@5.1.0-canary.447.5f743bf.0
  yarn add @quenty/promise@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/promisemaid@4.1.0-canary.447.5f743bf.0
  yarn add @quenty/propertyvalue@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/qframe@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/r15utils@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/racketingropeconstraint@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/radial-image@8.1.0-canary.447.5f743bf.0
  yarn add @quenty/ragdoll@14.1.0-canary.447.5f743bf.0
  yarn add @quenty/randomutils@5.1.0-canary.447.5f743bf.0
  yarn add @quenty/rbxasset@4.1.0-canary.447.5f743bf.0
  yarn add @quenty/rbxthumb@4.1.0-canary.447.5f743bf.0
  yarn add @quenty/receiptprocessing@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/region3int16utils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/region3utils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/remotefunctionutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/remoting@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/resetservice@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/rigbuilderutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/roblox-api-dump@7.1.0-canary.447.5f743bf.0
  yarn add @quenty/rodux-actions@8.1.0-canary.447.5f743bf.0
  yarn add @quenty/rodux-undo@7.1.0-canary.447.5f743bf.0
  yarn add @quenty/rogue-humanoid@8.1.0-canary.447.5f743bf.0
  yarn add @quenty/rogue-properties@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/rotatinglabel@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/rx@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/rxbinderutils@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/rxsignal@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/scoredactionservice@15.1.0-canary.447.5f743bf.0
  yarn add @quenty/screenshothudservice@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/scrollingframe@11.1.0-canary.447.5f743bf.0
  yarn add @quenty/seatutils@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/secrets@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/selectionimageutils@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/selectionutils@7.1.0-canary.447.5f743bf.0
  yarn add @quenty/servicebag@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/setmechanismcframe@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/settings@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/settings-inputkeymap@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/signal@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/singleton@5.1.0-canary.447.5f743bf.0
  yarn add @quenty/snackbar@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/socialserviceutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/softshutdown@8.1.0-canary.447.5f743bf.0
  yarn add @quenty/soundplayer@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/sounds@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/spawning@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/spring@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/sprites@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/statestack@13.1.0-canary.447.5f743bf.0
  yarn add @quenty/streamingutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/teamtracker@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/teamutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/teleportserviceutils@8.1.0-canary.447.5f743bf.0
  yarn add @quenty/templateprovider@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/terrainutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/textboxutils@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/textfilterservice@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/textfilterutils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/textserviceutils@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/throttle@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/tie@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/timedtween@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/timesyncservice@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/transitionmodel@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/transparencyservice@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/uiobjectutils@5.1.0-canary.447.5f743bf.0
  yarn add @quenty/undostack@6.1.0-canary.447.5f743bf.0
  yarn add @quenty/userserviceutils@8.1.0-canary.447.5f743bf.0
  yarn add @quenty/valuebaseutils@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/valueobject@12.1.0-canary.447.5f743bf.0
  yarn add @quenty/vector3utils@9.1.0-canary.447.5f743bf.0
  yarn add @quenty/viewport@10.1.0-canary.447.5f743bf.0
  yarn add @quenty/voicechat@4.1.0-canary.447.5f743bf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
