### PR TITLE
fix: correct type assertion for index in RoguePropertyTable __index function

### DIFF
--- a/src/rogue-properties/src/Shared/Implementation/RoguePropertyTable.lua
+++ b/src/rogue-properties/src/Shared/Implementation/RoguePropertyTable.lua
@@ -225,7 +225,7 @@ function RoguePropertyTable:__newindex(index, value)
 end
 
 function RoguePropertyTable:__index(index)
-	assert(type(index) == "string", "Bad index")
+	assert(type(index) == "string" or type(index) == "number", "Bad index")
 
 	if RoguePropertyTable[index] then
 		return RoguePropertyTable[index]


### PR DESCRIPTION
__index function checks if index is a number to do work, assertion prevents this from happening by only allowing strings.