### PR TITLE
fix: Fix Blend converter plugin erroring

### DIFF
--- a/plugins/ui-converter-plugin/src/modules/Server/UIConverter.lua
+++ b/plugins/ui-converter-plugin/src/modules/Server/UIConverter.lua
@@ -123,7 +123,9 @@ function UIConverter:PromisePropertiesForClass(className)
 						or property:IsWriteNotAccessibleSecurity()
 						or property:IsReadNotAccessibleSecurity()
 						or property:IsWriteLocalUserSecurity()
-						or property:IsReadLocalUserSecurity())
+						or property:IsReadLocalUserSecurity()
+						or property:IsWriteRobloxScriptSecurity()
+						or property:IsReadRobloxScriptSecurity())
 					then
 
 					table.insert(valid, property)

--- a/plugins/ui-converter-plugin/src/modules/Server/UIConverterUtils.lua
+++ b/plugins/ui-converter-plugin/src/modules/Server/UIConverterUtils.lua
@@ -24,7 +24,10 @@ local function roundNumber(value)
 	elseif value == -math.huge then
 		return "-math.huge"
 	else
-		return string.format("%0.6f", value):gsub("%.?0+$", "")
+		local formatted = string.format("%0.6f", value)
+		local stripped = formatted:gsub("%.?0+$", "")
+
+		return stripped
 	end
 end
 

--- a/src/roblox-api-dump/src/Server/RobloxApiMember.lua
+++ b/src/roblox-api-dump/src/Server/RobloxApiMember.lua
@@ -137,6 +137,22 @@ function RobloxApiMember:IsReadLocalUserSecurity()
 end
 
 --[=[
+	Returns whether this member has read RobloxScriptSecurity
+	@return boolean
+]=]
+function RobloxApiMember:IsReadRobloxScriptSecurity()
+	return self:GetReadSecurity() == "RobloxScriptSecurity"
+end
+
+--[=[
+	Returns whether this member has write RobloxScriptSecurity
+	@return boolean
+]=]
+function RobloxApiMember:IsWriteRobloxScriptSecurity()
+	return self:GetWriteSecurity() == "RobloxScriptSecurity"
+end
+
+--[=[
 	Returns whether this can serialize save
 	@return boolean?
 ]=]


### PR DESCRIPTION
There were new properties "Capabilities" and "Sandboxed" that were recently added to the `Instance` class, so this change adds a method to `RobloxApiMember.lua` in the `roblox-api-dump` package, which lets us check the permission for these properties. This will fix the plugin erroring when you attempt to convert instances.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/roblox-api-dump@8.3.1-canary.485.6fcadf5.0
  # or 
  yarn add @quenty/roblox-api-dump@8.3.1-canary.485.6fcadf5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
