### PR TITLE
fix: Add missing ObservePercentTarget methods

### DIFF
--- a/src/buttonhighlightmodel/src/Client/ButtonHighlightModel.lua
+++ b/src/buttonhighlightmodel/src/Client/ButtonHighlightModel.lua
@@ -229,6 +229,19 @@ function ButtonHighlightModel:ObservePercentPressed(acceleration)
 end
 
 --[=[
+	Observes target for how pressed the button is
+	@return Observable<number>
+]=]
+function ButtonHighlightModel:ObservePercentPressedTarget()
+	return self._isPressed:Observe()
+		:Pipe({
+			Rx.map(function(value)
+				return value and 1 or 0
+			end);
+		})
+end
+
+--[=[
 	Returns true if highlighted
 
 	@return boolean
@@ -334,6 +347,19 @@ end
 ]=]
 function ButtonHighlightModel:ObserveIsChoosen()
 	return self._isChoosen:Observe()
+end
+
+--[=[
+	Observes target for if the button is selected or not
+	@return Observable<number>
+]=]
+function ButtonHighlightModel:ObservePercentChoosenTarget()
+	return self._isChoosen:Observe()
+		:Pipe({
+			Rx.map(function(value)
+				return value and 1 or 0
+			end);
+		})
 end
 
 --[=[


### PR DESCRIPTION
ButtonHighlightModel has a method for observing the highlighted target `:ObservePercentHighlightedTarget()` but not one for observing the pressed, or selected targets.