### PR TITLE
feat: Add slotIds for priority1 and priority2 buttons

### DIFF
--- a/src/inputkeymaputils/src/Shared/Types/SlottedTouchButtonUtils.lua
+++ b/src/inputkeymaputils/src/Shared/Types/SlottedTouchButtonUtils.lua
@@ -36,7 +36,9 @@ local SlottedTouchButtonUtils = {}
 	@return SlottedTouchButton
 ]=]
 function SlottedTouchButtonUtils.createSlottedTouchButton(slotId)
-	assert(slotId == "primary1"
+	assert(slotId == "priority1"
+		or slotId == "priority2"
+		or slotId == "primary1"
 		or slotId == "primary2"
 		or slotId == "primary3"
 		or slotId == "primary4"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/inputkeymaputils@14.6.0-canary.473.55c4529.0
  npm install @quenty/scoredactionservice@16.7.0-canary.473.55c4529.0
  npm install @quenty/settings-inputkeymap@10.8.0-canary.473.55c4529.0
  # or 
  yarn add @quenty/inputkeymaputils@14.6.0-canary.473.55c4529.0
  yarn add @quenty/scoredactionservice@16.7.0-canary.473.55c4529.0
  yarn add @quenty/settings-inputkeymap@10.8.0-canary.473.55c4529.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
