### PR TITLE
fix: Deprecate some signal APIs and qGUI

### DIFF
--- a/src/qgui/src/Shared/qGUI.lua
+++ b/src/qgui/src/Shared/qGUI.lua
@@ -1,5 +1,7 @@
 --[=[
 	A group of utility functions to be used to help create visual effectcs with ROBLOX GUIs
+
+	@deprecated 2.3.1
 	@class qGui
 ]=]
 

--- a/src/ragdoll/src/Client/RagdollBindersClient.lua
+++ b/src/ragdoll/src/Client/RagdollBindersClient.lua
@@ -7,6 +7,7 @@
 	:::
 
 	@client
+	@deprecated 15.11.2
 	@class RagdollBindersClient
 ]=]
 

--- a/src/ragdoll/src/Server/RagdollBindersServer.lua
+++ b/src/ragdoll/src/Server/RagdollBindersServer.lua
@@ -7,6 +7,7 @@
 	:::
 
 	@server
+	@deprecated 15.11.2
 	@class RagdollBindersServer
 ]=]
 

--- a/src/steputils/src/Shared/StepUtils.lua
+++ b/src/steputils/src/Shared/StepUtils.lua
@@ -43,13 +43,9 @@ end
 	Yields until the frame deferral is done
 ]=]
 function StepUtils.deferWait()
-	local signal = Instance.new("BindableEvent")
-	task.defer(function()
-		signal:Fire()
-		signal:Destroy()
-	end)
-
-	signal.Event:Wait()
+	local current = coroutine.running()
+	task.defer(task.spawn, current)
+	coroutine.yield()
 end
 
 --[=[
@@ -158,26 +154,44 @@ end
 		part.CFrame = CFrame.new(0, 0, )
 	end))
 	```
+
+	:::tip
+	use `RunService.Stepped:Once()` instead
+	:::
+
+	@deprecated 3.5.2
 	@param func function -- Function to call
 	@return function -- Call this function to cancel call
 ]=]
 function StepUtils.onceAtStepped(func)
-	return StepUtils.onceAtEvent(RunService.Stepped, func)
+	local conn = RunService.Stepped:Once(func)
+	return function()
+		conn:Disconnect()
+	end
 end
 
 --[=[
 	Invokes the function once at renderstepped, unless the cancel callback is called.
 
+	:::tip
+	use `RunService.RenderStepped:Once()` instead
+	:::
+
+	@deprecated 3.5.2
 	@param func function -- Function to call
 	@return function -- Call this function to cancel call
 ]=]
 function StepUtils.onceAtRenderStepped(func)
-	return StepUtils.onceAtEvent(RunService.RenderStepped, func)
+	local conn = RunService.RenderStepped:Once(func)
+	return function()
+		conn:Disconnect()
+	end
 end
 
 --[=[
 	Invokes the function once at the given event, unless the cancel callback is called.
 
+	@deprecated 3.5.2
 	@param event Signal | RBXScriptSignal
 	@param func function -- Function to call
 	@return function -- Call this function to cancel call


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/actionmanager@13.9.1-canary.506.9cbf2c1.0
  npm install @quenty/adorneeboundingbox@8.9.1-canary.506.9cbf2c1.0
  npm install @quenty/adorneedata@7.10.1-canary.506.9cbf2c1.0
  npm install @quenty/adorneevalue@10.9.1-canary.506.9cbf2c1.0
  npm install @quenty/animationprovider@11.7.1-canary.506.9cbf2c1.0
  npm install @quenty/animations@8.9.1-canary.506.9cbf2c1.0
  npm install @quenty/assetserviceutils@5.11.1-canary.506.9cbf2c1.0
  npm install @quenty/attributeutils@14.9.1-canary.506.9cbf2c1.0
  npm install @quenty/avatareditorutils@7.10.1-canary.506.9cbf2c1.0
  npm install @quenty/basicpane@13.9.1-canary.506.9cbf2c1.0
  npm install @quenty/binder@14.10.1-canary.506.9cbf2c1.0
  npm install @quenty/bindtocloseservice@8.9.1-canary.506.9cbf2c1.0
  npm install @quenty/blend@12.9.1-canary.506.9cbf2c1.0
  npm install @quenty/bodycolorsutils@7.9.1-canary.506.9cbf2c1.0
  npm install @quenty/boundlinkutils@14.10.1-canary.506.9cbf2c1.0
  npm install @quenty/brio@14.9.1-canary.506.9cbf2c1.0
  npm install @quenty/buttondragmodel@1.7.1-canary.506.9cbf2c1.0
  npm install @quenty/buttonhighlightmodel@14.9.1-canary.506.9cbf2c1.0
  npm install @quenty/characterutils@12.9.1-canary.506.9cbf2c1.0
  npm install @quenty/chatproviderservice@9.13.1-canary.506.9cbf2c1.0
  npm install @quenty/clienttranslator@14.10.1-canary.506.9cbf2c1.0
  npm install @quenty/clipcharacters@12.10.1-canary.506.9cbf2c1.0
  npm install @quenty/cmdrservice@13.11.1-canary.506.9cbf2c1.0
  npm install @quenty/collectionserviceutils@8.9.1-canary.506.9cbf2c1.0
  npm install @quenty/color3utils@11.9.1-canary.506.9cbf2c1.0
  npm install @quenty/colorpalette@10.10.1-canary.506.9cbf2c1.0
  npm install @quenty/colorpicker@10.10.1-canary.506.9cbf2c1.0
  npm install @quenty/conditions@10.11.1-canary.506.9cbf2c1.0
  npm install @quenty/contentproviderutils@12.9.1-canary.506.9cbf2c1.0
  npm install @quenty/cooldown@11.11.1-canary.506.9cbf2c1.0
  npm install @quenty/coreguienabler@12.9.1-canary.506.9cbf2c1.0
  npm install @quenty/counter@7.9.1-canary.506.9cbf2c1.0
  npm install @quenty/datastore@13.11.1-canary.506.9cbf2c1.0
  npm install @quenty/deathreport@10.11.1-canary.506.9cbf2c1.0
  npm install @quenty/depthoffield@11.10.1-canary.506.9cbf2c1.0
  npm install @quenty/elo@7.10.1-canary.506.9cbf2c1.0
  npm install @quenty/equippedtracker@13.9.1-canary.506.9cbf2c1.0
  npm install @quenty/firstpersoncharactertransparency@14.10.1-canary.506.9cbf2c1.0
  npm install @quenty/flipbook@9.9.1-canary.506.9cbf2c1.0
  npm install @quenty/friendutils@12.9.1-canary.506.9cbf2c1.0
  npm install @quenty/gameconfig@12.13.1-canary.506.9cbf2c1.0
  npm install @quenty/gameproductservice@14.13.1-canary.506.9cbf2c1.0
  npm install @quenty/gamescalingutils@13.9.1-canary.506.9cbf2c1.0
  npm install @quenty/genericscreenguiprovider@13.11.1-canary.506.9cbf2c1.0
  npm install @quenty/hide@11.11.1-canary.506.9cbf2c1.0
  npm install @quenty/highlight@10.10.1-canary.506.9cbf2c1.0
  npm install @quenty/humanoidspeed@12.11.1-canary.506.9cbf2c1.0
  npm install @quenty/humanoidtracker@13.9.1-canary.506.9cbf2c1.0
  npm install @quenty/idleservice@13.12.1-canary.506.9cbf2c1.0
  npm install @quenty/ik@15.13.1-canary.506.9cbf2c1.0
  npm install @quenty/influxdbclient@7.11.1-canary.506.9cbf2c1.0
  npm install @quenty/inputkeymaputils@14.12.1-canary.506.9cbf2c1.0
  npm install @quenty/inputmode@13.10.1-canary.506.9cbf2c1.0
  npm install @quenty/instanceutils@13.9.1-canary.506.9cbf2c1.0
  npm install @quenty/linkutils@13.9.1-canary.506.9cbf2c1.0
  npm install @quenty/lipsum@14.9.1-canary.506.9cbf2c1.0
  npm install @quenty/localizedtextutils@12.9.1-canary.506.9cbf2c1.0
  npm install @quenty/modeltransparencyeffect@11.7.1-canary.506.9cbf2c1.0
  npm install @quenty/motor6d@7.11.1-canary.506.9cbf2c1.0
  npm install @quenty/observablecollection@12.9.1-canary.506.9cbf2c1.0
  npm install @quenty/particleengine@13.10.1-canary.506.9cbf2c1.0
  npm install @quenty/parttouchingcalculator@14.10.1-canary.506.9cbf2c1.0
  npm install @quenty/permissionprovider@14.11.1-canary.506.9cbf2c1.0
  npm install @quenty/playerbinder@14.10.1-canary.506.9cbf2c1.0
  npm install @quenty/playerhumanoidbinder@14.10.1-canary.506.9cbf2c1.0
  npm install @quenty/playerinputmode@9.11.1-canary.506.9cbf2c1.0
  npm install @quenty/playerutils@8.9.1-canary.506.9cbf2c1.0
  npm install @quenty/promptqueue@1.8.1-canary.506.9cbf2c1.0
  npm install @quenty/propertyvalue@7.9.1-canary.506.9cbf2c1.0
  npm install @quenty/qgui@2.3.1-canary.506.9cbf2c1.0
  npm install @quenty/r15utils@13.9.1-canary.506.9cbf2c1.0
  npm install @quenty/racketingropeconstraint@12.11.1-canary.506.9cbf2c1.0
  npm install @quenty/radial-image@9.9.1-canary.506.9cbf2c1.0
  npm install @quenty/ragdoll@15.12.1-canary.506.9cbf2c1.0
  npm install @quenty/receiptprocessing@7.10.1-canary.506.9cbf2c1.0
  npm install @quenty/remoting@12.10.1-canary.506.9cbf2c1.0
  npm install @quenty/resetservice@11.11.1-canary.506.9cbf2c1.0
  npm install @quenty/rigbuilderutils@10.11.1-canary.506.9cbf2c1.0
  npm install @quenty/rogue-humanoid@10.11.1-canary.506.9cbf2c1.0
  npm install @quenty/rogue-properties@11.11.1-canary.506.9cbf2c1.0
  npm install @quenty/rxbinderutils@14.10.1-canary.506.9cbf2c1.0
  npm install @quenty/scoredactionservice@16.13.1-canary.506.9cbf2c1.0
  npm install @quenty/screenshothudservice@7.10.1-canary.506.9cbf2c1.0
  npm install @quenty/seatutils@7.10.1-canary.506.9cbf2c1.0
  npm install @quenty/secrets@7.12.1-canary.506.9cbf2c1.0
  npm install @quenty/selectionutils@8.9.1-canary.506.9cbf2c1.0
  npm install @quenty/settings@11.12.1-canary.506.9cbf2c1.0
  npm install @quenty/settings-inputkeymap@10.14.1-canary.506.9cbf2c1.0
  npm install @quenty/snackbar@11.11.1-canary.506.9cbf2c1.0
  npm install @quenty/softshutdown@9.12.1-canary.506.9cbf2c1.0
  npm install @quenty/soundgroup@1.9.1-canary.506.9cbf2c1.0
  npm install @quenty/soundplayer@7.10.1-canary.506.9cbf2c1.0
  npm install @quenty/spawning@10.11.1-canary.506.9cbf2c1.0
  npm install @quenty/sprites@13.8.1-canary.506.9cbf2c1.0
  npm install @quenty/statestack@14.10.1-canary.506.9cbf2c1.0
  npm install @quenty/steputils@3.5.2-canary.506.9cbf2c1.0
  npm install @quenty/teamtracker@13.9.1-canary.506.9cbf2c1.0
  npm install @quenty/teamutils@10.9.1-canary.506.9cbf2c1.0
  npm install @quenty/teleportserviceutils@9.9.1-canary.506.9cbf2c1.0
  npm install @quenty/templateprovider@11.7.1-canary.506.9cbf2c1.0
  npm install @quenty/textfilterservice@13.10.1-canary.506.9cbf2c1.0
  npm install @quenty/textserviceutils@13.9.1-canary.506.9cbf2c1.0
  npm install @quenty/tie@10.11.1-canary.506.9cbf2c1.0
  npm install @quenty/timedtween@7.9.1-canary.506.9cbf2c1.0
  npm install @quenty/timesyncservice@13.10.1-canary.506.9cbf2c1.0
  npm install @quenty/transitionmodel@7.10.1-canary.506.9cbf2c1.0
  npm install @quenty/uiobjectutils@6.8.1-canary.506.9cbf2c1.0
  npm install @quenty/undostack@7.9.1-canary.506.9cbf2c1.0
  npm install @quenty/valuebaseutils@13.9.1-canary.506.9cbf2c1.0
  npm install @quenty/valueobject@13.9.1-canary.506.9cbf2c1.0
  npm install @quenty/viewport@11.12.1-canary.506.9cbf2c1.0
  # or 
  yarn add @quenty/actionmanager@13.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/adorneeboundingbox@8.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/adorneedata@7.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/adorneevalue@10.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/animationprovider@11.7.1-canary.506.9cbf2c1.0
  yarn add @quenty/animations@8.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/assetserviceutils@5.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/attributeutils@14.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/avatareditorutils@7.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/basicpane@13.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/binder@14.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/bindtocloseservice@8.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/blend@12.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/bodycolorsutils@7.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/boundlinkutils@14.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/brio@14.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/buttondragmodel@1.7.1-canary.506.9cbf2c1.0
  yarn add @quenty/buttonhighlightmodel@14.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/characterutils@12.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/chatproviderservice@9.13.1-canary.506.9cbf2c1.0
  yarn add @quenty/clienttranslator@14.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/clipcharacters@12.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/cmdrservice@13.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/collectionserviceutils@8.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/color3utils@11.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/colorpalette@10.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/colorpicker@10.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/conditions@10.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/contentproviderutils@12.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/cooldown@11.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/coreguienabler@12.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/counter@7.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/datastore@13.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/deathreport@10.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/depthoffield@11.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/elo@7.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/equippedtracker@13.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/firstpersoncharactertransparency@14.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/flipbook@9.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/friendutils@12.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/gameconfig@12.13.1-canary.506.9cbf2c1.0
  yarn add @quenty/gameproductservice@14.13.1-canary.506.9cbf2c1.0
  yarn add @quenty/gamescalingutils@13.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/genericscreenguiprovider@13.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/hide@11.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/highlight@10.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/humanoidspeed@12.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/humanoidtracker@13.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/idleservice@13.12.1-canary.506.9cbf2c1.0
  yarn add @quenty/ik@15.13.1-canary.506.9cbf2c1.0
  yarn add @quenty/influxdbclient@7.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/inputkeymaputils@14.12.1-canary.506.9cbf2c1.0
  yarn add @quenty/inputmode@13.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/instanceutils@13.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/linkutils@13.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/lipsum@14.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/localizedtextutils@12.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/modeltransparencyeffect@11.7.1-canary.506.9cbf2c1.0
  yarn add @quenty/motor6d@7.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/observablecollection@12.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/particleengine@13.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/parttouchingcalculator@14.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/permissionprovider@14.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/playerbinder@14.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/playerhumanoidbinder@14.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/playerinputmode@9.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/playerutils@8.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/promptqueue@1.8.1-canary.506.9cbf2c1.0
  yarn add @quenty/propertyvalue@7.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/qgui@2.3.1-canary.506.9cbf2c1.0
  yarn add @quenty/r15utils@13.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/racketingropeconstraint@12.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/radial-image@9.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/ragdoll@15.12.1-canary.506.9cbf2c1.0
  yarn add @quenty/receiptprocessing@7.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/remoting@12.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/resetservice@11.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/rigbuilderutils@10.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/rogue-humanoid@10.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/rogue-properties@11.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/rxbinderutils@14.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/scoredactionservice@16.13.1-canary.506.9cbf2c1.0
  yarn add @quenty/screenshothudservice@7.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/seatutils@7.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/secrets@7.12.1-canary.506.9cbf2c1.0
  yarn add @quenty/selectionutils@8.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/settings@11.12.1-canary.506.9cbf2c1.0
  yarn add @quenty/settings-inputkeymap@10.14.1-canary.506.9cbf2c1.0
  yarn add @quenty/snackbar@11.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/softshutdown@9.12.1-canary.506.9cbf2c1.0
  yarn add @quenty/soundgroup@1.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/soundplayer@7.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/spawning@10.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/sprites@13.8.1-canary.506.9cbf2c1.0
  yarn add @quenty/statestack@14.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/steputils@3.5.2-canary.506.9cbf2c1.0
  yarn add @quenty/teamtracker@13.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/teamutils@10.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/teleportserviceutils@9.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/templateprovider@11.7.1-canary.506.9cbf2c1.0
  yarn add @quenty/textfilterservice@13.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/textserviceutils@13.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/tie@10.11.1-canary.506.9cbf2c1.0
  yarn add @quenty/timedtween@7.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/timesyncservice@13.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/transitionmodel@7.10.1-canary.506.9cbf2c1.0
  yarn add @quenty/uiobjectutils@6.8.1-canary.506.9cbf2c1.0
  yarn add @quenty/undostack@7.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/valuebaseutils@13.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/valueobject@13.9.1-canary.506.9cbf2c1.0
  yarn add @quenty/viewport@11.12.1-canary.506.9cbf2c1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
