### PR TITLE
refactor: StateStack perf, typecheck bugfix

### DIFF
--- a/src/statestack/package.json
+++ b/src/statestack/package.json
@@ -25,7 +25,6 @@
     "Quenty"
   ],
   "dependencies": {
-    "@quenty/baseobject": "file:../baseobject",
     "@quenty/brio": "file:../brio",
     "@quenty/loader": "file:../loader",
     "@quenty/maid": "file:../maid",


### PR DESCRIPTION
Performance improvements.
And, fixes a bug where pushing an invalid value into the `StateStack` fatally corrupts it (read comment).
```lua
local stack = StateStack.new("a", "string")
local clean = stack:PushState("b")
task.defer(stack.PushState, stack, 1)
task.defer(function()
	-- '1' was added to the internal stack.
	-- Cleaning pulls it back up, setting .Value =, throwing inline!
	clean()
	print("New value", stack:GetState())
end)
```