### PR TITLE
fix: Spring object initializes properly

### DIFF
--- a/aftman.toml
+++ b/aftman.toml
@@ -5,7 +5,7 @@
 [tools]
 rojo = "quenty/rojo@7.4.3-quenty-npm-canary.2"
 run-in-roblox = "rojo-rbx/run-in-roblox@0.3.0"
-selene = "Kampfkarren/selene@0.26.1"
+selene = "Kampfkarren/selene@0.27.1"
 moonwave-extractor = "UpliftGames/moonwave@1.1.2"
 mantle = "blake-mealey/mantle@0.10.7"
 remodel = "rojo-rbx/remodel@0.9.1"

--- a/games/integration/aftman.toml
+++ b/games/integration/aftman.toml
@@ -2,4 +2,4 @@
 # For more information, see https://github.com/LPGhatguy/aftman
 [tools]
 rojo = "quenty/rojo@7.4.3-quenty-npm-canary.2"
-selene = "Kampfkarren/selene@0.26.1"
+selene = "Kampfkarren/selene@0.27.1"

--- a/src/servicebag/src/Shared/ServiceBag.lua
+++ b/src/servicebag/src/Shared/ServiceBag.lua
@@ -100,7 +100,9 @@ function ServiceBag:GetService(serviceType)
 		serviceType = require(serviceType)
 	end
 
-	assert(type(serviceType) == "table", "Bad serviceType definition")
+	if type(serviceType) ~= "table" then
+		error(string.format("Bad serviceType definition of type %s of type %s", tostring(serviceType), typeof(serviceType)))
+	end
 
 	local service = self._services[serviceType]
 	if service then

--- a/src/uiobjectutils/src/Client/GuiInteractionUtils.lua
+++ b/src/uiobjectutils/src/Client/GuiInteractionUtils.lua
@@ -19,10 +19,16 @@ local GuiInteractionUtils = {}
 function GuiInteractionUtils.observeInteractionEnabled(gui)
 	assert(typeof(gui) == "Instance" and gui:IsA("GuiObject"), "Bad gui")
 
-	return RxInstanceUtils.observeProperty(gui, "GuiState"):Pipe({
+	return Rx.combineLatest({
+		visible = RxInstanceUtils.observeProperty(gui, "Visible");
+		guiState = RxInstanceUtils.observeProperty(gui, "GuiState");
+		dataModel = RxInstanceUtils.observeFirstAncestorBrio(gui, "DataModel");
+	}):Pipe({
 		Rx.map(function(state)
-			-- Ensure we have interaction enabled (visible, et cetera)
-			return state ~= Enum.GuiState.NonInteractable
+			return state.visible
+				and state.guiState ~= Enum.GuiState.NonInteractable
+				and state.dataModel
+				and true or false
 		end);
 		Rx.distinct();
 	})

--- a/tools/nevermore-cli/templates/game-template/aftman.toml
+++ b/tools/nevermore-cli/templates/game-template/aftman.toml
@@ -2,5 +2,5 @@
 # For more information, see https://github.com/LPGhatguy/aftman
 [tools]
 rojo = "quenty/rojo@7.4.3-quenty-npm-canary.2"
-selene = "Kampfkarren/selene@0.26.1"
+selene = "Kampfkarren/selene@0.27.1"
 moonwave-extractor = "UpliftGames/moonwave@1.1.2"


### PR DESCRIPTION
Before the spring object would initialize with a number in Blend.Spring() if the initial observable emitted late, but speed or some other property changed. Now we delay emission until the first real type is made, so we don't swap types to a number when setting speed.

Querying the spring object will still result in the default number and value.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/adorneeboundingbox@8.5.1-canary.496.cb49bdf.0
  npm install @quenty/adorneevalue@10.5.1-canary.496.cb49bdf.0
  npm install @quenty/blend@12.5.1-canary.496.cb49bdf.0
  npm install @quenty/bodycolorsutils@7.5.1-canary.496.cb49bdf.0
  npm install @quenty/buttonhighlightmodel@14.5.1-canary.496.cb49bdf.0
  npm install @quenty/camera@14.7.1-canary.496.cb49bdf.0
  npm install @quenty/chatproviderservice@9.9.1-canary.496.cb49bdf.0
  npm install @quenty/clienttranslator@14.6.1-canary.496.cb49bdf.0
  npm install @quenty/clipcharacters@12.6.1-canary.496.cb49bdf.0
  npm install @quenty/cmdrservice@13.7.1-canary.496.cb49bdf.0
  npm install @quenty/color3utils@11.5.1-canary.496.cb49bdf.0
  npm install @quenty/colorpalette@10.6.1-canary.496.cb49bdf.0
  npm install @quenty/colorpicker@10.6.1-canary.496.cb49bdf.0
  npm install @quenty/cooldown@11.7.1-canary.496.cb49bdf.0
  npm install @quenty/datastore@13.7.1-canary.496.cb49bdf.0
  npm install @quenty/deathreport@10.7.1-canary.496.cb49bdf.0
  npm install @quenty/depthoffield@11.5.1-canary.496.cb49bdf.0
  npm install @quenty/elo@7.6.1-canary.496.cb49bdf.0
  npm install @quenty/flipbook@9.5.1-canary.496.cb49bdf.0
  npm install @quenty/gameconfig@12.9.1-canary.496.cb49bdf.0
  npm install @quenty/gameproductservice@14.9.1-canary.496.cb49bdf.0
  npm install @quenty/gamescalingutils@13.5.1-canary.496.cb49bdf.0
  npm install @quenty/genericscreenguiprovider@13.7.1-canary.496.cb49bdf.0
  npm install @quenty/hide@11.7.1-canary.496.cb49bdf.0
  npm install @quenty/highlight@10.6.1-canary.496.cb49bdf.0
  npm install @quenty/hintscoringutils@14.7.1-canary.496.cb49bdf.0
  npm install @quenty/humanoidspeed@12.7.1-canary.496.cb49bdf.0
  npm install @quenty/idleservice@13.8.1-canary.496.cb49bdf.0
  npm install @quenty/ik@15.9.1-canary.496.cb49bdf.0
  npm install @quenty/influxdbclient@7.7.1-canary.496.cb49bdf.0
  npm install @quenty/inputkeymaputils@14.8.1-canary.496.cb49bdf.0
  npm install @quenty/inputmode@13.6.1-canary.496.cb49bdf.0
  npm install @quenty/lipsum@14.5.1-canary.496.cb49bdf.0
  npm install @quenty/motor6d@7.7.1-canary.496.cb49bdf.0
  npm install @quenty/observablecollection@12.5.1-canary.496.cb49bdf.0
  npm install @quenty/permissionprovider@14.7.1-canary.496.cb49bdf.0
  npm install @quenty/playerinputmode@9.7.1-canary.496.cb49bdf.0
  npm install @quenty/promptqueue@1.3.1-canary.496.cb49bdf.0
  npm install @quenty/radial-image@9.5.1-canary.496.cb49bdf.0
  npm install @quenty/ragdoll@15.8.1-canary.496.cb49bdf.0
  npm install @quenty/receiptprocessing@7.6.1-canary.496.cb49bdf.0
  npm install @quenty/rogue-humanoid@10.7.1-canary.496.cb49bdf.0
  npm install @quenty/rogue-properties@11.7.1-canary.496.cb49bdf.0
  npm install @quenty/scoredactionservice@16.9.1-canary.496.cb49bdf.0
  npm install @quenty/screenshothudservice@7.6.1-canary.496.cb49bdf.0
  npm install @quenty/secrets@7.8.1-canary.496.cb49bdf.0
  npm install @quenty/servicebag@11.5.1-canary.496.cb49bdf.0
  npm install @quenty/settings@11.8.1-canary.496.cb49bdf.0
  npm install @quenty/settings-inputkeymap@10.10.1-canary.496.cb49bdf.0
  npm install @quenty/snackbar@11.6.1-canary.496.cb49bdf.0
  npm install @quenty/softshutdown@9.8.1-canary.496.cb49bdf.0
  npm install @quenty/soundgroup@1.5.1-canary.496.cb49bdf.0
  npm install @quenty/soundplayer@7.5.1-canary.496.cb49bdf.0
  npm install @quenty/spawning@10.7.1-canary.496.cb49bdf.0
  npm install @quenty/sprites@13.4.1-canary.496.cb49bdf.0
  npm install @quenty/textserviceutils@13.5.1-canary.496.cb49bdf.0
  npm install @quenty/timedtween@7.5.1-canary.496.cb49bdf.0
  npm install @quenty/transitionmodel@7.5.1-canary.496.cb49bdf.0
  npm install @quenty/uiobjectutils@6.4.1-canary.496.cb49bdf.0
  npm install @quenty/userserviceutils@9.6.1-canary.496.cb49bdf.0
  npm install @quenty/viewport@11.8.1-canary.496.cb49bdf.0
  npm install @quenty/nevermore-cli@4.4.1-canary.496.cb49bdf.0
  # or 
  yarn add @quenty/adorneeboundingbox@8.5.1-canary.496.cb49bdf.0
  yarn add @quenty/adorneevalue@10.5.1-canary.496.cb49bdf.0
  yarn add @quenty/blend@12.5.1-canary.496.cb49bdf.0
  yarn add @quenty/bodycolorsutils@7.5.1-canary.496.cb49bdf.0
  yarn add @quenty/buttonhighlightmodel@14.5.1-canary.496.cb49bdf.0
  yarn add @quenty/camera@14.7.1-canary.496.cb49bdf.0
  yarn add @quenty/chatproviderservice@9.9.1-canary.496.cb49bdf.0
  yarn add @quenty/clienttranslator@14.6.1-canary.496.cb49bdf.0
  yarn add @quenty/clipcharacters@12.6.1-canary.496.cb49bdf.0
  yarn add @quenty/cmdrservice@13.7.1-canary.496.cb49bdf.0
  yarn add @quenty/color3utils@11.5.1-canary.496.cb49bdf.0
  yarn add @quenty/colorpalette@10.6.1-canary.496.cb49bdf.0
  yarn add @quenty/colorpicker@10.6.1-canary.496.cb49bdf.0
  yarn add @quenty/cooldown@11.7.1-canary.496.cb49bdf.0
  yarn add @quenty/datastore@13.7.1-canary.496.cb49bdf.0
  yarn add @quenty/deathreport@10.7.1-canary.496.cb49bdf.0
  yarn add @quenty/depthoffield@11.5.1-canary.496.cb49bdf.0
  yarn add @quenty/elo@7.6.1-canary.496.cb49bdf.0
  yarn add @quenty/flipbook@9.5.1-canary.496.cb49bdf.0
  yarn add @quenty/gameconfig@12.9.1-canary.496.cb49bdf.0
  yarn add @quenty/gameproductservice@14.9.1-canary.496.cb49bdf.0
  yarn add @quenty/gamescalingutils@13.5.1-canary.496.cb49bdf.0
  yarn add @quenty/genericscreenguiprovider@13.7.1-canary.496.cb49bdf.0
  yarn add @quenty/hide@11.7.1-canary.496.cb49bdf.0
  yarn add @quenty/highlight@10.6.1-canary.496.cb49bdf.0
  yarn add @quenty/hintscoringutils@14.7.1-canary.496.cb49bdf.0
  yarn add @quenty/humanoidspeed@12.7.1-canary.496.cb49bdf.0
  yarn add @quenty/idleservice@13.8.1-canary.496.cb49bdf.0
  yarn add @quenty/ik@15.9.1-canary.496.cb49bdf.0
  yarn add @quenty/influxdbclient@7.7.1-canary.496.cb49bdf.0
  yarn add @quenty/inputkeymaputils@14.8.1-canary.496.cb49bdf.0
  yarn add @quenty/inputmode@13.6.1-canary.496.cb49bdf.0
  yarn add @quenty/lipsum@14.5.1-canary.496.cb49bdf.0
  yarn add @quenty/motor6d@7.7.1-canary.496.cb49bdf.0
  yarn add @quenty/observablecollection@12.5.1-canary.496.cb49bdf.0
  yarn add @quenty/permissionprovider@14.7.1-canary.496.cb49bdf.0
  yarn add @quenty/playerinputmode@9.7.1-canary.496.cb49bdf.0
  yarn add @quenty/promptqueue@1.3.1-canary.496.cb49bdf.0
  yarn add @quenty/radial-image@9.5.1-canary.496.cb49bdf.0
  yarn add @quenty/ragdoll@15.8.1-canary.496.cb49bdf.0
  yarn add @quenty/receiptprocessing@7.6.1-canary.496.cb49bdf.0
  yarn add @quenty/rogue-humanoid@10.7.1-canary.496.cb49bdf.0
  yarn add @quenty/rogue-properties@11.7.1-canary.496.cb49bdf.0
  yarn add @quenty/scoredactionservice@16.9.1-canary.496.cb49bdf.0
  yarn add @quenty/screenshothudservice@7.6.1-canary.496.cb49bdf.0
  yarn add @quenty/secrets@7.8.1-canary.496.cb49bdf.0
  yarn add @quenty/servicebag@11.5.1-canary.496.cb49bdf.0
  yarn add @quenty/settings@11.8.1-canary.496.cb49bdf.0
  yarn add @quenty/settings-inputkeymap@10.10.1-canary.496.cb49bdf.0
  yarn add @quenty/snackbar@11.6.1-canary.496.cb49bdf.0
  yarn add @quenty/softshutdown@9.8.1-canary.496.cb49bdf.0
  yarn add @quenty/soundgroup@1.5.1-canary.496.cb49bdf.0
  yarn add @quenty/soundplayer@7.5.1-canary.496.cb49bdf.0
  yarn add @quenty/spawning@10.7.1-canary.496.cb49bdf.0
  yarn add @quenty/sprites@13.4.1-canary.496.cb49bdf.0
  yarn add @quenty/textserviceutils@13.5.1-canary.496.cb49bdf.0
  yarn add @quenty/timedtween@7.5.1-canary.496.cb49bdf.0
  yarn add @quenty/transitionmodel@7.5.1-canary.496.cb49bdf.0
  yarn add @quenty/uiobjectutils@6.4.1-canary.496.cb49bdf.0
  yarn add @quenty/userserviceutils@9.6.1-canary.496.cb49bdf.0
  yarn add @quenty/viewport@11.8.1-canary.496.cb49bdf.0
  yarn add @quenty/nevermore-cli@4.4.1-canary.496.cb49bdf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
