### PR TITLE
fix: Fix rogue properties 

### DIFF
--- a/src/humanoidspeed/src/Server/HumanoidSpeed.lua
+++ b/src/humanoidspeed/src/Server/HumanoidSpeed.lua
@@ -9,7 +9,7 @@ local require = require(script.Parent.loader).load(script)
 
 local BaseObject = require("BaseObject")
 local RogueHumanoidProperties = require("RogueHumanoidProperties")
-local Binder = require("Binder")
+local PlayerHumanoidBinder = require("PlayerHumanoidBinder")
 
 local HumanoidSpeed = setmetatable({}, BaseObject)
 HumanoidSpeed.ClassName = "HumanoidSpeed"
@@ -61,4 +61,4 @@ function HumanoidSpeed:ApplySpeedAdditive(amount)
 	return self._properties.WalkSpeed:CreateAdditive(amount)
 end
 
-return Binder.new("HumanoidSpeed", HumanoidSpeed)
+return PlayerHumanoidBinder.new("HumanoidSpeed", HumanoidSpeed)

--- a/src/rogue-humanoid/src/Shared/RogueHumanoidBase.lua
+++ b/src/rogue-humanoid/src/Shared/RogueHumanoidBase.lua
@@ -46,13 +46,12 @@ function RogueHumanoidBase.new(humanoid, serviceBag)
 		end))
 	end
 
-	self._scaleState = ValueObject.fromObservable(Rx.combineLatest({
+	self._scaleState = self._maid:Add(ValueObject.fromObservable(Rx.combineLatest({
 		scale = self._properties.Scale:Observe();
 		maxSize = self._properties.ScaleMax:Observe();
 		minSize = self._properties.ScaleMin:Observe();
-	}))
+	})))
 
-	self._maid:GiveTask(self._scaleState)
 	self._maid:GiveTask(self._scaleState:Observe():Subscribe(function(state)
 		if state then
 			self:_updateScale(state)
@@ -90,7 +89,7 @@ function RogueHumanoidBase:_updateScale(state)
 	for _, name in pairs(GROWTH_VALUE_NAMES) do
 		local numberValue = self._obj:FindFirstChild(name)
 		if not numberValue then
-			return
+			continue
 		end
 
 		self:_updateScaleValue(numberValue, state)

--- a/src/rogue-properties/src/Shared/Implementation/RogueProperty.lua
+++ b/src/rogue-properties/src/Shared/Implementation/RogueProperty.lua
@@ -211,8 +211,8 @@ function RogueProperty:Observe()
 				current = Rx.of(self._definition:GetDefaultValue())
 			end
 
-			for _, item in pairs(self._roguePropertyService:GetProviders()) do
-				current = item:ObserveModifiedVersion(baseValue, self, current)
+			for _, provider in pairs(self._roguePropertyService:GetProviders()) do
+				current = provider:ObserveModifiedVersion(baseValue, self, current)
 			end
 
 			return current

--- a/src/rogue-properties/src/Shared/Modifiers/Additive/RogueAdditiveProvider.lua
+++ b/src/rogue-properties/src/Shared/Modifiers/Additive/RogueAdditiveProvider.lua
@@ -13,6 +13,7 @@ local RoguePropertyModifierUtils = require("RoguePropertyModifierUtils")
 local RoguePropertyService = require("RoguePropertyService")
 local Observable = require("Observable")
 local Maid = require("Maid")
+local ValueObject = require("ValueObject")
 
 local RogueAdditiveProvider = {}
 RogueAdditiveProvider.ServiceName = "RogueAdditiveProvider"
@@ -86,6 +87,12 @@ function RogueAdditiveProvider:ObserveModifiedVersion(propObj, rogueProperty, ob
 		return Observable.new(function(sub)
 			local topMaid = Maid.new()
 
+			local lastValue = topMaid:Add(ValueObject.fromObservable(observeBaseValue))
+
+			local function update()
+				sub:Fire(lastValue.Value)
+			end
+
 			topMaid:GiveTask(self:_observeAddersBrio(propObj):Subscribe(function(brio)
 				if brio:IsDead() then
 					return
@@ -95,25 +102,25 @@ function RogueAdditiveProvider:ObserveModifiedVersion(propObj, rogueProperty, ob
 				local value = brio:GetValue()
 
 				maid:GiveTask(value:ObserveAdditive():Subscribe(function()
-					sub:Fire()
+					update()
 				end))
 
-				sub:Fire()
+				update()
 
 				maid:GiveTask(function()
-					sub:Fire()
+					update()
 				end)
 			end))
 
 			topMaid:GiveTask(observeBaseValue:Subscribe(function()
-				sub:Fire()
+				update()
 			end))
 
 			return topMaid
 		end):Pipe({
 			Rx.throttleDefer();
-			Rx.map(function()
-				return self:GetModifiedVersion(propObj, rogueProperty, propObj.Value)
+			Rx.map(function(baseValue)
+				return self:GetModifiedVersion(propObj, rogueProperty, baseValue)
 			end);
 		})
 	else


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/humanoidspeed@11.0.1-canary.451.ee93033.0
  npm install @quenty/rogue-humanoid@9.0.1-canary.451.ee93033.0
  npm install @quenty/rogue-properties@10.0.1-canary.451.ee93033.0
  # or 
  yarn add @quenty/humanoidspeed@11.0.1-canary.451.ee93033.0
  yarn add @quenty/rogue-humanoid@9.0.1-canary.451.ee93033.0
  yarn add @quenty/rogue-properties@10.0.1-canary.451.ee93033.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
