### PR TITLE
feat: custom key for private server datastore

### DIFF
--- a/src/datastore/src/Server/PrivateServerDataStoreService.lua
+++ b/src/datastore/src/Server/PrivateServerDataStoreService.lua
@@ -33,6 +33,10 @@ function PrivateServerDataStoreService:PromiseDataStore()
 			local dataStore = DataStore.new(robloxDataStore, self:_getKey())
 			self._maid:GiveTask(dataStore)
 
+			if game.PrivateServerOwnerId ~= 0 then
+				dataStore:Store("LastPrivateServerOwnerId", game.PrivateServerOwnerId)
+			end
+
 			self._maid:GiveTask(self._bindToCloseService:RegisterPromiseOnCloseCallback(function()
 				return dataStore:Save()
 			end))
@@ -41,6 +45,12 @@ function PrivateServerDataStoreService:PromiseDataStore()
 		end)
 
 	return self._dataStorePromise
+end
+
+function PrivateServerDataStoreService:SetCustomKey(customKey)
+	assert(self._dataStorePromise == nil, "[PrivateServerDataStoreService] - Already got datastore, cannot set custom key")
+
+	self._customKey = customKey
 end
 
 function PrivateServerDataStoreService:_promiseRobloxDataStore()
@@ -55,6 +65,9 @@ function PrivateServerDataStoreService:_promiseRobloxDataStore()
 end
 
 function PrivateServerDataStoreService:_getKey()
+	if self._customKey then
+		return self._customKey
+	end
 	if game.PrivateServerId ~= "" then
 		return game.PrivateServerId
 	else


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/chatproviderservice@9.2.0-canary.455.45dc12d.0
  npm install @quenty/datastore@13.2.0-canary.455.45dc12d.0
  npm install @quenty/secrets@7.2.0-canary.455.45dc12d.0
  npm install @quenty/settings@11.2.0-canary.455.45dc12d.0
  npm install @quenty/settings-inputkeymap@10.2.0-canary.455.45dc12d.0
  npm install @quenty/softshutdown@9.2.0-canary.455.45dc12d.0
  # or 
  yarn add @quenty/chatproviderservice@9.2.0-canary.455.45dc12d.0
  yarn add @quenty/datastore@13.2.0-canary.455.45dc12d.0
  yarn add @quenty/secrets@7.2.0-canary.455.45dc12d.0
  yarn add @quenty/settings@11.2.0-canary.455.45dc12d.0
  yarn add @quenty/settings-inputkeymap@10.2.0-canary.455.45dc12d.0
  yarn add @quenty/softshutdown@9.2.0-canary.455.45dc12d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
