### PR TITLE
fix: Fix docs build

### DIFF
--- a/src/tie/src/Shared/TieDefinition.lua
+++ b/src/tie/src/Shared/TieDefinition.lua
@@ -599,9 +599,9 @@ end
 	invoking interface methods, or querying the interface will result
 	in errors.
 
-	```tip
+	:::tip
 	Probably use :Find() instead of Get, since this always returns an interface.
-	```
+	:::
 
 	@param adornee Instance -- Adornee to get interface on
 	@param tieRealm TieRealm?


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/conditions@10.12.1-canary.514.c328cc1.0
  npm install @quenty/gameproductservice@14.14.1-canary.514.c328cc1.0
  npm install @quenty/humanoidspeed@12.12.1-canary.514.c328cc1.0
  npm install @quenty/idleservice@13.13.1-canary.514.c328cc1.0
  npm install @quenty/ik@15.14.1-canary.514.c328cc1.0
  npm install @quenty/motor6d@7.12.1-canary.514.c328cc1.0
  npm install @quenty/racketingropeconstraint@12.12.1-canary.514.c328cc1.0
  npm install @quenty/ragdoll@15.13.1-canary.514.c328cc1.0
  npm install @quenty/rogue-humanoid@10.12.1-canary.514.c328cc1.0
  npm install @quenty/rogue-properties@11.12.1-canary.514.c328cc1.0
  npm install @quenty/settings@11.13.1-canary.514.c328cc1.0
  npm install @quenty/settings-inputkeymap@10.15.1-canary.514.c328cc1.0
  npm install @quenty/tie@10.12.1-canary.514.c328cc1.0
  # or 
  yarn add @quenty/conditions@10.12.1-canary.514.c328cc1.0
  yarn add @quenty/gameproductservice@14.14.1-canary.514.c328cc1.0
  yarn add @quenty/humanoidspeed@12.12.1-canary.514.c328cc1.0
  yarn add @quenty/idleservice@13.13.1-canary.514.c328cc1.0
  yarn add @quenty/ik@15.14.1-canary.514.c328cc1.0
  yarn add @quenty/motor6d@7.12.1-canary.514.c328cc1.0
  yarn add @quenty/racketingropeconstraint@12.12.1-canary.514.c328cc1.0
  yarn add @quenty/ragdoll@15.13.1-canary.514.c328cc1.0
  yarn add @quenty/rogue-humanoid@10.12.1-canary.514.c328cc1.0
  yarn add @quenty/rogue-properties@11.12.1-canary.514.c328cc1.0
  yarn add @quenty/settings@11.13.1-canary.514.c328cc1.0
  yarn add @quenty/settings-inputkeymap@10.15.1-canary.514.c328cc1.0
  yarn add @quenty/tie@10.12.1-canary.514.c328cc1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
