### PR TITLE
fix: Fix ObserveAtIndex on ObservableSortedList

### DIFF
--- a/src/observablecollection/src/Shared/SortedList/ObservableSortedList.lua
+++ b/src/observablecollection/src/Shared/SortedList/ObservableSortedList.lua
@@ -296,7 +296,7 @@ function ObservableSortedList:ObserveAtIndex(indexToObserve)
 
 	return self._indexObservers:Observe(indexToObserve)
 		:Pipe({
-			Rx.start(function()
+			Rx.map(function()
 				local node = self:_findNodeAtIndex(indexToObserve)
 				if node then
 					return node.data, node


### PR DESCRIPTION
Currently, `ObserveAtIndex` returns the node instead of the data which breaks a few packages. Switching `Rx.start` to `Rx.map` seems to fix the problem and give the desired behavior, but I'm not 100% sure if this is the intended behavior or if this would break anything.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/adorneeboundingbox@8.12.1-canary.517.2bd4a12.0
  npm install @quenty/animationprovider@11.10.1-canary.517.2bd4a12.0
  npm install @quenty/chatproviderservice@9.16.1-canary.517.2bd4a12.0
  npm install @quenty/cmdrservice@13.14.1-canary.517.2bd4a12.0
  npm install @quenty/colorpalette@10.13.1-canary.517.2bd4a12.0
  npm install @quenty/gameconfig@12.16.1-canary.517.2bd4a12.0
  npm install @quenty/gameproductservice@14.16.1-canary.517.2bd4a12.0
  npm install @quenty/highlight@10.13.1-canary.517.2bd4a12.0
  npm install @quenty/humanoidspeed@12.14.1-canary.517.2bd4a12.0
  npm install @quenty/inputkeymaputils@14.15.1-canary.517.2bd4a12.0
  npm install @quenty/observablecollection@12.12.1-canary.517.2bd4a12.0
  npm install @quenty/rogue-humanoid@10.14.1-canary.517.2bd4a12.0
  npm install @quenty/rogue-properties@11.14.1-canary.517.2bd4a12.0
  npm install @quenty/scoredactionservice@16.16.1-canary.517.2bd4a12.0
  npm install @quenty/secrets@7.15.1-canary.517.2bd4a12.0
  npm install @quenty/settings@11.15.1-canary.517.2bd4a12.0
  npm install @quenty/settings-inputkeymap@10.17.1-canary.517.2bd4a12.0
  npm install @quenty/soundgroup@1.12.1-canary.517.2bd4a12.0
  npm install @quenty/spawning@10.14.1-canary.517.2bd4a12.0
  npm install @quenty/templateprovider@11.10.1-canary.517.2bd4a12.0
  # or 
  yarn add @quenty/adorneeboundingbox@8.12.1-canary.517.2bd4a12.0
  yarn add @quenty/animationprovider@11.10.1-canary.517.2bd4a12.0
  yarn add @quenty/chatproviderservice@9.16.1-canary.517.2bd4a12.0
  yarn add @quenty/cmdrservice@13.14.1-canary.517.2bd4a12.0
  yarn add @quenty/colorpalette@10.13.1-canary.517.2bd4a12.0
  yarn add @quenty/gameconfig@12.16.1-canary.517.2bd4a12.0
  yarn add @quenty/gameproductservice@14.16.1-canary.517.2bd4a12.0
  yarn add @quenty/highlight@10.13.1-canary.517.2bd4a12.0
  yarn add @quenty/humanoidspeed@12.14.1-canary.517.2bd4a12.0
  yarn add @quenty/inputkeymaputils@14.15.1-canary.517.2bd4a12.0
  yarn add @quenty/observablecollection@12.12.1-canary.517.2bd4a12.0
  yarn add @quenty/rogue-humanoid@10.14.1-canary.517.2bd4a12.0
  yarn add @quenty/rogue-properties@11.14.1-canary.517.2bd4a12.0
  yarn add @quenty/scoredactionservice@16.16.1-canary.517.2bd4a12.0
  yarn add @quenty/secrets@7.15.1-canary.517.2bd4a12.0
  yarn add @quenty/settings@11.15.1-canary.517.2bd4a12.0
  yarn add @quenty/settings-inputkeymap@10.17.1-canary.517.2bd4a12.0
  yarn add @quenty/soundgroup@1.12.1-canary.517.2bd4a12.0
  yarn add @quenty/spawning@10.14.1-canary.517.2bd4a12.0
  yarn add @quenty/templateprovider@11.10.1-canary.517.2bd4a12.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
