### PR TITLE
fix: Fix package reports + make smoketest more consistent

### DIFF
--- a/docs/testing/integration-testing.md
+++ b/docs/testing/integration-testing.md
@@ -190,6 +190,7 @@ nevermore batch deploy --output results.json
 | `--logs` | Show build/upload logs |
 | `--publish` | Publish all deployed places |
 | `--target` | Deploy target name (default: `test`) |
+| `--smoke-test` | Run a post-deploy smoke test on targets with `basePlace` (off by default) |
 
 Change detection uses `pnpm ls --filter "...[base]"` to find packages (and their dependents) that changed since the base ref, then filters to those with a matching deploy target.
 
@@ -232,7 +233,9 @@ Downloading a base place uses the Roblox Asset Delivery API, which requires the 
 
 ### Smoke testing
 
-When `basePlace` is configured, the deploy pipeline automatically runs a smoke test after uploading. The smoke test spawns all `Script` instances in `ServerScriptService` and waits 30 seconds for errors. If any script throws, the deploy is marked as failed. No test assertions are needed — a clean boot is the test.
+`nevermore batch deploy --smoke-test` runs a smoke test after uploading, for any target with `basePlace` configured. The smoke test spawns all `Script` instances in `ServerScriptService` and waits 30 seconds for errors. If any script throws, the deploy is marked as failed. No test assertions are needed — a clean boot is the test.
+
+The flag is opt-in: without `--smoke-test`, deploys finish as soon as the upload completes, even when `basePlace` is set. Targets without `basePlace` ignore the flag.
 
 ## CI integration
 

--- a/tools/cli-output-helpers/src/reporting/github/formatting.ts
+++ b/tools/cli-output-helpers/src/reporting/github/formatting.ts
@@ -149,9 +149,10 @@ export function formatResultStatus(
   }
 
   const failedPhase = pkg.failedPhase;
+  const effectiveLabel = pkg.failureLabel ?? failureLabel;
   const label = failedPhase
-    ? `**${failureLabel}** at ${failedPhase}`
-    : `**${failureLabel}**`;
+    ? `**${effectiveLabel}** at ${failedPhase}`
+    : `**${effectiveLabel}**`;
   return `❌ ${label} (${duration})`;
 }
 

--- a/tools/cli-output-helpers/src/reporting/grouped-reporter.ts
+++ b/tools/cli-output-helpers/src/reporting/grouped-reporter.ts
@@ -71,7 +71,8 @@ export class GroupedReporter extends BaseReporter {
     const showLogs = this._options.showLogs || !result.success;
     const duration = formatDurationMs(result.durationMs);
     const successLabel = this._options.successLabel ?? 'Passed';
-    const failureLabel = this._options.failureLabel ?? 'FAILED';
+    const failureLabel =
+      result.failureLabel ?? this._options.failureLabel ?? 'FAILED';
 
     const progressText = formatProgressResult(result.progressSummary);
     const empty = isEmptyTestRun(result.progressSummary);

--- a/tools/cli-output-helpers/src/reporting/json-file-reporter.ts
+++ b/tools/cli-output-helpers/src/reporting/json-file-reporter.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs/promises';
 import { OutputHelper } from '../outputHelper.js';
-import { BaseReporter } from './reporter.js';
+import { BaseReporter, type PackageResult } from './reporter.js';
 import { formatJson } from './format-json.js';
 import { type IStateTracker } from './state/state-tracker.js';
 
@@ -19,7 +19,10 @@ export class JsonFileReporter extends BaseReporter {
   }
 
   override async stopAsync(): Promise<void> {
-    const results = this._state.getResults();
+    const results = this._state
+      .getAllPackages()
+      .map((p) => p.result)
+      .filter((r): r is PackageResult => r !== undefined);
     const failures = this._state.getFailures();
     const durationMs = Date.now() - this._state.startTimeMs;
 

--- a/tools/cli-output-helpers/src/reporting/reporter.ts
+++ b/tools/cli-output-helpers/src/reporting/reporter.ts
@@ -69,6 +69,8 @@ export interface PackageResult {
   error?: string;
   progressSummary?: ProgressSummary;
   failedPhase?: JobPhase;
+  /** Per-result override of the reporter's default failure label. */
+  failureLabel?: string;
 }
 
 /** Summary of a complete batch run. */

--- a/tools/cli-output-helpers/src/reporting/spinner-reporter.ts
+++ b/tools/cli-output-helpers/src/reporting/spinner-reporter.ts
@@ -181,7 +181,7 @@ export class SpinnerReporter extends BaseReporter {
       : OutputHelper.formatError('✗');
     const status = result.success
       ? this._options.successLabel ?? 'Passed'
-      : this._options.failureLabel ?? 'FAILED';
+      : result.failureLabel ?? this._options.failureLabel ?? 'FAILED';
     const formatted = result.success
       ? OutputHelper.formatSuccess(status)
       : OutputHelper.formatError(status);
@@ -240,9 +240,11 @@ export class SpinnerReporter extends BaseReporter {
       } else if (state.status === 'failed') {
         const icon = OutputHelper.formatError('✗');
         const failedPhase = state.result?.failedPhase;
+        const failureLabel =
+          state.result?.failureLabel ?? this._options.failureLabel ?? 'FAILED';
         const plain = failedPhase
-          ? `${this._options.failureLabel ?? 'FAILED'} at ${failedPhase}`
-          : this._options.failureLabel ?? 'FAILED';
+          ? `${failureLabel} at ${failedPhase}`
+          : failureLabel;
         const statusText = OutputHelper.formatError(
           plain.padEnd(STATUS_COLUMN_WIDTH)
         );

--- a/tools/cli-output-helpers/src/reporting/summary-table-reporter.ts
+++ b/tools/cli-output-helpers/src/reporting/summary-table-reporter.ts
@@ -98,9 +98,8 @@ export class SummaryTableReporter extends BaseReporter {
         : this._successLabel;
     }
     const failedPhase = result.failedPhase;
-    return failedPhase
-      ? `${this._failureLabel} at ${failedPhase}`
-      : this._failureLabel;
+    const failureLabel = result.failureLabel ?? this._failureLabel;
+    return failedPhase ? `${failureLabel} at ${failedPhase}` : failureLabel;
   }
 
   private _colorStatus(

--- a/tools/nevermore-cli/src/commands/batch-command/batch-deploy-command.ts
+++ b/tools/nevermore-cli/src/commands/batch-command/batch-deploy-command.ts
@@ -48,6 +48,7 @@ interface BatchDeployArgs extends NevermoreGlobalArgs {
   limit?: number;
   logs?: boolean;
   target?: string;
+  smokeTest?: boolean;
 }
 
 export const batchDeployCommand: CommandModule<
@@ -97,6 +98,13 @@ export const batchDeployCommand: CommandModule<
       })
       .option('logs', {
         describe: 'Show build/upload logs for all packages (not just failures)',
+        type: 'boolean',
+        default: false,
+      })
+      .option('smoke-test', {
+        describe:
+          'Run a post-deploy smoke test on targets with basePlace ' +
+          '(executes server scripts via Open Cloud and waits for errors)',
         type: 'boolean',
         default: false,
       });
@@ -228,9 +236,8 @@ async function _runAsync(args: BatchDeployArgs): Promise<void> {
         // Eagerly release build artifacts after upload
         await context.releaseBuiltPlaceAsync(builtPlace);
 
-        // Run smoke test for targets with basePlace
         let logs: string;
-        if (buildTarget.target.basePlace) {
+        if (args.smokeTest && buildTarget.target.basePlace) {
           OutputHelper.verbose('Running post-deploy smoke test...');
           const smokeResult = await _runSmokeTestAsync(
             pkgReporter,

--- a/tools/nevermore-cli/src/commands/batch-command/batch-deploy-command.ts
+++ b/tools/nevermore-cli/src/commands/batch-command/batch-deploy-command.ts
@@ -247,6 +247,7 @@ async function _runAsync(args: BatchDeployArgs): Promise<void> {
               placeId: buildTarget.target.placeId,
               success: false,
               logs: _annotateSmokeTestFailure(logs),
+              failureLabel: 'SMOKE TEST FAILED',
             };
           }
         } else {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/cli-output-helpers@1.17.0-canary.703.26469438872.0
  npm install @quenty/nevermore-cli@4.32.0-canary.703.26469438872.0
  npm install @quenty/nevermore-cli-helpers@1.16.0-canary.703.26469438872.0
  npm install @quenty/nevermore-template-helpers@1.18.0-canary.703.26469438872.0
  npm install @quenty/studio-bridge@0.15.0-canary.703.26469438872.0
  # or 
  yarn add @quenty/cli-output-helpers@1.17.0-canary.703.26469438872.0
  yarn add @quenty/nevermore-cli@4.32.0-canary.703.26469438872.0
  yarn add @quenty/nevermore-cli-helpers@1.16.0-canary.703.26469438872.0
  yarn add @quenty/nevermore-template-helpers@1.18.0-canary.703.26469438872.0
  yarn add @quenty/studio-bridge@0.15.0-canary.703.26469438872.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
