### PR TITLE
Fix: BoundParentTracker does not track parent being binded

### DIFF
--- a/src/binder/src/Shared/Trackers/BoundParentTracker.lua
+++ b/src/binder/src/Shared/Trackers/BoundParentTracker.lua
@@ -29,6 +29,12 @@ function BoundParentTracker.new(binder, child)
 		end
 	end))
 
+	self._maid:GiveTask(self._binder:GetClassAddedSignal():Connect(function(_, instance)
+		if self._child.Parent == instance then
+			self:_update()
+		end
+	end))
+
 	-- Perform update
 	self._maid:GiveTask(self._child:GetPropertyChangedSignal("Parent"):Connect(function()
 		self:_update()


### PR DESCRIPTION
Fix for probably unintended behavior.
[BoundAncestorTracker](https://github.com/Quenty/NevermoreEngine/blob/main/src/binder/src/Shared/Trackers/BoundAncestorTracker.lua#L45) tracks ancestors being binded, but BoundParentTracker does not track parents being binded.