### PR TITLE
fix: Support part operations in ModelAppearance API

### DIFF
--- a/src/modelappearance/src/Shared/ModelAppearance.lua
+++ b/src/modelappearance/src/Shared/ModelAppearance.lua
@@ -32,6 +32,10 @@ function ModelAppearance.new(model)
 			if part:IsA("Seat") or part:IsA("VehicleSeat") then
 				self._seats[part] = part
 			end
+
+			if part:IsA("PartOperation") then
+				self._parts[part].UsePartColor = part.UsePartColor
+			end
 		elseif part:IsA("ClickDetector") or part:IsA("BodyMover") then
 			table.insert(self._interactions, part)
 		end
@@ -102,6 +106,10 @@ function ModelAppearance:SetColor(color)
 	self._color = color
 	for part, _ in pairs(self._parts) do
 		part.Color = color
+
+		if part:IsA("PartOperation") then
+			part.UsePartColor = true
+		end
 	end
 end
 
@@ -113,6 +121,10 @@ function ModelAppearance:ResetColor()
 	self._color = nil
 	for part, properties in pairs(self._parts) do
 		part.Color = properties.Color
+
+		if part:IsA("PartOperation") then
+			part.UsePartColor = properties.UsePartColor
+		end
 	end
 end
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/modelappearance@10.7.2-canary.528.6a7533e.0
  # or 
  yarn add @quenty/modelappearance@10.7.2-canary.528.6a7533e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
