### PR TITLE
fix: Fix plugin template to fix Rojo build issues

### DIFF
--- a/tools/nevermore-cli/templates/plugin-template/default.project.json
+++ b/tools/nevermore-cli/templates/plugin-template/default.project.json
@@ -2,15 +2,10 @@
   "name": "{{pluginNameProper}}",
   "globIgnorePaths": [ "**/.package-lock.json" ],
   "tree": {
-    "$className": "DataModel",
-    "ServerScriptService": {
-      "{{pluginNameProper}}": {
-        "$path": "src",
-        "node_modules": {
-          "$className": "Folder",
-          "$path": "node_modules"
-        }
-      }
+    "$path": "src",
+    "node_modules": {
+      "$className": "Folder",
+      "$path": "node_modules"
     }
   }
 }


### PR DESCRIPTION
With the `default.project.json` included by `nevermore init-plugin`, Rojo cannot properly build the plugin. In its current state, the resulting plugin file will be missing the code. These changes should fix that.