### PR TITLE
fix: No matching version found for @quentystudios/t@^3.0.1 while installing @quenty/snackbar

### DIFF
--- a/src/snackbar/package.json
+++ b/src/snackbar/package.json
@@ -48,7 +48,7 @@
     "@quenty/transitionmodel": "file:../transitionmodel",
     "@quenty/utf8": "file:../utf8",
     "@quenty/valueobject": "file:../valueobject",
-    "@quentystudios/t": "^3.0.1"
+    "@quentystudios/t": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Set dependency version for @quentystudios/t to ^3.0.0 in src/snackbar/package.json. This fixes the following error while installing @quenty/snackbar:
`npm ERR! code ETARGET
npm ERR! notarget No matching version found for @quentystudios/t@^3.0.1.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.`