### PR TITLE
fix: CameraControls destruction in Enabled state

### DIFF
--- a/src/camera/src/Client/Controls/CameraControls.lua
+++ b/src/camera/src/Client/Controls/CameraControls.lua
@@ -345,9 +345,8 @@ function CameraControls:_handleGamepadRotateStart()
 end
 
 function CameraControls:Destroy()
-	self._gamepadRotateModel:Destroy()
-
 	self:Disable()
+	self._gamepadRotateModel:Destroy()
 	setmetatable(self, nil)
 end
 


### PR DESCRIPTION
Unbinding a CAS action emits `Enum.UserInputType.None`. This breaks destruction in the enabled state.