### PR TITLE
fix: Set the first valid preferred action from the list

### DIFF
--- a/src/scoredactionservice/src/Client/Picker/ScoredActionPicker.lua
+++ b/src/scoredactionservice/src/Client/Picker/ScoredActionPicker.lua
@@ -54,7 +54,13 @@ function ScoredActionPicker:Update()
 		warn(string.format("[ScoredActionPicker.Update] - Action list has size of %d/%d", #actionList, MAX_ACTION_LIST_SIZE_BEFORE_WARN))
 	end
 
-	self._currentPreferred.Value = self:_tryGetValidPreferredAction(actionList[1])
+	for _, action in actionList do
+		local preferredAction = self:_tryGetValidPreferredAction(action)
+		if preferredAction then
+			self._currentPreferred.Value = preferredAction
+			break
+		end
+	end
 end
 
 function ScoredActionPicker:_tryGetValidPreferredAction(action)


### PR DESCRIPTION
This change improves the behavior of the action picker by returning the first valid preferred action from the list, instead of just setting the first one in the table. The behavior can be observed when there are multiple actions within range.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/scoredactionservice@16.22.1-canary.529.b027236.0
  # or 
  yarn add @quenty/scoredactionservice@16.22.1-canary.529.b027236.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
