### PR TITLE
chore(package-lock): update nevermore-template-helpers version

### DIFF
--- a/tools/nevermore-cli/package-lock.json
+++ b/tools/nevermore-cli/package-lock.json
@@ -51,7 +51,7 @@
     },
     "../nevermore-template-helpers": {
       "name": "@quenty/nevermore-template-helpers",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@quenty/cli-output-helpers": "file:../cli-output-helpers",


### PR DESCRIPTION
This pull request includes a minor version update to the `@quenty/nevermore-template-helpers` dependency in the `tools/nevermore-cli/package-lock.json` file. The version has been updated from `1.2.3` to `1.3.0`.