### PR TITLE
feat(cli): add structured progress and failure context to reporting

### DIFF
--- a/tools/cli-output-helpers/src/reporting/composite-reporter.ts
+++ b/tools/cli-output-helpers/src/reporting/composite-reporter.ts
@@ -1,4 +1,4 @@
-import { type PackageResult, type Reporter, type JobPhase } from './reporter.js';
+import { type PackageResult, type Reporter, type JobPhase, type ProgressSummary } from './reporter.js';
 import { LiveStateTracker } from './state/live-state-tracker.js';
 
 /**
@@ -19,6 +19,10 @@ export class CompositeReporter implements Reporter {
     this._reporters = factory(this._state);
   }
 
+  get state(): LiveStateTracker {
+    return this._state;
+  }
+
   async startAsync(): Promise<void> {
     await this._state.startAsync();
     for (const r of this._reporters) {
@@ -37,6 +41,13 @@ export class CompositeReporter implements Reporter {
     this._state.onPackagePhaseChange(packageName, phase);
     for (const r of this._reporters) {
       r.onPackagePhaseChange(packageName, phase);
+    }
+  }
+
+  onPackageProgressUpdate(packageName: string, progress: ProgressSummary): void {
+    this._state.onPackageProgressUpdate(packageName, progress);
+    for (const r of this._reporters) {
+      r.onPackageProgressUpdate(packageName, progress);
     }
   }
 

--- a/tools/cli-output-helpers/src/reporting/github/comment-table-reporter.ts
+++ b/tools/cli-output-helpers/src/reporting/github/comment-table-reporter.ts
@@ -2,6 +2,7 @@ import { isCI } from '../../cli-utils.js';
 import {
   type PackageResult,
   type PackageStatus,
+  type ProgressSummary,
   BaseReporter,
 } from '../reporter.js';
 import { type IStateTracker } from '../state/state-tracker.js';
@@ -83,6 +84,10 @@ export class GithubCommentTableReporter extends BaseReporter {
     _name: string,
     _phase: PackageStatus
   ): void {
+    this._scheduleUpdate();
+  }
+
+  override onPackageProgressUpdate(_name: string, _progress: ProgressSummary): void {
     this._scheduleUpdate();
   }
 

--- a/tools/cli-output-helpers/src/reporting/index.ts
+++ b/tools/cli-output-helpers/src/reporting/index.ts
@@ -6,7 +6,19 @@ export {
   type PackageStatus,
   type PackageResult,
   type BatchSummary,
+  type ProgressSummary,
+  type TestCountProgress,
+  type ByteProgress,
+  type StepProgress,
 } from './reporter.js';
+
+// Progress formatting helpers
+export {
+  formatProgressInline,
+  formatProgressResult,
+  isEmptyTestRun,
+  summarizeFailure,
+} from './progress-format.js';
 
 // State tracking
 export {

--- a/tools/cli-output-helpers/src/reporting/progress-format.ts
+++ b/tools/cli-output-helpers/src/reporting/progress-format.ts
@@ -1,0 +1,97 @@
+/**
+ * Formatting helpers for ProgressSummary values.
+ */
+
+import { type ProgressSummary, type JobPhase } from './reporter.js';
+
+/**
+ * Format progress for inline display in spinners and running status.
+ * Returns empty string when progress is undefined.
+ *
+ * - test-counts: "(5/23)"
+ * - bytes: "12.3 MB" or "45%"
+ * - steps: "(3/10)"
+ */
+export function formatProgressInline(progress?: ProgressSummary): string {
+  if (!progress) return '';
+
+  switch (progress.kind) {
+    case 'test-counts':
+      return `(${progress.passed}/${progress.total})`;
+    case 'bytes':
+      if (progress.totalBytes > 0 && progress.transferredBytes > 0) {
+        return `(${_formatBytes(progress.transferredBytes)}/${_formatBytes(progress.totalBytes)})`;
+      }
+      return `(${_formatBytes(progress.totalBytes)})`;
+    case 'steps':
+      if (progress.total > 0) {
+        return `(${progress.completed}/${progress.total})`;
+      }
+      // Indeterminate: show label or just the count
+      return progress.label ? `(${progress.label})` : `(${progress.completed})`;
+  }
+}
+
+/**
+ * Format progress for final result display (passed/failed lines).
+ * Returns empty string when progress is undefined.
+ *
+ * - test-counts: "(23/100)" or "(0/0)"
+ * - bytes: "(12.3 MB)"
+ * - steps: "(3/10)"
+ */
+export function formatProgressResult(progress?: ProgressSummary): string {
+  if (!progress) return '';
+
+  switch (progress.kind) {
+    case 'test-counts':
+      return `(${progress.passed}/${progress.total})`;
+    case 'bytes':
+      return `(${_formatBytes(progress.totalBytes)})`;
+    case 'steps':
+      return `(${progress.completed}/${progress.total})`;
+  }
+}
+
+/** True when progress is test-counts with total === 0. */
+export function isEmptyTestRun(progress?: ProgressSummary): boolean {
+  return progress?.kind === 'test-counts' && progress.total === 0;
+}
+
+/**
+ * Condense a raw error string and optional failedPhase into a short one-liner.
+ *
+ * Examples:
+ *   summarizeFailure("Upload failed: 409 Conflict: {...}", "uploading")
+ *     → "at uploading: Upload failed (409)"
+ *   summarizeFailure("timeout after 120s", "executing")
+ *     → "at executing: timeout after 120s"
+ */
+export function summarizeFailure(
+  error?: string,
+  failedPhase?: JobPhase
+): string {
+  const parts: string[] = [];
+
+  if (failedPhase) {
+    parts.push(`at ${failedPhase}`);
+  }
+
+  if (error) {
+    const firstLine = error.split('\n')[0];
+    const short = firstLine.length > 60 ? firstLine.slice(0, 57) + '...' : firstLine;
+    if (parts.length > 0) {
+      parts.push(`: ${short}`);
+    } else {
+      parts.push(short);
+    }
+  }
+
+  return parts.join('');
+}
+
+function _formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/tools/cli-output-helpers/src/reporting/simple-reporter.ts
+++ b/tools/cli-output-helpers/src/reporting/simple-reporter.ts
@@ -1,6 +1,7 @@
 import { OutputHelper } from '../outputHelper.js';
 import { type PackageResult, BaseReporter } from './reporter.js';
 import { type IStateTracker } from './state/state-tracker.js';
+import { formatProgressResult } from './progress-format.js';
 
 export interface SimpleReporterOptions {
   alwaysShowLogs: boolean;
@@ -37,8 +38,10 @@ export class SimpleReporter extends BaseReporter {
       OutputHelper.info('(no output)');
     }
 
+    const progressText = formatProgressResult(result.progressSummary);
     if (result.success) {
-      OutputHelper.info(this._successMessage);
+      const msg = progressText ? `${this._successMessage} ${progressText}` : this._successMessage;
+      OutputHelper.info(msg);
     } else {
       OutputHelper.error(this._failureMessage);
     }

--- a/tools/cli-output-helpers/src/reporting/state/loaded-state-tracker.ts
+++ b/tools/cli-output-helpers/src/reporting/state/loaded-state-tracker.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises';
 import {
   type PackageResult,
+  type PackageStatus,
   type BatchSummary,
 } from '../reporter.js';
 import {
@@ -48,6 +49,7 @@ export class LoadedStateTracker implements IStateTracker {
         status: result.success ? 'passed' : 'failed',
         durationMs: result.durationMs,
         result,
+        progress: result.progressSummary,
       });
       if (!result.success) {
         failures.push(result);
@@ -91,5 +93,9 @@ export class LoadedStateTracker implements IStateTracker {
 
   getFailures(): PackageResult[] {
     return this._failures;
+  }
+
+  getCurrentPhase(name: string): PackageStatus | undefined {
+    return this._packages.get(name)?.status;
   }
 }

--- a/tools/cli-output-helpers/src/reporting/state/state-tracker.ts
+++ b/tools/cli-output-helpers/src/reporting/state/state-tracker.ts
@@ -1,4 +1,4 @@
-import { type PackageResult, type PackageStatus } from '../reporter.js';
+import { type PackageResult, type PackageStatus, type ProgressSummary } from '../reporter.js';
 
 export interface PackageState {
   name: string;
@@ -7,6 +7,7 @@ export interface PackageState {
   durationMs?: number;
   result?: PackageResult;
   bufferedOutput?: string[];
+  progress?: ProgressSummary;
 }
 
 /**
@@ -21,4 +22,5 @@ export interface IStateTracker {
   getAllPackages(): PackageState[];
   getResults(): PackageResult[];
   getFailures(): PackageResult[];
+  getCurrentPhase(name: string): PackageStatus | undefined;
 }

--- a/tools/cli-output-helpers/src/reporting/summary-table-reporter.ts
+++ b/tools/cli-output-helpers/src/reporting/summary-table-reporter.ts
@@ -2,6 +2,7 @@ import { OutputHelper } from '../outputHelper.js';
 import { formatDurationMs } from '../cli-utils.js';
 import { BaseReporter } from './reporter.js';
 import { type IStateTracker } from './state/state-tracker.js';
+import { formatProgressResult, isEmptyTestRun } from './progress-format.js';
 
 export interface SummaryTableReporterOptions {
   /** Label for successful results in the table. Default: "Passed" */
@@ -38,18 +39,43 @@ export class SummaryTableReporter extends BaseReporter {
     const passed = results.length - failures.length;
     const durationMs = Date.now() - this._state.startTimeMs;
 
-    console.log('');
-    console.log('Package'.padEnd(40) + 'Status'.padEnd(10) + 'Duration');
-    console.log('-'.repeat(60));
+    const STATUS_WIDTH = 26;
 
+    console.log('');
+    console.log('Package'.padEnd(40) + 'Status'.padEnd(STATUS_WIDTH) + 'Duration');
+    console.log('─'.repeat(40 + STATUS_WIDTH + 8));
+
+    let emptyRunCount = 0;
     for (const result of results) {
-      const status = result.success
-        ? OutputHelper.formatSuccess(this._successLabel)
-        : OutputHelper.formatError(this._failureLabel);
+      const progressText = formatProgressResult(result.progressSummary);
+      const empty = isEmptyTestRun(result.progressSummary);
+      if (empty) emptyRunCount++;
+
+      let label: string;
+      if (result.success) {
+        label = progressText ? `${this._successLabel} ${progressText}` : this._successLabel;
+      } else {
+        const failedPhase = result.failedPhase;
+        label = failedPhase
+          ? `${this._failureLabel} at ${failedPhase}`
+          : this._failureLabel;
+      }
+
+      // Pad the plain text BEFORE wrapping in ANSI so padEnd counts visible chars
+      const paddedLabel = label.padEnd(STATUS_WIDTH);
+      let status: string;
+      if (result.success) {
+        status = empty
+          ? OutputHelper.formatWarning(paddedLabel)
+          : OutputHelper.formatSuccess(paddedLabel);
+      } else {
+        status = OutputHelper.formatError(paddedLabel);
+      }
+
       const duration = OutputHelper.formatDim(
         formatDurationMs(result.durationMs)
       );
-      console.log(result.packageName.padEnd(40) + status.padEnd(20) + duration);
+      console.log(result.packageName.padEnd(40) + status + duration);
     }
 
     console.log('');
@@ -64,5 +90,13 @@ export class SummaryTableReporter extends BaseReporter {
     console.log(
       `${results.length} ${this._summaryVerb}, ${passedText}, ${failedText} ${totalTime}`
     );
+
+    if (emptyRunCount > 0) {
+      console.log(
+        OutputHelper.formatWarning(
+          `⚠ ${emptyRunCount} package(s) ran 0 tests — check test discovery`
+        )
+      );
+    }
   }
 }

--- a/tools/nevermore-cli/src/commands/batch-command/batch-deploy-command.ts
+++ b/tools/nevermore-cli/src/commands/batch-command/batch-deploy-command.ts
@@ -172,7 +172,7 @@ async function _runAsync(args: BatchDeployArgs): Promise<void> {
     apiKey,
     rateLimiter: new RateLimiter(),
   });
-  const context = new CloudJobContext(client);
+  const context = new CloudJobContext(reporter, client);
 
   await reporter.startAsync();
 
@@ -188,7 +188,6 @@ async function _runAsync(args: BatchDeployArgs): Promise<void> {
           targetName,
           outputFileName: publish ? 'publish.rbxl' : 'deploy.rbxl',
           packagePath: pkg.path,
-          reporter: pkgReporter,
           packageName: pkg.name,
         });
 

--- a/tools/nevermore-cli/src/commands/deploy-command/index.ts
+++ b/tools/nevermore-cli/src/commands/deploy-command/index.ts
@@ -168,7 +168,7 @@ export class DeployCommand<T> implements CommandModule<T, DeployArgs> {
 
     const apiKey = await getApiKeyAsync(args);
     const client = new OpenCloudClient({ apiKey, rateLimiter: new RateLimiter() });
-    const context = new CloudJobContext(client);
+    const context = new CloudJobContext(reporter, client);
 
     await reporter.startAsync();
 

--- a/tools/nevermore-cli/src/commands/test-command/test-command.ts
+++ b/tools/nevermore-cli/src/commands/test-command/test-command.ts
@@ -105,16 +105,17 @@ export class TestProjectCommand<T>
 
       const context = args.cloud
         ? new CloudJobContext(
+            reporter,
             new OpenCloudClient({
               apiKey: await getApiKeyAsync(args),
               rateLimiter: new RateLimiter(),
             })
           )
-        : new LocalJobContext();
+        : new LocalJobContext(reporter);
 
       let result;
       try {
-        result = await runSingleTestAsync(context, reporter, {
+        result = await runSingleTestAsync(context, {
           packagePath: cwd,
           packageName,
           scriptText: args.scriptText,
@@ -128,6 +129,9 @@ export class TestProjectCommand<T>
         success: result.success,
         logs: result.logs,
         durationMs: 0,
+        progressSummary: result.testCounts
+          ? { kind: 'test-counts', ...result.testCounts }
+          : undefined,
       });
 
       await reporter.stopAsync();

--- a/tools/nevermore-cli/src/utils/build/upload.ts
+++ b/tools/nevermore-cli/src/utils/build/upload.ts
@@ -33,11 +33,23 @@ export async function uploadPlaceAsync(
   const apiKey = await getApiKeyAsync(args);
 
   reporter?.onPackagePhaseChange(packageName ?? '', 'uploading');
+
+  const onProgress = reporter && packageName
+    ? (transferred: number, total: number) => {
+        reporter.onPackageProgressUpdate(packageName, {
+          kind: 'bytes',
+          transferredBytes: transferred,
+          totalBytes: total,
+        });
+      }
+    : undefined;
+
   const version = await client.uploadPlaceAsync(
     target.universeId,
     target.placeId,
     rbxlPath,
-    args.publish
+    args.publish,
+    onProgress
   );
 
   return { client, apiKey, target, version };

--- a/tools/nevermore-cli/src/utils/job-context/job-context.ts
+++ b/tools/nevermore-cli/src/utils/job-context/job-context.ts
@@ -1,4 +1,3 @@
-import { type Reporter } from '@quenty/cli-output-helpers/reporting';
 import { type BuildPlaceOptions, type BuiltPlace } from '../build/build.js';
 
 export type { BuiltPlace } from '../build/build.js';
@@ -32,10 +31,10 @@ export interface JobContext {
   buildPlaceAsync(options: BuildPlaceOptions): Promise<BuiltPlace>;
 
   /** Deploy a built place to the execution environment. Returns a handle for subsequent operations. */
-  deployBuiltPlaceAsync(reporter: Reporter, options: DeployPlaceOptions): Promise<Deployment>;
+  deployBuiltPlaceAsync(options: DeployPlaceOptions): Promise<Deployment>;
 
   /** Execute a Luau script in a deployed place. */
-  runScriptAsync(deployment: Deployment, reporter: Reporter, options: RunScriptOptions): Promise<ScriptRunResult>;
+  runScriptAsync(deployment: Deployment, options: RunScriptOptions): Promise<ScriptRunResult>;
 
   /** Retrieve raw logs from the most recent script execution on this deployment. */
   getLogsAsync(deployment: Deployment): Promise<string>;

--- a/tools/nevermore-cli/src/utils/job-context/local-job-context.ts
+++ b/tools/nevermore-cli/src/utils/job-context/local-job-context.ts
@@ -24,12 +24,11 @@ class LocalDeployment implements Deployment {
 export class LocalJobContext extends BaseJobContext {
   private _deployments = new Set<LocalDeployment>();
 
-  constructor(openCloudClient?: OpenCloudClient) {
-    super(openCloudClient);
+  constructor(reporter: Reporter, openCloudClient?: OpenCloudClient) {
+    super(reporter, openCloudClient);
   }
 
   async deployBuiltPlaceAsync(
-    reporter: Reporter,
     options: DeployPlaceOptions
   ): Promise<Deployment> {
     const { builtPlace, packageName } = options;
@@ -38,7 +37,7 @@ export class LocalJobContext extends BaseJobContext {
       placePath: builtPlace.rbxlPath,
       onPhase: (phase) => {
         if (phase === 'launching' || phase === 'connecting') {
-          reporter.onPackagePhaseChange(packageName, phase);
+          this._reporter.onPackagePhaseChange(packageName, phase);
         }
       },
     });
@@ -52,13 +51,12 @@ export class LocalJobContext extends BaseJobContext {
 
   async runScriptAsync(
     deployment: Deployment,
-    reporter: Reporter,
     options: RunScriptOptions
   ): Promise<ScriptRunResult> {
     const localDeployment = deployment as LocalDeployment;
     const { scriptContent, packageName, timeoutMs } = options;
 
-    reporter.onPackagePhaseChange(packageName, 'executing');
+    this._reporter.onPackagePhaseChange(packageName, 'executing');
 
     try {
       const result = await localDeployment.bridge.executeAsync({

--- a/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.ts
+++ b/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.ts
@@ -1,9 +1,11 @@
 import { OutputHelper } from '@quenty/cli-output-helpers';
+import { type ParsedTestCounts, parseTestCounts } from '../test-log-parser.js';
 
 export interface BatchPackageResult {
   slug: string;
   success: boolean;
   logs: string;
+  testCounts?: ParsedTestCounts;
 }
 
 const BEGIN_MARKER = '===BATCH_TEST_BEGIN ';
@@ -136,7 +138,8 @@ export function parseBatchTestLogs(
       );
     }
 
-    results.set(packageName, { slug, success, logs: sectionLogs });
+    const testCounts = sectionLogs ? parseTestCounts(sectionLogs) : undefined;
+    results.set(packageName, { slug, success, logs: sectionLogs, testCounts });
   }
 
   return results;

--- a/tools/nevermore-cli/src/utils/testing/test-log-parser.ts
+++ b/tools/nevermore-cli/src/utils/testing/test-log-parser.ts
@@ -1,8 +1,15 @@
 import { OutputHelper } from '@quenty/cli-output-helpers';
 
+export interface ParsedTestCounts {
+  passed: number;
+  failed: number;
+  total: number;
+}
+
 export interface ParsedTestLogs {
   success: boolean;
   logs: string;
+  testCounts?: ParsedTestCounts;
 }
 
 /**
@@ -25,5 +32,31 @@ export function parseTestLogs(rawOutput: string): ParsedTestLogs {
   return {
     success: !hasJestFailures && !hasRuntimeError,
     logs: rawOutput,
+    testCounts: parseTestCounts(rawOutput),
   };
+}
+
+/**
+ * Parse Jest "Tests: N failed, N passed, N total" line into structured counts.
+ * Returns undefined if no test summary line is found.
+ */
+export function parseTestCounts(rawOutput: string): ParsedTestCounts | undefined {
+  const clean = OutputHelper.stripAnsi(rawOutput);
+
+  // Match "Tests:  2 failed, 23 passed, 25 total" or "Tests:  25 passed, 25 total"
+  const match = clean.match(/Tests:\s+(.+?)\s+total/);
+  if (!match) return undefined;
+
+  const prefix = match[1];
+  const totalMatch = clean.match(/Tests:\s+.+?(\d+)\s+total/);
+  if (!totalMatch) return undefined;
+
+  const total = parseInt(totalMatch[1], 10);
+  const passedMatch = prefix.match(/(\d+)\s+passed/);
+  const failedMatch = prefix.match(/(\d+)\s+failed/);
+
+  const passed = passedMatch ? parseInt(passedMatch[1], 10) : 0;
+  const failed = failedMatch ? parseInt(failedMatch[1], 10) : 0;
+
+  return { passed, failed, total };
 }

--- a/tools/nevermore-cli/templates/batch-test-runner.luau
+++ b/tools/nevermore-cli/templates/batch-test-runner.luau
@@ -84,15 +84,6 @@ for _, slug in packageSlugs do
 	-- the marker in the log stream.
 	RunService.Heartbeat:Wait()
 
-	if testOk then
-		print("===BATCH_TEST_END " .. slug .. " PASS===")
-		table.insert(results, { slug = slug, success = true })
-	else
-		warn("[BatchTest] " .. slug .. ": " .. tostring(testErr))
-		print("===BATCH_TEST_END " .. slug .. " FAIL===")
-		table.insert(results, { slug = slug, success = false, error = tostring(testErr) })
-	end
-
 	-- CLEANUP: restore service state
 	allPackages[slug].Parent = nil
 	for _, c in workspace:GetChildren() do
@@ -118,6 +109,15 @@ for _, slug in packageSlugs do
 	-- time wait, since each frame drains its deferred queue.
 	for _ = 1, 3 do
 		RunService.Heartbeat:Wait()
+	end
+
+	if testOk then
+		print("===BATCH_TEST_END " .. slug .. " PASS===")
+		table.insert(results, { slug = slug, success = true })
+	else
+		warn("[BatchTest] " .. slug .. ": " .. tostring(testErr))
+		print("===BATCH_TEST_END " .. slug .. " FAIL===")
+		table.insert(results, { slug = slug, success = false, error = tostring(testErr) })
 	end
 end
 


### PR DESCRIPTION
Reporters now show test counts, upload byte progress, and build step progress inline. Failures are attributed to the phase where they occurred (e.g. "FAILED at uploading") instead of showing raw error strings. Streaming upload progress uses ReadableStream chunks for real-time byte reporting, and Open Cloud poll states are surfaced during the executing phase.

Also moves parseTestCounts into runSingleTestAsync so both single and batch test commands get test count reporting without duplication.