### PR TITLE
fix: Support Content type in Blend converter plugin

### DIFF
--- a/plugins/ui-converter-plugin/src/modules/Server/RxUIConverterUtils.lua
+++ b/plugins/ui-converter-plugin/src/modules/Server/RxUIConverterUtils.lua
@@ -25,6 +25,7 @@ function RxUIConverterUtils.observeAnyChangedBelowInst(inst)
 			end))
 
 			maid[descendant] = maid
+			topMaid[descendant] = maid
 		end
 
 		topMaid:GiveTask(inst.DescendantAdded:Connect(function(descendant)

--- a/plugins/ui-converter-plugin/src/modules/Server/UIConverterUtils.lua
+++ b/plugins/ui-converter-plugin/src/modules/Server/UIConverterUtils.lua
@@ -91,9 +91,9 @@ function UIConverterUtils.toLuaPropertyString(value: any, debugHint: string): st
 	if valueType == "string" then
 		local multiline = UIConverterUtils.toMultiLineEscape(value)
 		if multiline then
-			return multiline
+			return `"{multiline}"`
 		else
-			return string.format("%q", value)
+			return `"{value}"`
 		end
 	elseif valueType == "number" then
 		return roundNumber(value)
@@ -243,6 +243,13 @@ function UIConverterUtils.toLuaPropertyString(value: any, debugHint: string): st
 				tostring(value.Style)
 			)
 		end
+	elseif valueType == "Content" then
+		-- TODO: Do we need to handle Enum.ContentSourceType.Object?
+		if value.SourceType == Enum.ContentSourceType.Uri then
+			return `Content.fromUri("{value.Uri or ""}")`
+		else
+			return ""
+		end
 	elseif valueType == "userdata" then
 		-- FontFace
 		warn(
@@ -269,7 +276,7 @@ end
 function UIConverterUtils.convertPropertiesToTable(properties, refLookupMap)
 	local data = {}
 	for key, value in properties do
-		if key ~= "Parent" then
+		if key ~= "Parent" and key ~= "ImageContent" then
 			if typeof(value) == "Instance" then
 				data[key] = UIConverterUtils.getRefProperty(refLookupMap, value)
 			else
@@ -313,7 +320,11 @@ function UIConverterUtils.propertiesTableToString(library, properties)
 
 	local data = {}
 	for _, key in keys do
-		table.insert(data, string.format("%s = %s;", key, properties[key]))
+		if key == "[Blend.Children]" then
+			table.insert(data, properties[key])
+		else
+			table.insert(data, string.format("%s = %s;", key, properties[key]))
+		end
 	end
 
 	return table.concat(data, "\n")
@@ -548,8 +559,15 @@ function UIConverterUtils.promiseToLibraryInstance(
 
 				if next(childrenPromises) then
 					return PromiseUtils.all(childrenPromises):Then(function(...)
+						local ignoreIndent = false
+						-- The [Blend.Children] syntax isn't required anymore,
+						-- we can just list the items
+						if library == "Blend" then
+							ignoreIndent = true
+						end
+
 						converted[UIConverterUtils.getChildrenKey(library)] =
-							UIConverterUtils.convertListOfItemsToTable({ ... })
+							UIConverterUtils.convertListOfItemsToTable({ ... }, ignoreIndent)
 						return converted
 					end)
 				end
@@ -589,7 +607,7 @@ function UIConverterUtils.getEntryListCode(library: UIConverterLibrary, refLooku
 	end
 end
 
-function UIConverterUtils.convertListOfItemsToTable(results: { string }): string
+function UIConverterUtils.convertListOfItemsToTable(results: { string }, ignoreIndent: boolean?): string
 	local strings = {}
 	for _, item in results do
 		if item then
@@ -597,7 +615,11 @@ function UIConverterUtils.convertListOfItemsToTable(results: { string }): string
 		end
 	end
 	local childrenText = table.concat(strings, "\n")
-	return string.format("{\n%s\n}", UIConverterUtils.indent(childrenText))
+	if not ignoreIndent then
+		return string.format("{\n%s\n}", UIConverterUtils.indent(childrenText))
+	else
+		return childrenText
+	end
 end
 
 return UIConverterUtils


### PR DESCRIPTION
Fixes a memory leak with selected instances, and adds support for the new `Content` type. On ImageLabels, the `ImageContent` property is added in addition to `Image`, so I decided to disable it for now since it's not required.