### PR TITLE
fix: RandomUtils.weightedChoice when chances array starts with 0(s)

### DIFF
--- a/src/randomutils/src/Shared/RandomUtils.lua
+++ b/src/randomutils/src/Shared/RandomUtils.lua
@@ -145,6 +145,9 @@ function RandomUtils.weightedChoice(list, weights, random)
 		local totalSum = 0
 
 		for i=1, #list do
+			if weights[i] == 0 then
+				continue
+			end
 			totalSum = totalSum + weights[i]
 			local threshold = totalSum/total
 			if randomNum <= threshold then


### PR DESCRIPTION
If the passed chances array starts with a zero, the first element will be be picked if `math.random() == 0`, as the function returns [0,1). An element with a weight of zero should never be picked.