### PR TITLE
Improve `nevermore deploy` error reporting and `nevermore init` to include deployment and tests as part of the template

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,6 @@ jobs:
           filter: 'blob:none'        # skip historical blobs to speed checkout
           persist-credentials: false # https://stackoverflow.com/questions/74744498/github-pushing-to-protected-branches-with-fine-grained-token
 
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '21'
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,11 +12,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '21'
-
       - run: npm i -g moonwave@latest
       - name: Publish
         run: |

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -8,7 +8,7 @@ jobs:
     name: Release Extension
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - run: npm ci
         working-directory: tools/nevermore-vscode

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,11 +11,6 @@ jobs:
       - name: Fetch base branch for changeset diff
         run: git fetch origin ${{ github.base_ref }} --depth=1
 
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '21'
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/studio-linux-ci.yml
+++ b/.github/workflows/studio-linux-ci.yml
@@ -206,6 +206,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          cache: true
 
       - name: Setup registries
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: tests
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -8,12 +11,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Fetch base branch for changeset diff
+        if: github.event_name == 'pull_request'
         run: git fetch origin ${{ github.base_ref }} --depth=1
-
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '21'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -49,7 +48,7 @@ jobs:
 
       - name: Run tests
         id: run-tests
-        run: nevermore batch test --cloud --aggregated --base origin/${{ github.base_ref }} --output test-results.json --yes --verbose --logs
+        run: nevermore batch test --cloud --aggregated ${{ github.event_name == 'pull_request' && format('--base origin/{0}', github.base_ref) || '' }} --output test-results.json --yes --verbose --logs
         env:
           ROBLOX_OPEN_CLOUD_API_KEY: ${{ secrets.ROBLOX_UNIT_TEST_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -23,11 +23,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '21'
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -61,11 +56,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '21'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+**/deploy.nevermore.json @quenty

--- a/tools/cli-output-helpers/src/outputHelper.test.ts
+++ b/tools/cli-output-helpers/src/outputHelper.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { OutputHelper } from './outputHelper.js';
+
+describe('OutputHelper.formatErrorChain', () => {
+  const originalVerbose = OutputHelper.isVerbose();
+
+  afterEach(() => {
+    OutputHelper.setVerbose(originalVerbose);
+  });
+
+  it('returns String(value) for non-Error inputs', () => {
+    expect(OutputHelper.formatErrorChain('boom')).toBe('boom');
+    expect(OutputHelper.formatErrorChain(42)).toBe('42');
+    expect(OutputHelper.formatErrorChain(null)).toBe('null');
+  });
+
+  it('returns just the message for a bare Error in non-verbose mode', () => {
+    OutputHelper.setVerbose(false);
+    expect(OutputHelper.formatErrorChain(new Error('nope'))).toBe('nope');
+  });
+
+  it('walks .cause chain (the undici fetch-failed case)', () => {
+    OutputHelper.setVerbose(false);
+    const cause = new Error('ECONNRESET');
+    const err = new Error('fetch failed', { cause });
+    expect(OutputHelper.formatErrorChain(err)).toBe(
+      'fetch failed\n  caused by: ECONNRESET'
+    );
+  });
+
+  it('walks multiple nested causes', () => {
+    OutputHelper.setVerbose(false);
+    const inner = new Error('socket hang up');
+    const mid = new Error('Connect Timeout Error', { cause: inner });
+    const outer = new Error('fetch failed', { cause: mid });
+    expect(OutputHelper.formatErrorChain(outer)).toBe(
+      'fetch failed\n  caused by: Connect Timeout Error\n  caused by: socket hang up'
+    );
+  });
+
+  it('stops at non-Error cause values', () => {
+    OutputHelper.setVerbose(false);
+    const err = new Error('outer', { cause: 'plain string' });
+    expect(OutputHelper.formatErrorChain(err)).toBe('outer');
+  });
+
+  it('does not loop on self-referential cause cycles', () => {
+    OutputHelper.setVerbose(false);
+    const a: Error & { cause?: unknown } = new Error('a');
+    const b: Error & { cause?: unknown } = new Error('b');
+    a.cause = b;
+    b.cause = a;
+    expect(OutputHelper.formatErrorChain(a)).toBe('a\n  caused by: b');
+  });
+
+  it('first line stays the head message so summarizeError-style trimming still works', () => {
+    OutputHelper.setVerbose(false);
+    const err = new Error('fetch failed', { cause: new Error('whatever') });
+    const firstLine = OutputHelper.formatErrorChain(err).split('\n')[0];
+    expect(firstLine).toBe('fetch failed');
+  });
+
+  it('appends the stack in verbose mode', () => {
+    OutputHelper.setVerbose(true);
+    const err = new Error('boom');
+    const out = OutputHelper.formatErrorChain(err);
+    expect(out.startsWith('boom\n')).toBe(true);
+    expect(out).toContain(err.stack!);
+  });
+});

--- a/tools/cli-output-helpers/src/outputHelper.ts
+++ b/tools/cli-output-helpers/src/outputHelper.ts
@@ -117,6 +117,25 @@ export class OutputHelper {
     console.error(this._hasAnsi(message) ? message : this.formatError(message));
   }
 
+  /** Format an error including its `.cause` chain. Appends the stack in verbose mode. */
+  public static formatErrorChain(err: unknown): string {
+    if (!(err instanceof Error)) return String(err);
+
+    const parts = [err.message];
+    const seen = new Set<unknown>([err]);
+    let cur: unknown = (err as { cause?: unknown }).cause;
+    while (cur instanceof Error && !seen.has(cur)) {
+      seen.add(cur);
+      parts.push(`  caused by: ${cur.message}`);
+      cur = (cur as { cause?: unknown }).cause;
+    }
+
+    if (this._verbose && err.stack) {
+      parts.push('', err.stack);
+    }
+    return parts.join('\n');
+  }
+
   /**
    * Logs information to the console
    * @param message Message to write

--- a/tools/cli-output-helpers/src/reporting/simple-reporter.ts
+++ b/tools/cli-output-helpers/src/reporting/simple-reporter.ts
@@ -6,7 +6,10 @@ import {
   BaseReporter,
 } from './reporter.js';
 import { type IStateTracker } from './state/state-tracker.js';
-import { formatProgressInline, formatProgressResult } from './progress-format.js';
+import {
+  formatProgressInline,
+  formatProgressResult,
+} from './progress-format.js';
 
 export interface SimpleReporterOptions {
   alwaysShowLogs: boolean;

--- a/tools/cli-output-helpers/src/reporting/simple-reporter.ts
+++ b/tools/cli-output-helpers/src/reporting/simple-reporter.ts
@@ -1,10 +1,20 @@
 import { OutputHelper } from '../outputHelper.js';
-import { type PackageResult, BaseReporter } from './reporter.js';
+import {
+  type JobPhase,
+  type PackageResult,
+  type ProgressSummary,
+  BaseReporter,
+} from './reporter.js';
 import { type IStateTracker } from './state/state-tracker.js';
-import { formatProgressResult } from './progress-format.js';
+import { formatProgressInline, formatProgressResult } from './progress-format.js';
 
 export interface SimpleReporterOptions {
   alwaysShowLogs: boolean;
+  /**
+   * When true, every package lifecycle event prints a `[name] status` line.
+   * Default false — only the final result is printed.
+   */
+  verbose?: boolean;
   /** Message shown on success. Default: "Completed!" */
   successMessage?: string;
   /** Message shown on failure. Default: "Failed!" */
@@ -18,15 +28,54 @@ export interface SimpleReporterOptions {
 export class SimpleReporter extends BaseReporter {
   private _state: IStateTracker;
   private _alwaysShowLogs: boolean;
+  private _verbose: boolean;
   private _successMessage: string;
   private _failureMessage: string;
+  private _lastVerboseLine: string | undefined;
 
   constructor(state: IStateTracker, options: SimpleReporterOptions) {
     super();
     this._state = state;
     this._alwaysShowLogs = options.alwaysShowLogs;
+    this._verbose = options.verbose ?? false;
     this._successMessage = options.successMessage ?? 'Completed!';
     this._failureMessage = options.failureMessage ?? 'Failed!';
+  }
+
+  override onPackageStart(name: string): void {
+    this._logVerbose(name, 'started');
+  }
+
+  override onPackagePhaseChange(name: string, phase: JobPhase): void {
+    this._logVerbose(name, phase);
+  }
+
+  override onPackageProgressUpdate(
+    name: string,
+    progress: ProgressSummary
+  ): void {
+    // Strip the surrounding parens formatProgressInline adds for spinner use.
+    const status = formatProgressInline(progress).replace(/^\(|\)$/g, '');
+    if (!status) return;
+
+    // Prefix with the active phase so progress lines read as
+    // "[pkg] uploading 1.2 MB/2.0 MB" instead of just "[pkg] 1.2 MB/2.0 MB".
+    const phase = this._state.getCurrentPhase(name);
+    const labeled =
+      phase && phase !== 'pending' && phase !== 'passed' && phase !== 'failed'
+        ? `${phase} ${status}`
+        : status;
+    this._logVerbose(name, labeled);
+  }
+
+  // Dedupes consecutive identical lines so high-frequency byte/poll updates
+  // that happen to render to the same string don't spam.
+  private _logVerbose(name: string, status: string): void {
+    if (!this._verbose) return;
+    const line = `[${name}] ${status}`;
+    if (line === this._lastVerboseLine) return;
+    this._lastVerboseLine = line;
+    OutputHelper.info(line);
   }
 
   override onPackageResult(result: PackageResult): void {

--- a/tools/nevermore-cli/src/commands/batch-command/batch-deploy-command.ts
+++ b/tools/nevermore-cli/src/commands/batch-command/batch-deploy-command.ts
@@ -179,6 +179,7 @@ async function _runAsync(args: BatchDeployArgs): Promise<void> {
 
   await reporter.startAsync();
 
+  let exitCode = 0;
   try {
     const results = await runBatchAsync<BatchDeployResult>({
       packages,
@@ -239,13 +240,16 @@ async function _runAsync(args: BatchDeployArgs): Promise<void> {
         };
       },
     });
-
-    await reporter.stopAsync();
-
-    process.exit(results.summary.failed > 0 ? 1 : 0);
+    if (results.summary.failed > 0) exitCode = 1;
+  } catch (err) {
+    OutputHelper.error(err instanceof Error ? err.message : String(err));
+    exitCode = 1;
   } finally {
     await context.disposeAsync();
   }
+
+  await reporter.stopAsync();
+  process.exit(exitCode);
 }
 
 function _annotateSmokeTestFailure(logs: string): string {

--- a/tools/nevermore-cli/src/commands/batch-command/batch-test-command.ts
+++ b/tools/nevermore-cli/src/commands/batch-command/batch-test-command.ts
@@ -50,6 +50,7 @@ interface BatchTestArgs extends NevermoreGlobalArgs {
   aggregated?: boolean;
   batchPlaceId?: number;
   batchUniverseId?: number;
+  timeout?: number;
 }
 
 export const batchTestCommand: CommandModule<
@@ -110,6 +111,11 @@ export const batchTestCommand: CommandModule<
       .option('batch-universe-id', {
         describe:
           'Override universeId for the aggregated batch upload (--aggregated only)',
+        type: 'number',
+      })
+      .option('timeout', {
+        describe:
+          'Per-package script execution time in seconds. Sent to the Open Cloud API so Roblox cancels server-side on overrun (default: 120)',
         type: 'number',
       });
   },
@@ -199,7 +205,7 @@ async function _runAsync(args: BatchTestArgs): Promise<void> {
     });
   }
 
-  const timeoutMs = 120_000;
+  const timeoutMs = (args.timeout ?? 120) * 1000;
 
   // In aggregated mode, the inner context gets a broadcast reporter that translates
   // phase changes from the shared '_batch_' operation to all real packages

--- a/tools/nevermore-cli/src/commands/batch-command/batch-test-command.ts
+++ b/tools/nevermore-cli/src/commands/batch-command/batch-test-command.ts
@@ -24,7 +24,6 @@ import {
 import {
   type LiveStateTracker,
   type BatchTestResult,
-  type BatchTestSummary,
   CompositeReporter,
   GithubCommentTableReporter,
   GroupedReporter,
@@ -222,9 +221,10 @@ async function _runAsync(args: BatchTestArgs): Promise<void> {
     : innerContext;
 
   await reporter.startAsync();
-  let results: BatchTestSummary;
+
+  let exitCode = 0;
   try {
-    results = await runBatchAsync<BatchTestResult>({
+    const results = await runBatchAsync<BatchTestResult>({
       packages,
       concurrency,
       reporter,
@@ -248,6 +248,10 @@ async function _runAsync(args: BatchTestArgs): Promise<void> {
         };
       },
     });
+    if (results.summary.failed > 0) exitCode = 1;
+  } catch (err) {
+    OutputHelper.error(err instanceof Error ? err.message : String(err));
+    exitCode = 1;
   } finally {
     await context.disposeAsync();
   }
@@ -256,7 +260,7 @@ async function _runAsync(args: BatchTestArgs): Promise<void> {
 
   // Node.js fetch (undici) keeps TCP connections alive in a global pool,
   // which prevents the event loop from draining. Explicit exit required.
-  process.exit(results.summary.failed > 0 ? 1 : 0);
+  process.exit(exitCode);
 }
 
 async function _runWithRetryAsync(

--- a/tools/nevermore-cli/src/commands/batch-command/batch-test-command.ts
+++ b/tools/nevermore-cli/src/commands/batch-command/batch-test-command.ts
@@ -250,7 +250,7 @@ async function _runAsync(args: BatchTestArgs): Promise<void> {
     });
     if (results.summary.failed > 0) exitCode = 1;
   } catch (err) {
-    OutputHelper.error(err instanceof Error ? err.message : String(err));
+    OutputHelper.error(OutputHelper.formatErrorChain(err));
     exitCode = 1;
   } finally {
     await context.disposeAsync();

--- a/tools/nevermore-cli/src/commands/deploy-command/index.ts
+++ b/tools/nevermore-cli/src/commands/deploy-command/index.ts
@@ -16,12 +16,8 @@ import { OpenCloudClient } from '../../utils/open-cloud/open-cloud-client.js';
 import { RateLimiter } from '../../utils/open-cloud/rate-limiter.js';
 import { CloudJobContext } from '../../utils/job-context/cloud-job-context.js';
 import { readPackageNameAsync } from '../../utils/nevermore-cli-utils.js';
-import {
-  loadDeployConfigAsync,
-  resolveDefaultTargetName,
-  resolveDeployConfigPath,
-} from '../../utils/build/deploy-config.js';
 import { handleInitAsync } from './deploy-init.js';
+import { selectTargetAsync } from './select-target.js';
 
 export interface DeployArgs extends NevermoreGlobalArgs {
   apiKey?: string;
@@ -158,15 +154,11 @@ export class DeployCommand<T> implements CommandModule<T, DeployArgs> {
     const cwd = process.cwd();
     const packageName = (await readPackageNameAsync(cwd)) ?? path.basename(cwd);
 
-    let targetName: string;
-    let targetAutoDetected = false;
-    if (args.target) {
-      targetName = args.target;
-    } else {
-      const config = await loadDeployConfigAsync(resolveDeployConfigPath(cwd));
-      targetName = resolveDefaultTargetName(config);
-      targetAutoDetected = true;
-    }
+    const { targetName, autoDetected: targetAutoDetected } =
+      await selectTargetAsync(cwd, {
+        explicitTarget: args.target,
+        publish: args.publish ?? false,
+      });
 
     const useSpinner = process.stdout.isTTY && !args.verbose;
     const showLogs = args.logs ?? false;

--- a/tools/nevermore-cli/src/commands/deploy-command/index.ts
+++ b/tools/nevermore-cli/src/commands/deploy-command/index.ts
@@ -219,6 +219,8 @@ export class DeployCommand<T> implements CommandModule<T, DeployArgs> {
     const startMs = Date.now();
     reporter.onPackageStart(packageName);
 
+    let exitCode = 0;
+    let publishedVersion: number | undefined;
     try {
       const builtPlace = await context.buildPlaceAsync({
         targetName,
@@ -235,6 +237,7 @@ export class DeployCommand<T> implements CommandModule<T, DeployArgs> {
         reporter,
         packageName,
       });
+      publishedVersion = version;
 
       const durationMs = Date.now() - startMs;
       const action = args.publish ? 'Published' : 'Saved';
@@ -245,13 +248,6 @@ export class DeployCommand<T> implements CommandModule<T, DeployArgs> {
         durationMs,
         progressSummary: { kind: 'version', version },
       });
-
-      if (args.publish) {
-        OutputHelper.info(`Published v${version} — live in game.`);
-      } else {
-        OutputHelper.info(`Saved v${version} — not yet live.`);
-        OutputHelper.hint('Use --publish to make it live in game.');
-      }
     } catch (err) {
       const durationMs = Date.now() - startMs;
       const errorMessage = err instanceof Error ? err.message : String(err);
@@ -263,13 +259,22 @@ export class DeployCommand<T> implements CommandModule<T, DeployArgs> {
         durationMs,
         error: errorMessage,
       });
-
-      await reporter.stopAsync();
-      throw err;
+      exitCode = 1;
     } finally {
       await context.disposeAsync();
     }
 
     await reporter.stopAsync();
+
+    if (publishedVersion !== undefined) {
+      if (args.publish) {
+        OutputHelper.info(`Published v${publishedVersion} — live in game.`);
+      } else {
+        OutputHelper.info(`Saved v${publishedVersion} — not yet live.`);
+        OutputHelper.hint('Use --publish to make it live in game.');
+      }
+    }
+
+    if (exitCode !== 0) process.exit(exitCode);
   }
 }

--- a/tools/nevermore-cli/src/commands/deploy-command/select-target.ts
+++ b/tools/nevermore-cli/src/commands/deploy-command/select-target.ts
@@ -1,0 +1,80 @@
+import inquirer from 'inquirer';
+import {
+  type DeployConfig,
+  loadDeployConfigAsync,
+  resolveDefaultTargetName,
+  resolveDeployConfigPath,
+} from '../../utils/build/deploy-config.js';
+
+export interface SelectTargetOptions {
+  explicitTarget?: string;
+  publish: boolean;
+}
+
+export interface SelectTargetResult {
+  targetName: string;
+  autoDetected: boolean;
+}
+
+export async function selectTargetAsync(
+  cwd: string,
+  options: SelectTargetOptions
+): Promise<SelectTargetResult> {
+  if (options.explicitTarget) {
+    return { targetName: options.explicitTarget, autoDetected: false };
+  }
+
+  const config = await loadDeployConfigAsync(resolveDeployConfigPath(cwd));
+  const targets = Object.keys(config.targets);
+
+  if (targets.length <= 1 || !_canPrompt()) {
+    return {
+      targetName: resolveDefaultTargetName(config),
+      autoDetected: true,
+    };
+  }
+
+  const targetName = await _promptForTargetAsync(config, options.publish);
+  return { targetName, autoDetected: false };
+}
+
+function _canPrompt(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+async function _promptForTargetAsync(
+  config: DeployConfig,
+  publish: boolean
+): Promise<string> {
+  const targets = Object.keys(config.targets);
+  const preferred = _preferredTarget(targets);
+  const orderedTargets = preferred
+    ? [preferred, ...targets.filter((t) => t !== preferred)]
+    : targets;
+
+  const choices = orderedTargets.map((name) => {
+    const target = config.targets[name]!;
+    return {
+      name: `${name} (place ${target.placeId})`,
+      value: name,
+    };
+  });
+
+  const action = publish ? 'publish' : 'deploy';
+  const { selection } = await inquirer.prompt<{ selection: string }>([
+    {
+      type: 'select',
+      name: 'selection',
+      message: `Select a target to ${action} to:`,
+      choices,
+      default: preferred,
+    },
+  ]);
+  return selection;
+}
+
+function _preferredTarget(targets: string[]): string | undefined {
+  if (targets.includes('integration')) return 'integration';
+  if (targets.includes('test')) return 'test';
+  return undefined;
+}

--- a/tools/nevermore-cli/src/commands/test-command/test-command.ts
+++ b/tools/nevermore-cli/src/commands/test-command/test-command.ts
@@ -29,6 +29,7 @@ export interface TestProjectArgs extends NevermoreGlobalArgs {
   scriptTemplate?: string;
   scriptText?: string;
   output?: string;
+  timeout?: number;
 }
 
 export class TestProjectCommand<T>
@@ -73,6 +74,11 @@ export class TestProjectCommand<T>
     args.option('output', {
       describe: 'Write JSON results to this file',
       type: 'string',
+    });
+    args.option('timeout', {
+      describe:
+        'Max script execution time in seconds. Sent to the Open Cloud API so Roblox cancels server-side on overrun (default: 120)',
+      type: 'number',
     });
 
     return args as Argv<TestProjectArgs>;
@@ -128,6 +134,8 @@ export class TestProjectCommand<T>
           packagePath: cwd,
           packageName,
           scriptText: args.scriptText,
+          timeoutMs:
+            args.timeout !== undefined ? args.timeout * 1000 : undefined,
         });
       } finally {
         await context.disposeAsync();

--- a/tools/nevermore-cli/src/commands/test-command/test-command.ts
+++ b/tools/nevermore-cli/src/commands/test-command/test-command.ts
@@ -96,6 +96,7 @@ export class TestProjectCommand<T>
               })
             : new SimpleReporter(state, {
                 alwaysShowLogs: showLogs,
+                verbose: args.verbose,
                 successMessage: 'Tests passed!',
                 failureMessage:
                   'Tests failed! See output above for more information.',

--- a/tools/nevermore-cli/src/commands/test-command/test-command.ts
+++ b/tools/nevermore-cli/src/commands/test-command/test-command.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import { Argv, CommandModule } from 'yargs';
-import { OutputHelper } from '@quenty/cli-output-helpers';
 import { NevermoreGlobalArgs } from '../../args/global-args.js';
 import { getApiKeyAsync } from '@quenty/nevermore-cli-helpers';
 import { OpenCloudClient } from '../../utils/open-cloud/open-cloud-client.js';
@@ -79,37 +78,38 @@ export class TestProjectCommand<T>
   };
 
   public handler = async (args: TestProjectArgs) => {
-    try {
-      const cwd = process.cwd();
-      const packageName =
-        (await readPackageNameAsync(cwd)) ?? path.basename(cwd);
-      const showLogs = args.logs ?? false;
-      const useSpinner = process.stdout.isTTY && !args.verbose;
+    const cwd = process.cwd();
+    const packageName =
+      (await readPackageNameAsync(cwd)) ?? path.basename(cwd);
+    const showLogs = args.logs ?? false;
+    const useSpinner = process.stdout.isTTY && !args.verbose;
 
-      const reporter = new CompositeReporter(
-        [packageName],
-        (state: LiveStateTracker) => {
-          const reporters: Reporter[] = [
-            useSpinner
-              ? new SpinnerReporter(state, {
-                  showLogs,
-                  actionVerb: 'Testing',
-                })
-              : new SimpleReporter(state, {
-                  alwaysShowLogs: showLogs,
-                  successMessage: 'Tests passed!',
-                  failureMessage:
-                    'Tests failed! See output above for more information.',
-                }),
-          ];
-          if (args.output) {
-            reporters.push(new JsonFileReporter(state, args.output));
-          }
-          return reporters;
+    const reporter = new CompositeReporter(
+      [packageName],
+      (state: LiveStateTracker) => {
+        const reporters: Reporter[] = [
+          useSpinner
+            ? new SpinnerReporter(state, {
+                showLogs,
+                actionVerb: 'Testing',
+              })
+            : new SimpleReporter(state, {
+                alwaysShowLogs: showLogs,
+                successMessage: 'Tests passed!',
+                failureMessage:
+                  'Tests failed! See output above for more information.',
+              }),
+        ];
+        if (args.output) {
+          reporters.push(new JsonFileReporter(state, args.output));
         }
-      );
-      await reporter.startAsync();
+        return reporters;
+      }
+    );
+    await reporter.startAsync();
 
+    let exitCode = 0;
+    try {
       const context = args.cloud
         ? new CloudJobContext(
             reporter,
@@ -140,13 +140,19 @@ export class TestProjectCommand<T>
           ? { kind: 'test-counts', ...result.testCounts }
           : undefined,
       });
-
-      await reporter.stopAsync();
+      if (!result.success) exitCode = 1;
     } catch (err) {
-      OutputHelper.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
+      reporter.onPackageResult({
+        packageName,
+        success: false,
+        logs: '',
+        durationMs: 0,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      exitCode = 1;
     }
 
-    process.exit(0);
+    await reporter.stopAsync();
+    process.exit(exitCode);
   };
 }

--- a/tools/nevermore-cli/src/commands/test-command/test-command.ts
+++ b/tools/nevermore-cli/src/commands/test-command/test-command.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { Argv, CommandModule } from 'yargs';
+import { OutputHelper } from '@quenty/cli-output-helpers';
 import { NevermoreGlobalArgs } from '../../args/global-args.js';
 import { getApiKeyAsync } from '@quenty/nevermore-cli-helpers';
 import { OpenCloudClient } from '../../utils/open-cloud/open-cloud-client.js';
@@ -147,7 +148,7 @@ export class TestProjectCommand<T>
         success: false,
         logs: '',
         durationMs: 0,
-        error: err instanceof Error ? err.message : String(err),
+        error: OutputHelper.formatErrorChain(err),
       });
       exitCode = 1;
     }

--- a/tools/nevermore-cli/src/commands/test-command/test-command.ts
+++ b/tools/nevermore-cli/src/commands/test-command/test-command.ts
@@ -86,8 +86,7 @@ export class TestProjectCommand<T>
 
   public handler = async (args: TestProjectArgs) => {
     const cwd = process.cwd();
-    const packageName =
-      (await readPackageNameAsync(cwd)) ?? path.basename(cwd);
+    const packageName = (await readPackageNameAsync(cwd)) ?? path.basename(cwd);
     const showLogs = args.logs ?? false;
     const useSpinner = process.stdout.isTTY && !args.verbose;
 

--- a/tools/nevermore-cli/src/utils/batch/batch-runner.ts
+++ b/tools/nevermore-cli/src/utils/batch/batch-runner.ts
@@ -112,7 +112,7 @@ async function _runOneAsync<TResult extends PackageResult>(
       const durationMs = partial.durationMs ?? Date.now() - startMs;
       return { ...partial, durationMs } as TResult;
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
+      const errorMessage = OutputHelper.formatErrorChain(err);
       const currentPhase = stateTracker?.getCurrentPhase(pkg.name);
       const failedPhase =
         currentPhase &&

--- a/tools/nevermore-cli/src/utils/build/deploy-config.test.ts
+++ b/tools/nevermore-cli/src/utils/build/deploy-config.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type DeployConfig,
+  type DeployTarget,
+  resolveDefaultTargetName,
+} from './deploy-config.js';
+
+function makeTarget(placeId: number): DeployTarget {
+  return {
+    universeId: 1,
+    placeId,
+    project: 'default.project.json',
+  };
+}
+
+function makeConfig(targets: Record<string, DeployTarget>): DeployConfig {
+  return { targets };
+}
+
+describe('resolveDefaultTargetName', () => {
+  it('returns the only target when there is just one', () => {
+    const config = makeConfig({ prod: makeTarget(1) });
+    expect(resolveDefaultTargetName(config)).toBe('prod');
+  });
+
+  it('prefers integration over test when both exist', () => {
+    const config = makeConfig({
+      test: makeTarget(1),
+      integration: makeTarget(2),
+    });
+    expect(resolveDefaultTargetName(config)).toBe('integration');
+  });
+
+  it('falls back to test when integration is absent', () => {
+    const config = makeConfig({ test: makeTarget(1), dev: makeTarget(2) });
+    expect(resolveDefaultTargetName(config)).toBe('test');
+  });
+
+  it('returns integration when present alongside non-test targets', () => {
+    const config = makeConfig({
+      integration: makeTarget(1),
+      dev: makeTarget(2),
+    });
+    expect(resolveDefaultTargetName(config)).toBe('integration');
+  });
+
+  it('throws when no preferred target exists and multiple options are present', () => {
+    const config = makeConfig({ foo: makeTarget(1), bar: makeTarget(2) });
+    expect(() => resolveDefaultTargetName(config)).toThrowError(/foo, bar/);
+  });
+});

--- a/tools/nevermore-cli/src/utils/build/deploy-config.ts
+++ b/tools/nevermore-cli/src/utils/build/deploy-config.ts
@@ -88,15 +88,19 @@ export function resolveDeployTarget(
 }
 
 /**
- * Pick a target name when the user did not specify one. If the config has
- * exactly one target, use it. Otherwise prefer "test" if it exists; if not,
- * throw with the list of available targets.
+ * Pick a target name when the user did not specify one and we cannot prompt
+ * (non-TTY / CI). Single target wins; otherwise prefer "integration" over
+ * "test" so `--publish` does not silently target the test place. Throws when
+ * neither is present.
  */
 export function resolveDefaultTargetName(config: DeployConfig): string {
   const availableTargets = Object.keys(config.targets);
 
   if (availableTargets.length === 1) {
     return availableTargets[0]!;
+  }
+  if (config.targets['integration']) {
+    return 'integration';
   }
   if (config.targets['test']) {
     return 'test';

--- a/tools/nevermore-cli/src/utils/job-context/cloud-job-context.ts
+++ b/tools/nevermore-cli/src/utils/job-context/cloud-job-context.ts
@@ -80,8 +80,13 @@ export class CloudJobContext extends BaseJobContext {
       cloudDeployment.universeId,
       cloudDeployment.placeId,
       cloudDeployment.version,
-      scriptContent
+      scriptContent,
+      timeoutMs
     );
+
+    // Give the server-side timeout a head start so we observe the cancelled
+    // task state instead of bailing out on the client first.
+    const CLIENT_TIMEOUT_GRACE_MS = 30_000;
 
     let pollCount = 0;
     const completedTask = await Promise.race([
@@ -98,7 +103,10 @@ export class CloudJobContext extends BaseJobContext {
           label,
         });
       }),
-      timeoutAsync(timeoutMs, `Test timed out after ${timeoutMs / 1000}s`),
+      timeoutAsync(
+        timeoutMs + CLIENT_TIMEOUT_GRACE_MS,
+        `Test timed out after ${timeoutMs / 1000}s`
+      ),
     ]);
 
     cloudDeployment.taskPath = task.path;

--- a/tools/nevermore-cli/src/utils/open-cloud/open-cloud-client.ts
+++ b/tools/nevermore-cli/src/utils/open-cloud/open-cloud-client.ts
@@ -216,7 +216,11 @@ export class OpenCloudClient {
     const apiKey = await this._resolveApiKeyAsync();
     const url = `https://apis.roblox.com/cloud/v2/universes/${universeId}/places/${placeId}/versions/${placeVersion}/luau-execution-session-tasks`;
 
-    const body: { script: string; timeout?: string } = { script };
+    const body: {
+      script: string;
+      timeout?: string;
+      enableBinaryOutput?: boolean;
+    } = { script, enableBinaryOutput: false };
     if (timeoutMs !== undefined) {
       // Roblox encodes durations as Google AIP duration strings (e.g. "120s").
       // The server uses this to cancel runaway scripts on its end.
@@ -322,26 +326,53 @@ export class OpenCloudClient {
 
   private async _fetchRawLogsAsync(taskPath: string): Promise<string> {
     const apiKey = await this._resolveApiKeyAsync();
-    const response = await this._rateLimiter.fetchAsync(
-      `https://apis.roblox.com/cloud/v2/${taskPath}/logs`,
-      {
+    const messages: string[] = [];
+    let pageToken: string | undefined;
+
+    do {
+      const url = new URL(`https://apis.roblox.com/cloud/v2/${taskPath}/logs`);
+      url.searchParams.set('view', 'STRUCTURED');
+      if (pageToken) {
+        url.searchParams.set('pageToken', pageToken);
+      }
+
+      const response = await this._rateLimiter.fetchAsync(url.toString(), {
         method: 'GET',
         headers: {
           'X-API-Key': apiKey,
         },
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Get logs failed: ${response.status}: ${text}`);
       }
-    );
 
-    if (!response.ok) {
-      const text = await response.text();
-      throw new Error(`Get logs failed: ${response.status}: ${text}`);
-    }
+      const data = (await response.json()) as {
+        luauExecutionSessionTaskLogs?: Array<{
+          messages?: string[];
+          structuredMessages?: Array<{
+            message: string;
+            createTime: string;
+            messageType: string;
+          }>;
+        }>;
+        nextPageToken?: string;
+      };
 
-    const data = (await response.json()) as {
-      luauExecutionSessionTaskLogs: Array<{ messages: string[] }>;
-    };
+      for (const entry of data.luauExecutionSessionTaskLogs ?? []) {
+        if (entry.structuredMessages?.length) {
+          for (const msg of entry.structuredMessages) {
+            messages.push(msg.message);
+          }
+        } else if (entry.messages?.length) {
+          messages.push(...entry.messages);
+        }
+      }
 
-    const messages = data.luauExecutionSessionTaskLogs?.[0]?.messages ?? [];
+      pageToken = data.nextPageToken || undefined;
+    } while (pageToken);
+
     return messages.join('\n');
   }
 

--- a/tools/nevermore-cli/src/utils/open-cloud/open-cloud-client.ts
+++ b/tools/nevermore-cli/src/utils/open-cloud/open-cloud-client.ts
@@ -19,6 +19,7 @@ export interface LuauTask {
     | 'COMPLETE'
     | 'FAILED';
   script: string;
+  timeout?: string;
 }
 
 export interface OpenCloudClientOptions {
@@ -209,10 +210,18 @@ export class OpenCloudClient {
     universeId: number,
     placeId: number,
     placeVersion: number,
-    script: string
+    script: string,
+    timeoutMs?: number
   ): Promise<LuauTask> {
     const apiKey = await this._resolveApiKeyAsync();
     const url = `https://apis.roblox.com/cloud/v2/universes/${universeId}/places/${placeId}/versions/${placeVersion}/luau-execution-session-tasks`;
+
+    const body: { script: string; timeout?: string } = { script };
+    if (timeoutMs !== undefined) {
+      // Roblox encodes durations as Google AIP duration strings (e.g. "120s").
+      // The server uses this to cancel runaway scripts on its end.
+      body.timeout = `${Math.max(1, Math.ceil(timeoutMs / 1000))}s`;
+    }
 
     const response = await this._rateLimiter.fetchAsync(url, {
       method: 'POST',
@@ -220,7 +229,7 @@ export class OpenCloudClient {
         'Content-Type': 'application/json',
         'X-API-Key': apiKey,
       },
-      body: JSON.stringify({ script }),
+      body: JSON.stringify(body),
     });
 
     if (!response.ok) {

--- a/tools/nevermore-cli/templates/game-template/.github/workflows/integration.yml
+++ b/tools/nevermore-cli/templates/game-template/.github/workflows/integration.yml
@@ -1,45 +1,44 @@
-# Roblox Deploy
+# Roblox Integration Deploy
 #
-# Builds and uploads the project to your Roblox place.
+# Builds and uploads the project to your Roblox integration place on every pull request.
 # This workflow is inactive until you complete the setup below.
 #
 # Setup:
-#   1. Run `nevermore deploy init` to create deploy.nevermore.json
+#   1. Run `nevermore deploy init` to create deploy.nevermore.json (with an `integration` target)
 #   2. Add ROBLOX_OPEN_CLOUD_API_KEY as a repository secret
 #      (Create one at https://create.roblox.com/dashboard/credentials)
-#   3. Deploys will run automatically when code is pushed to main
-#   4. You can also trigger a deploy manually from the Actions tab
+#   3. Deploys will run automatically on every pull request
 #
 # Docs: https://quenty.github.io/NevermoreEngine/docs/testing/integration-testing
 
-name: deploy
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+name: integration
+on: [pull_request]
 jobs:
-  config-check:
+  integration:
     runs-on: ubuntu-latest
-    outputs:
-      enabled: $\{{ steps.check.outputs.enabled }}
+    environment: integration
     steps:
       - id: check
+        name: Check config
         run: |
-          if [ -n "$KEY" ]; then echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else echo "::notice::Deploy skipped — ROBLOX_OPEN_CLOUD_API_KEY not configured. See top of this file for setup."; fi
+          if [ -n "$KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Integration skipped — ROBLOX_OPEN_CLOUD_API_KEY not configured. See top of this file for setup."
+          fi
         env:
           KEY: $\{{ secrets.ROBLOX_OPEN_CLOUD_API_KEY }}
 
-  deploy:
-    needs: config-check
-    if: needs.config-check.outputs.enabled == 'true'
-    runs-on: ubuntu-latest
-    steps:
       - name: Checkout repository
+        if: steps.check.outputs.enabled == 'true'
         uses: actions/checkout@v6
 
+      - name: Fetch base branch for changeset diff
+        if: steps.check.outputs.enabled == 'true'
+        run: git fetch origin $\{{ github.base_ref }} --depth=1
+
       - name: Setup Aftman
+        if: steps.check.outputs.enabled == 'true'
         uses: ok-nick/setup-aftman@v0.4.2
         with:
           version: 'v0.3.0'
@@ -47,11 +46,13 @@ jobs:
           cache: true
 
       - name: Setup pnpm
+        if: steps.check.outputs.enabled == 'true'
         uses: pnpm/action-setup@v4
         with:
           cache: true
 
       - name: Setup npm for GitHub Packages
+        if: steps.check.outputs.enabled == 'true'
         run: |
           if [[ -n "$NPM_GITHUB_QUENTYSTUDIOS_TOKEN" ]]; then
             echo "//npm.pkg.github.com/:_authToken=$NPM_GITHUB_QUENTYSTUDIOS_TOKEN" >> .npmrc
@@ -67,16 +68,19 @@ jobs:
           NPM_TOKEN: $\{{ secrets.NPM_TOKEN }}
 
       - name: Link and install packages
+        if: steps.check.outputs.enabled == 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Deploy
-        id: deploy
-        run: npx @quenty/nevermore-cli deploy run --yes --verbose --logs --output deploy-results.json
+      - name: Deploy integration
+        id: deploy-integration
+        if: steps.check.outputs.enabled == 'true'
+        run: npx @quenty/nevermore-cli batch deploy --target integration --publish --base origin/$\{{ github.base_ref }} --output integration-results.json --yes --verbose --logs
         env:
           ROBLOX_OPEN_CLOUD_API_KEY: $\{{ secrets.ROBLOX_OPEN_CLOUD_API_KEY }}
+          GITHUB_TOKEN: $\{{ secrets.GITHUB_TOKEN }}
 
       - name: Post deploy results
-        if: always()
-        run: npx @quenty/nevermore-cli tools post-deploy-results deploy-results.json --yes --run-outcome $\{{ steps.deploy.outcome }}
+        if: always() && steps.check.outputs.enabled == 'true'
+        run: npx @quenty/nevermore-cli tools post-deploy-results integration-results.json --yes --run-outcome $\{{ steps.deploy-integration.outcome }}
         env:
           GITHUB_TOKEN: $\{{ secrets.GITHUB_TOKEN }}

--- a/tools/nevermore-cli/templates/game-template/.github/workflows/tests.yml
+++ b/tools/nevermore-cli/templates/game-template/.github/workflows/tests.yml
@@ -7,47 +7,46 @@
 #   1. Run `nevermore deploy init` to create deploy.nevermore.json with a test target
 #   2. Add ROBLOX_OPEN_CLOUD_API_KEY as a repository secret
 #      (Create one at https://create.roblox.com/dashboard/credentials)
-#   3. Tests will run automatically on pull requests
+#   3. Tests will run automatically on pull requests and on push to main
 #
 # Docs: https://quenty.github.io/NevermoreEngine/docs/testing
 
 name: tests
 on:
   pull_request:
+  push:
+    branches: [main]
 jobs:
-  config-check:
+  tests:
     runs-on: ubuntu-latest
-    outputs:
-      enabled: $\{{ steps.check.outputs.enabled }}
     steps:
       - id: check
+        name: Check config
         run: |
-          if [ -n "$KEY" ]; then echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else echo "::notice::Tests skipped — ROBLOX_OPEN_CLOUD_API_KEY not configured. See top of this file for setup."; fi
+          if [ -n "$KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Tests skipped — ROBLOX_OPEN_CLOUD_API_KEY not configured. See top of this file for setup."
+          fi
         env:
           KEY: $\{{ secrets.ROBLOX_OPEN_CLOUD_API_KEY }}
 
-  tests:
-    needs: config-check
-    if: needs.config-check.outputs.enabled == 'true'
-    runs-on: ubuntu-latest
-    steps:
       - name: Checkout repository
+        if: steps.check.outputs.enabled == 'true'
         uses: actions/checkout@v6
 
-      - name: Setup Aftman
-        uses: ok-nick/setup-aftman@v0.4.2
-        with:
-          version: 'v0.3.0'
-          token: $\{{ secrets.GITHUB_TOKEN }}
-          cache: true
+      - name: Fetch base branch for changeset diff
+        if: steps.check.outputs.enabled == 'true' && github.event_name == 'pull_request'
+        run: git fetch origin $\{{ github.base_ref }} --depth=1
 
       - name: Setup pnpm
+        if: steps.check.outputs.enabled == 'true'
         uses: pnpm/action-setup@v4
         with:
           cache: true
 
       - name: Setup npm for GitHub Packages
+        if: steps.check.outputs.enabled == 'true'
         run: |
           if [[ -n "$NPM_GITHUB_QUENTYSTUDIOS_TOKEN" ]]; then
             echo "//npm.pkg.github.com/:_authToken=$NPM_GITHUB_QUENTYSTUDIOS_TOKEN" >> .npmrc
@@ -63,20 +62,31 @@ jobs:
           NPM_TOKEN: $\{{ secrets.NPM_TOKEN }}
 
       - name: Link and install packages
+        if: steps.check.outputs.enabled == 'true'
         run: pnpm install --frozen-lockfile
+
+      - name: Setup Aftman
+        if: steps.check.outputs.enabled == 'true'
+        uses: ok-nick/setup-aftman@v0.4.2
+        with:
+          version: 'v0.3.0'
+          token: $\{{ secrets.GITHUB_TOKEN }}
+          cache: true
 
       - name: Run tests
         id: run-tests
-        run: npx @quenty/nevermore-cli test --cloud --yes --verbose --logs --output test-results.json
+        if: steps.check.outputs.enabled == 'true'
+        run: npx @quenty/nevermore-cli batch test --cloud --aggregated $\{{ github.event_name == 'pull_request' && format('--base origin/{0}', github.base_ref) || '' }} --output test-results.json --yes --verbose --logs
         env:
           ROBLOX_OPEN_CLOUD_API_KEY: $\{{ secrets.ROBLOX_OPEN_CLOUD_API_KEY }}
+          GITHUB_TOKEN: $\{{ secrets.GITHUB_TOKEN }}
 
       - name: Build sourcemap for annotation resolution
-        if: always()
+        if: always() && steps.check.outputs.enabled == 'true'
         run: npm run build:sourcemap
 
       - name: Post test results
-        if: always()
+        if: always() && steps.check.outputs.enabled == 'true'
         run: npx @quenty/nevermore-cli tools post-test-results test-results.json --yes --run-outcome $\{{ steps.run-tests.outcome }}
         env:
           GITHUB_TOKEN: $\{{ secrets.GITHUB_TOKEN }}

--- a/tools/nevermore-cli/templates/game-template/README.md
+++ b/tools/nevermore-cli/templates/game-template/README.md
@@ -56,15 +56,36 @@ npm run format
 
 Note that you should also configure your editor to automatically format files using Stylua.
 
+# Tests
+
+Tests live next to the code they cover and end in `.spec.lua`. They run on Roblox via [`@quenty/nevermore-test-runner`](https://www.npmjs.com/package/@quenty/nevermore-test-runner) using [jest-lua](https://github.com/jsdotlua/jest-lua).
+
+Run tests locally against the cloud:
+
+```bash
+npm test
+```
+
+The matcher and runner config live in [`src/modules/jest.config.lua`](src/modules/jest.config.lua).
+
+# Deploying
+
+Deploy targets are defined in `deploy.nevermore.json`. Run `npx @quenty/nevermore-cli deploy init` to scaffold one. To push an integration build manually:
+
+```bash
+npm run deploy
+```
+
 # CI/CD
 
 This project includes GitHub Actions workflows in `.github/workflows/`:
 
 - **Linting** (`linting.yml`) — Runs automatically on PRs and push to main. Posts inline annotations on PRs for luau-lsp, stylua, selene, and moonwave issues.
 - **Tests** (`tests.yml`) — Runs on PRs when configured. Set up with `nevermore deploy init` to create a `deploy.nevermore.json`, then add `ROBLOX_OPEN_CLOUD_API_KEY` as a repository secret.
+- **Integration** (`integration.yml`) — Deploys PRs to an `integration` target so reviewers can play the change. Same setup as tests; optionally create a GitHub Environment named `integration` to scope the secret.
 - **Deploy** (`deploy.yml`) — Runs on push to main when configured. Same setup as tests: `nevermore deploy init` + `ROBLOX_OPEN_CLOUD_API_KEY` secret.
 
-Tests and deploy workflows are inactive until configured — they skip cleanly with a notice annotation explaining the setup steps.
+Tests, integration, and deploy workflows are inactive until configured — they skip cleanly with a notice annotation explaining the setup steps.
 
 # Getting Luau-lsp to work in VSCode
 

--- a/tools/nevermore-cli/templates/game-template/aftman.toml
+++ b/tools/nevermore-cli/templates/game-template/aftman.toml
@@ -2,6 +2,7 @@
 # For more information, see https://github.com/LPGhatguy/aftman
 [tools]
 luau-lsp = "Quenty/luau-lsp@1.58.0-quenty.1"
+lune = "lune-org/lune@0.10.4"
 moonwave-extractor = "UpliftGames/moonwave@1.3.0"
 rojo = "quenty/rojo@7.7.0-rc.1-quenty.4"
 selene = "Kampfkarren/selene@0.29.0"

--- a/tools/nevermore-cli/templates/game-template/default.project.json
+++ b/tools/nevermore-cli/templates/game-template/default.project.json
@@ -11,6 +11,9 @@
   "tree": {
     "$className": "DataModel",
     "ServerScriptService": {
+      "$properties": {
+        "LoadStringEnabled": true
+      },
       "{{gameNameProper}}": {
         "$className": "Folder",
         "game": {

--- a/tools/nevermore-cli/templates/game-template/package.json
+++ b/tools/nevermore-cli/templates/game-template/package.json
@@ -12,15 +12,20 @@
   "scripts": {
     "build:sourcemap": "rojo sourcemap default.project.json --output sourcemap.json --absolute",
     "format": "stylua --config-path=stylua.toml src",
-    "lint:luau": "luau-lsp analyze --sourcemap=sourcemap.json --base-luaurc=.luaurc --defs=globalTypes.d.lua --flag:LuauSolverV2=false --ignore=**/node_modules/** --ignore=**/*.story.lua --ignore=**/*.client.lua --ignore=**/*.server.lua src",
+    "lint:luau": "luau-lsp analyze --sourcemap=sourcemap.json --base-luaurc=.luaurc --defs=globalTypes.d.lua --flag:LuauSolverV2=false --ignore=**/node_modules/** --ignore=**/*.spec.lua --ignore=**/*.story.lua --ignore=**/*.client.lua --ignore=**/*.server.lua src",
     "lint:moonwave": "moonwave-extractor extract src",
     "lint:selene": "selene --no-summary --config=selene.toml src",
     "lint:stylua": "stylua --config-path=stylua.toml --check src",
     "prelint:selene": "selene generate-roblox-std",
     "prelint:luau": "npm run build:sourcemap && npx @quenty/nevermore-cli tools download-roblox-types",
+    "test": "npx @quenty/nevermore-cli test",
+    "deploy": "npx @quenty/nevermore-cli deploy --target integration",
     "preinstall": "npx only-allow pnpm"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@quenty/nevermore-test-runner": "^1.4.0",
+    "@quentystudios/jest-lua": "3.10.0-quenty.2"
+  },
   "publishConfig": {
     "access": "restricted"
   }

--- a/tools/nevermore-cli/templates/game-template/src/modules/jest.config.lua
+++ b/tools/nevermore-cli/templates/game-template/src/modules/jest.config.lua
@@ -1,0 +1,4 @@
+return {
+	passWithNoTests = true,
+	testMatch = { "**/*.spec" },
+}

--- a/tools/nevermore-cli/templates/game-template/src/scripts/Server/ServerMain.server.lua
+++ b/tools/nevermore-cli/templates/game-template/src/scripts/Server/ServerMain.server.lua
@@ -8,6 +8,12 @@ local root = ServerScriptService.{{gameNameProper}}
 local loader = root:FindFirstChild("LoaderUtils", true).Parent
 local require = require(loader).bootstrapGame(root)
 
+local NevermoreTestRunnerUtils = require("NevermoreTestRunnerUtils")
+
+if NevermoreTestRunnerUtils.runTestsIfNeededAsync(root.game) then
+	return
+end
+
 local serviceBag = require("ServiceBag").new()
 serviceBag:GetService(require("{{gameNameProper}}Service"))
 serviceBag:Init()

--- a/tools/nevermore-cli/templates/plugin-template/.github/workflows/integration.yml
+++ b/tools/nevermore-cli/templates/plugin-template/.github/workflows/integration.yml
@@ -1,45 +1,44 @@
-# Roblox Deploy
+# Roblox Integration Deploy
 #
-# Builds and uploads the project to your Roblox place.
+# Builds and uploads the project to your Roblox integration place on every pull request.
 # This workflow is inactive until you complete the setup below.
 #
 # Setup:
-#   1. Run `nevermore deploy init` to create deploy.nevermore.json
+#   1. Run `nevermore deploy init` to create deploy.nevermore.json (with an `integration` target)
 #   2. Add ROBLOX_OPEN_CLOUD_API_KEY as a repository secret
 #      (Create one at https://create.roblox.com/dashboard/credentials)
-#   3. Deploys will run automatically when code is pushed to main
-#   4. You can also trigger a deploy manually from the Actions tab
+#   3. Deploys will run automatically on every pull request
 #
 # Docs: https://quenty.github.io/NevermoreEngine/docs/testing/integration-testing
 
-name: deploy
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+name: integration
+on: [pull_request]
 jobs:
-  config-check:
+  integration:
     runs-on: ubuntu-latest
-    outputs:
-      enabled: $\{{ steps.check.outputs.enabled }}
+    environment: integration
     steps:
       - id: check
+        name: Check config
         run: |
-          if [ -n "$KEY" ]; then echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else echo "::notice::Deploy skipped — ROBLOX_OPEN_CLOUD_API_KEY not configured. See top of this file for setup."; fi
+          if [ -n "$KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Integration skipped — ROBLOX_OPEN_CLOUD_API_KEY not configured. See top of this file for setup."
+          fi
         env:
           KEY: $\{{ secrets.ROBLOX_OPEN_CLOUD_API_KEY }}
 
-  deploy:
-    needs: config-check
-    if: needs.config-check.outputs.enabled == 'true'
-    runs-on: ubuntu-latest
-    steps:
       - name: Checkout repository
+        if: steps.check.outputs.enabled == 'true'
         uses: actions/checkout@v6
 
+      - name: Fetch base branch for changeset diff
+        if: steps.check.outputs.enabled == 'true'
+        run: git fetch origin $\{{ github.base_ref }} --depth=1
+
       - name: Setup Aftman
+        if: steps.check.outputs.enabled == 'true'
         uses: ok-nick/setup-aftman@v0.4.2
         with:
           version: 'v0.3.0'
@@ -47,11 +46,13 @@ jobs:
           cache: true
 
       - name: Setup pnpm
+        if: steps.check.outputs.enabled == 'true'
         uses: pnpm/action-setup@v4
         with:
           cache: true
 
       - name: Setup npm for GitHub Packages
+        if: steps.check.outputs.enabled == 'true'
         run: |
           if [[ -n "$NPM_GITHUB_QUENTYSTUDIOS_TOKEN" ]]; then
             echo "//npm.pkg.github.com/:_authToken=$NPM_GITHUB_QUENTYSTUDIOS_TOKEN" >> .npmrc
@@ -67,16 +68,19 @@ jobs:
           NPM_TOKEN: $\{{ secrets.NPM_TOKEN }}
 
       - name: Link and install packages
+        if: steps.check.outputs.enabled == 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Deploy
-        id: deploy
-        run: npx @quenty/nevermore-cli deploy run --yes --verbose --logs --output deploy-results.json
+      - name: Deploy integration
+        id: deploy-integration
+        if: steps.check.outputs.enabled == 'true'
+        run: npx @quenty/nevermore-cli batch deploy --target integration --publish --base origin/$\{{ github.base_ref }} --output integration-results.json --yes --verbose --logs
         env:
           ROBLOX_OPEN_CLOUD_API_KEY: $\{{ secrets.ROBLOX_OPEN_CLOUD_API_KEY }}
+          GITHUB_TOKEN: $\{{ secrets.GITHUB_TOKEN }}
 
       - name: Post deploy results
-        if: always()
-        run: npx @quenty/nevermore-cli tools post-deploy-results deploy-results.json --yes --run-outcome $\{{ steps.deploy.outcome }}
+        if: always() && steps.check.outputs.enabled == 'true'
+        run: npx @quenty/nevermore-cli tools post-deploy-results integration-results.json --yes --run-outcome $\{{ steps.deploy-integration.outcome }}
         env:
           GITHUB_TOKEN: $\{{ secrets.GITHUB_TOKEN }}

--- a/tools/nevermore-cli/templates/plugin-template/.github/workflows/tests.yml
+++ b/tools/nevermore-cli/templates/plugin-template/.github/workflows/tests.yml
@@ -7,35 +7,36 @@
 #   1. Run `nevermore deploy init` to create deploy.nevermore.json with a test target
 #   2. Add ROBLOX_OPEN_CLOUD_API_KEY as a repository secret
 #      (Create one at https://create.roblox.com/dashboard/credentials)
-#   3. Tests will run automatically on pull requests
+#   3. Tests will run automatically on pull requests and on push to main
 #
 # Docs: https://quenty.github.io/NevermoreEngine/docs/testing
 
 name: tests
 on:
   pull_request:
+  push:
+    branches: [main]
 jobs:
-  config-check:
+  tests:
     runs-on: ubuntu-latest
-    outputs:
-      enabled: $\{{ steps.check.outputs.enabled }}
     steps:
       - id: check
+        name: Check config
         run: |
-          if [ -n "$KEY" ]; then echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else echo "::notice::Tests skipped — ROBLOX_OPEN_CLOUD_API_KEY not configured. See top of this file for setup."; fi
+          if [ -n "$KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Tests skipped — ROBLOX_OPEN_CLOUD_API_KEY not configured. See top of this file for setup."
+          fi
         env:
           KEY: $\{{ secrets.ROBLOX_OPEN_CLOUD_API_KEY }}
 
-  tests:
-    needs: config-check
-    if: needs.config-check.outputs.enabled == 'true'
-    runs-on: ubuntu-latest
-    steps:
       - name: Checkout repository
+        if: steps.check.outputs.enabled == 'true'
         uses: actions/checkout@v6
 
       - name: Setup Aftman
+        if: steps.check.outputs.enabled == 'true'
         uses: ok-nick/setup-aftman@v0.4.2
         with:
           version: 'v0.3.0'
@@ -43,11 +44,13 @@ jobs:
           cache: true
 
       - name: Setup pnpm
+        if: steps.check.outputs.enabled == 'true'
         uses: pnpm/action-setup@v4
         with:
           cache: true
 
       - name: Setup npm for GitHub Packages
+        if: steps.check.outputs.enabled == 'true'
         run: |
           if [[ -n "$NPM_GITHUB_QUENTYSTUDIOS_TOKEN" ]]; then
             echo "//npm.pkg.github.com/:_authToken=$NPM_GITHUB_QUENTYSTUDIOS_TOKEN" >> .npmrc
@@ -63,20 +66,22 @@ jobs:
           NPM_TOKEN: $\{{ secrets.NPM_TOKEN }}
 
       - name: Link and install packages
+        if: steps.check.outputs.enabled == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Run tests
         id: run-tests
+        if: steps.check.outputs.enabled == 'true'
         run: npx @quenty/nevermore-cli test --cloud --yes --verbose --logs --output test-results.json
         env:
           ROBLOX_OPEN_CLOUD_API_KEY: $\{{ secrets.ROBLOX_OPEN_CLOUD_API_KEY }}
 
       - name: Build sourcemap for annotation resolution
-        if: always()
+        if: always() && steps.check.outputs.enabled == 'true'
         run: npm run build:sourcemap
 
       - name: Post test results
-        if: always()
+        if: always() && steps.check.outputs.enabled == 'true'
         run: npx @quenty/nevermore-cli tools post-test-results test-results.json --yes --run-outcome $\{{ steps.run-tests.outcome }}
         env:
           GITHUB_TOKEN: $\{{ secrets.GITHUB_TOKEN }}

--- a/tools/studio-bridge/src/cli/script-executor.ts
+++ b/tools/studio-bridge/src/cli/script-executor.ts
@@ -102,18 +102,18 @@ export async function executeScriptAsync(
     OutputHelper.setVerbose(false);
   }
 
-  const server = new StudioBridgeServer({
-    placePath,
-    timeoutMs,
-    onPhase: (phase: StudioBridgePhase) => {
-      if (phase === 'done') return;
-      reporter.onPackagePhaseChange(packageName, phase);
-    },
-  });
-
   const outputLines: string[] = [];
+  let server: StudioBridgeServer | undefined;
   let result;
   try {
+    server = new StudioBridgeServer({
+      placePath,
+      timeoutMs,
+      onPhase: (phase: StudioBridgePhase) => {
+        if (phase === 'done') return;
+        reporter.onPackagePhaseChange(packageName, phase);
+      },
+    });
     await server.startAsync();
     result = await server.executeAsync({
       scriptContent,
@@ -149,7 +149,7 @@ export async function executeScriptAsync(
       logs: `[StudioBridge] Error: ${errorMessage}`,
     };
   } finally {
-    await server.stopAsync();
+    await server?.stopAsync();
   }
 
   const elapsed = performance.now() - startTime;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/cli-output-helpers@1.14.0-canary.697.26191573587.0
  npm install @quenty/nevermore-cli@4.29.0-canary.697.26191573587.0
  npm install @quenty/nevermore-cli-helpers@1.13.0-canary.697.26191573587.0
  npm install @quenty/nevermore-template-helpers@1.15.0-canary.697.26191573587.0
  npm install @quenty/studio-bridge@0.12.0-canary.697.26191573587.0
  # or 
  yarn add @quenty/cli-output-helpers@1.14.0-canary.697.26191573587.0
  yarn add @quenty/nevermore-cli@4.29.0-canary.697.26191573587.0
  yarn add @quenty/nevermore-cli-helpers@1.13.0-canary.697.26191573587.0
  yarn add @quenty/nevermore-template-helpers@1.15.0-canary.697.26191573587.0
  yarn add @quenty/studio-bridge@0.12.0-canary.697.26191573587.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
