### PR TITLE
fix: Using integer keys in w/ Observe methods in ObservableMap

### DIFF
--- a/src/observablecollection/src/Shared/ObservableMap.lua
+++ b/src/observablecollection/src/Shared/ObservableMap.lua
@@ -122,15 +122,16 @@ function ObservableMap:_observeKeyValueChanged(packValue)
 			handleValue(key, value)
 		end
 
-		maid:GiveTask(self.KeyValueChanged:Connect(handleValue))
+		local conn = self.KeyValueChanged:Connect(handleValue)
 
-		self._maid[sub] = maid
-		maid:GiveTask(function()
+		local function cleanup()
 			self._maid[sub] = nil
+			conn:Disconnect()
 			sub:Complete()
-		end)
-
-		return maid
+			maid:Destroy()
+		end
+		self._maid[sub] = cleanup
+		return cleanup
 	end)
 end
 


### PR DESCRIPTION
The maid is given some cleanup w/ `:GiveTask`, so they get given keys `1` and `2` internally. The value brios are also put into this maid, so if you did `map:Set(1, ...)` you'd break everything observing the container.