### PR TITLE
fix: Work around Roblox bug with OrderedDataStore never finishing

### DIFF
--- a/src/datastore/package.json
+++ b/src/datastore/package.json
@@ -31,6 +31,7 @@
     "@quenty/loader": "file:../loader",
     "@quenty/maid": "file:../maid",
     "@quenty/math": "file:../math",
+    "@quenty/pagesutils": "file:../pagesutils",
     "@quenty/promise": "file:../promise",
     "@quenty/rx": "file:../rx",
     "@quenty/servicebag": "file:../servicebag",


### PR DESCRIPTION
https://devforum.roblox.com/t/ordereddatastore-pages-object-is-never-isfinished-resulting-in-finite-loops-when-n-0/3558372
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/chatproviderservice@9.24.1-canary.543.25d35f7.0
  npm install @quenty/datastore@13.19.1-canary.543.25d35f7.0
  npm install @quenty/secrets@7.22.1-canary.543.25d35f7.0
  npm install @quenty/settings@11.22.1-canary.543.25d35f7.0
  npm install @quenty/settings-inputkeymap@10.24.1-canary.543.25d35f7.0
  npm install @quenty/softshutdown@9.22.1-canary.543.25d35f7.0
  # or 
  yarn add @quenty/chatproviderservice@9.24.1-canary.543.25d35f7.0
  yarn add @quenty/datastore@13.19.1-canary.543.25d35f7.0
  yarn add @quenty/secrets@7.22.1-canary.543.25d35f7.0
  yarn add @quenty/settings@11.22.1-canary.543.25d35f7.0
  yarn add @quenty/settings-inputkeymap@10.24.1-canary.543.25d35f7.0
  yarn add @quenty/softshutdown@9.22.1-canary.543.25d35f7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
