### PR TITLE
fix: Prevent input rebind oscillation

### DIFF
--- a/src/settings/src/Client/Player/PlayerSettingsClient.lua
+++ b/src/settings/src/Client/Player/PlayerSettingsClient.lua
@@ -152,7 +152,11 @@ function PlayerSettingsClient.ObserveValue<T>(
 			end
 		end
 
-		maid:GiveTask(self._pendingReplicationDataInTransit.Changed:Connect(update))
+		maid:GiveTask(self._pendingReplicationDataInTransit.Changed:Connect(function(newValue)
+			if newValue ~= nil then
+				update()
+			end
+		end))
 
 		self._toReplicateCallbacks[settingName] = self._toReplicateCallbacks[settingName] or {}
 		self._toReplicateCallbacks[settingName][update] = true


### PR DESCRIPTION
In deferred signal mode, rebinding inputs in the settings menu causes key maps to perpetually switch between old and new values. This change prevents a seemingly unnecessary update from firing `PlayerSettingsClient.ObserveValue` subscriptions with a stale value.