### PR TITLE
feat: Expand ModelTransparencyEffect support

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2930,6 +2930,12 @@ importers:
       '@quenty/baseobject':
         specifier: workspace:*
         version: link:../baseobject
+      '@quenty/hide':
+        specifier: workspace:*
+        version: link:../hide
+      '@quenty/instanceutils':
+        specifier: workspace:*
+        version: link:../instanceutils
       '@quenty/loader':
         specifier: workspace:*
         version: link:../loader

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2930,6 +2930,9 @@ importers:
       '@quenty/baseobject':
         specifier: workspace:*
         version: link:../baseobject
+      '@quenty/enums':
+        specifier: workspace:*
+        version: link:../enums
       '@quenty/hide':
         specifier: workspace:*
         version: link:../hide

--- a/src/modeltransparencyeffect/package.json
+++ b/src/modeltransparencyeffect/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@quenty/acceltween": "workspace:*",
     "@quenty/baseobject": "workspace:*",
+    "@quenty/enums": "workspace:*",
     "@quenty/hide": "workspace:*",
     "@quenty/instanceutils": "workspace:*",
     "@quenty/loader": "workspace:*",

--- a/src/modeltransparencyeffect/package.json
+++ b/src/modeltransparencyeffect/package.json
@@ -30,6 +30,8 @@
   "dependencies": {
     "@quenty/acceltween": "workspace:*",
     "@quenty/baseobject": "workspace:*",
+    "@quenty/hide": "workspace:*",
+    "@quenty/instanceutils": "workspace:*",
     "@quenty/loader": "workspace:*",
     "@quenty/servicebag": "workspace:*",
     "@quenty/steputils": "workspace:*",

--- a/src/modeltransparencyeffect/src/Client/ModelTransparencyEffect.lua
+++ b/src/modeltransparencyeffect/src/Client/ModelTransparencyEffect.lua
@@ -1,6 +1,6 @@
 --!nonstrict
 --[=[
-	Allows a model to have transparent set locally on the client
+	Allows a model to have transparency set locally on the client
 
 	@client
 	@class ModelTransparencyEffect
@@ -11,6 +11,7 @@ local require = require(script.Parent.loader).load(script)
 local AccelTween = require("AccelTween")
 local BaseObject = require("BaseObject")
 local HideUtils = require("HideUtils")
+local ModelTransparencyMode = require("ModelTransparencyMode")
 local RxInstanceUtils = require("RxInstanceUtils")
 local ServiceBag = require("ServiceBag")
 local StepUtils = require("StepUtils")
@@ -20,15 +21,13 @@ local ModelTransparencyEffect = setmetatable({}, BaseObject)
 ModelTransparencyEffect.ClassName = "ModelTransparencyEffect"
 ModelTransparencyEffect.__index = ModelTransparencyEffect
 
-export type TransparencyMode = "SetTransparency" | "SetLocalTransparencyModifier"
-
 export type ModelTransparencyEffect =
 	typeof(setmetatable(
 		{} :: {
 			_serviceBag: ServiceBag.ServiceBag,
 			_transparency: AccelTween.AccelTween,
 			_transparencyService: TransparencyService.TransparencyService,
-			_transparencyServiceMethodName: TransparencyMode,
+			_transparencyServiceMethodName: ModelTransparencyMode.ModelTransparencyMode,
 			_parts: { [Instance]: boolean },
 			_startAnimation: (self: ModelTransparencyEffect) -> (),
 		},
@@ -45,7 +44,7 @@ export type ModelTransparencyEffect =
 function ModelTransparencyEffect.new(
 	serviceBag: ServiceBag.ServiceBag,
 	adornee: Instance,
-	transparencyServiceMethodName: TransparencyMode?
+	transparencyServiceMethodName: ModelTransparencyMode.ModelTransparencyMode?
 ): ModelTransparencyEffect
 	assert(adornee, "Bad adornee")
 
@@ -54,14 +53,14 @@ function ModelTransparencyEffect.new(
 	self._serviceBag = assert(serviceBag, "No serviceBag")
 
 	assert(
-		type(transparencyServiceMethodName) == "string" or transparencyServiceMethodName == nil,
+		ModelTransparencyMode:IsValue(transparencyServiceMethodName) or transparencyServiceMethodName == nil,
 		"Bad transparencyServiceMethodName"
 	)
 
 	self._transparencyService = self._serviceBag:GetService(TransparencyService :: any)
 
 	self._transparency = AccelTween.new(20)
-	self._transparencyServiceMethodName = transparencyServiceMethodName or "SetTransparency"
+	self._transparencyServiceMethodName = transparencyServiceMethodName or ModelTransparencyMode.TRANSPARENCY
 
 	self._startAnimation, self._maid._stop = StepUtils.bindToRenderStep(self._update)
 
@@ -157,11 +156,10 @@ function ModelTransparencyEffect._setupParts(self: ModelTransparencyEffect)
 
 	self._parts = {}
 
-	local usingLocalTransparency = (self._transparencyServiceMethodName == "SetLocalTransparencyModifier")
 	local transparencyServiceMethod = self._transparencyService[self._transparencyServiceMethodName]
 
 	local function canHide(part: Instance): boolean
-		return if usingLocalTransparency
+		return if (self._transparencyServiceMethodName == ModelTransparencyMode.LOCAL_TRANSPARENCY)
 			then HideUtils.hasLocalTransparencyModifier(part)
 			else (part:IsA("BasePart") or part:IsA("Decal"))
 	end

--- a/src/modeltransparencyeffect/src/Client/ModelTransparencyEffect.lua
+++ b/src/modeltransparencyeffect/src/Client/ModelTransparencyEffect.lua
@@ -10,6 +10,8 @@ local require = require(script.Parent.loader).load(script)
 
 local AccelTween = require("AccelTween")
 local BaseObject = require("BaseObject")
+local HideUtils = require("HideUtils")
+local RxInstanceUtils = require("RxInstanceUtils")
 local ServiceBag = require("ServiceBag")
 local StepUtils = require("StepUtils")
 local TransparencyService = require("TransparencyService")
@@ -155,32 +157,37 @@ function ModelTransparencyEffect._setupParts(self: ModelTransparencyEffect)
 
 	self._parts = {}
 
-	if self._obj:IsA("BasePart") or self._obj:IsA("Decal") then
+	local usingLocalTransparency = (self._transparencyServiceMethodName == "SetLocalTransparencyModifier")
+	local transparencyServiceMethod = self._transparencyService[self._transparencyServiceMethodName]
+
+	local function canHide(part: Instance): boolean
+		return if usingLocalTransparency
+			then HideUtils.hasLocalTransparencyModifier(part)
+			else (part:IsA("BasePart") or part:IsA("Decal"))
+	end
+
+	if canHide(self._obj) then
 		self._parts[self._obj] = true
 	end
 
-	for _, part in self._obj:GetDescendants() do
-		if part:IsA("BasePart") or part:IsA("Decal") then
-			self._parts[part] = true
-		end
-	end
-
-	self._maid:GiveTask(self._obj.DescendantAdded:Connect(function(child)
-		if child:IsA("BasePart") or child:IsA("Decal") then
-			self._parts[child] = true
-			self:_startAnimation()
-		end
-	end))
-
-	self._maid:GiveTask(self._obj.DescendantRemoving:Connect(function(child)
-		if self._transparencyService:IsDead() then
+	self._maid:GiveTask(RxInstanceUtils.observeDescendantsBrio(self._obj, canHide):Subscribe(function(brio)
+		if brio:IsDead() then
 			return
 		end
 
-		if self._parts[child] then
-			self._parts[child] = nil
-			self._transparencyService[self._transparencyServiceMethodName](self._transparencyService, self, child, nil)
-		end
+		local maid, part = brio:ToMaidAndValue()
+
+		self._parts[part] = true
+		self:_startAnimation()
+
+		maid:GiveTask(function()
+			if self._transparencyService:IsDead() or not self._parts[part] then
+				return
+			end
+
+			self._parts[part] = nil
+			transparencyServiceMethod(self._transparencyService, self, part, nil)
+		end)
 	end))
 
 	self._maid:GiveTask(function()
@@ -188,8 +195,8 @@ function ModelTransparencyEffect._setupParts(self: ModelTransparencyEffect)
 			return
 		end
 
-		for part, _ in self._parts do
-			self._transparencyService[self._transparencyServiceMethodName](self._transparencyService, self, part, nil)
+		for part in self._parts do
+			transparencyServiceMethod(self._transparencyService, self, part, nil)
 		end
 	end)
 end

--- a/src/modeltransparencyeffect/src/Shared/ModelTransparencyMode.lua
+++ b/src/modeltransparencyeffect/src/Shared/ModelTransparencyMode.lua
@@ -1,0 +1,15 @@
+--!strict
+--[=[
+	@class ModelTransparencyMode
+]=]
+
+local require = require(script.Parent.loader).load(script)
+
+local SimpleEnum = require("SimpleEnum")
+
+export type ModelTransparencyMode = "SetTransparency" | "SetLocalTransparencyModifier"
+
+return SimpleEnum.new({
+	TRANSPARENCY = "SetTransparency" :: "SetTransparency",
+	LOCAL_TRANSPARENCY = "SetLocalTransparencyModifier" :: "SetLocalTransparencyModifier",
+})


### PR DESCRIPTION
Currently, `ModelTransparencyEffect` only supports parts and decals. This leads to awkward scenarios like particle emitters showing while characters are hidden.

When the effect is defined with a `transparencyServiceMethodName` of "SetLocalTransparencyModifier", this change applies the effect to all instances with a `LocalTransparencyModifier` property.