### PR TITLE
Fix: signal resuming dead thread causing error

### DIFF
--- a/src/signal/src/Shared/Signal.lua
+++ b/src/signal/src/Shared/Signal.lua
@@ -226,7 +226,9 @@ function Signal.Wait<T...>(self: Signal<T...>): T...
 	local connection: Connection<T...>
 	connection = (self :: any):Connect(function(...)
 		connection:Disconnect()
-		task.spawn(waitingCoroutine, ...)
+		if coroutine.status(waitingCoroutine) == "suspended" then
+			task.spawn(waitingCoroutine, ...)
+		end
 	end)
 
 	return coroutine.yield()


### PR DESCRIPTION
When calling `:Wait` and the yielding thread later gets cancelled, it will throw an error from trying to resume a dead coroutine. This is a fix for that. Additional info is explained in this video: https://youtu.be/yevAvHU3ewo.