### PR TITLE
Loader: Remove Studio check, Move Modules to ReplicatedFirst

### DIFF
--- a/src/loader/src/init.lua
+++ b/src/loader/src/init.lua
@@ -5,7 +5,6 @@
 ]=]
 
 local ReplicatedFirst = game:GetService("ReplicatedFirst")
-local RunService = game:GetService("RunService")
 
 local DependencyUtils = require(script.Dependencies.DependencyUtils)
 local LoaderLinkCreator = require(script.LoaderLink.LoaderLinkCreator)


### PR DESCRIPTION
The Studio check is not only unneeded but it also doesnt simulate live server states which isnt the point of play testing regardless of performance.

I decided to move the modules to ReplicatedFirst because ReplicatedStorage and ReplicatedFirst have nearly the same functionality where I would even say that ReplicatedFirst is more benefitial than ReplicatedStorage. I also think ReplicatedStorage is supposed to be used like this, just think like ReplicatedStorage being ServerStorage and ReplicatedFirst being ServerScriptService, it is simply much more logical and it also removes the issue of scripts that run in ReplicatedFirst having to wait for the loader to be replicated to the Client.