### PR TITLE
fix: Rename priority1 & priority2 -> primary4 & primary5

### DIFF
--- a/src/inputkeymaputils/src/Shared/Types/SlottedTouchButtonUtils.lua
+++ b/src/inputkeymaputils/src/Shared/Types/SlottedTouchButtonUtils.lua
@@ -36,12 +36,11 @@ local SlottedTouchButtonUtils = {}
 	@return SlottedTouchButton
 ]=]
 function SlottedTouchButtonUtils.createSlottedTouchButton(slotId)
-	assert(slotId == "priority1"
-		or slotId == "priority2"
-		or slotId == "primary1"
+	assert(slotId == "primary1"
 		or slotId == "primary2"
 		or slotId == "primary3"
 		or slotId == "primary4"
+		or slotId == "primary5"
 		or slotId == "inner1"
 		or slotId == "inner2"
 		or slotId == "jumpbutton"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/inputkeymaputils@14.5.1-canary.474.daf1700.0
  npm install @quenty/scoredactionservice@16.6.1-canary.474.daf1700.0
  npm install @quenty/settings-inputkeymap@10.7.1-canary.474.daf1700.0
  # or 
  yarn add @quenty/inputkeymaputils@14.5.1-canary.474.daf1700.0
  yarn add @quenty/scoredactionservice@16.6.1-canary.474.daf1700.0
  yarn add @quenty/settings-inputkeymap@10.7.1-canary.474.daf1700.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
