### PR TITLE
Update .editorconfig keys from game template

### DIFF
--- a/tools/nevermore-cli/templates/game-template/.editorconfig
+++ b/tools/nevermore-cli/templates/game-template/.editorconfig
@@ -10,5 +10,5 @@ insert_final_newline = false
 indent_style = tab
 
 [*.{json,yml}]
-indent_style = spaces
-indent_width = 2
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This PR corrects a couple of typos in the `.editorconfig` file of the game template.

### Explained changes
According to the [EditorConfig spec](https://spec.editorconfig.org/index.html#supported-pairs):

- The key `indent_width` should be `indent_size`
- The value of `indent_style`, previously set to `spaces` (plural), should be `space` (singular).