### PR TITLE
fix: Prevent playback on invalid targets

### DIFF
--- a/src/animations/src/Shared/AnimationSlotPlayer.lua
+++ b/src/animations/src/Shared/AnimationSlotPlayer.lua
@@ -296,8 +296,8 @@ function AnimationSlotPlayer.Play(
 	end)
 
 	topMaid:GiveTask(self._animationTarget
-		:ObserveBrio(function(target)
-			return target ~= nil
+		:ObserveBrio(function(target: Instance?)
+			return (target ~= nil) and (target.Parent ~= nil)
 		end)
 		:Subscribe(function(brio)
 			if brio:IsDead() then


### PR DESCRIPTION
`AnimationSlotPlayer` attempts playback even as targets are being destructed. In cases where the animator has already been destroyed, `HumanoidAnimatorUtils` creates a new one on the client, which produces a warning.

This checks if the animation target has a valid parent before attempting playback.