### PR TITLE
fix: Prevent playback on invalid targets

### DIFF
--- a/src/animations/src/Shared/AnimationSlotPlayer.lua
+++ b/src/animations/src/Shared/AnimationSlotPlayer.lua
@@ -297,7 +297,7 @@ function AnimationSlotPlayer.Play(
 
 	topMaid:GiveTask(self._animationTarget
 		:ObserveBrio(function(target)
-			return target ~= nil
+			return target ~= nil and target.Parent ~= nil
 		end)
 		:Subscribe(function(brio)
 			if brio:IsDead() then

--- a/src/clienttranslator/src/Shared/Utils/LocalizationServiceUtils.lua
+++ b/src/clienttranslator/src/Shared/Utils/LocalizationServiceUtils.lua
@@ -65,7 +65,7 @@ function LocalizationServiceUtils.promisePlayerTranslator(player: Player)
 	end)
 
 	return promiseTranslator:Catch(function(err)
-		if err ~= ERROR_PUBLISH_REQUIRED and error ~= ERROR_TIMEOUT then
+		if err ~= ERROR_PUBLISH_REQUIRED and err ~= ERROR_TIMEOUT then
 			warn(string.format("[LocalizationServiceUtils.promisePlayerTranslator] - %s", tostring(err)))
 		end
 

--- a/src/clienttranslator/src/Shared/Utils/LocalizationServiceUtils.lua
+++ b/src/clienttranslator/src/Shared/Utils/LocalizationServiceUtils.lua
@@ -65,7 +65,7 @@ function LocalizationServiceUtils.promisePlayerTranslator(player: Player)
 	end)
 
 	return promiseTranslator:Catch(function(err)
-		if err ~= ERROR_PUBLISH_REQUIRED and err ~= ERROR_TIMEOUT then
+		if err ~= ERROR_PUBLISH_REQUIRED and error ~= ERROR_TIMEOUT then
 			warn(string.format("[LocalizationServiceUtils.promisePlayerTranslator] - %s", tostring(err)))
 		end
 


### PR DESCRIPTION
`AnimationSlotPlayer` currently attempts playback even as targets are being destructed. In cases where the animator has already been destroyed, `HumanoidAnimatorUtils` needlessly creates a new one on the client, which produces a warning.

This checks if the animation target has a valid parent before attempting playback.