### PR TITLE
feat(chatproviderservice): convert package to --!strict typing

### DIFF
--- a/src/chatproviderservice/src/Client/Binders/HasChatTagsClient.lua
+++ b/src/chatproviderservice/src/Client/Binders/HasChatTagsClient.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class HasChatTagsClient
 ]=]
@@ -18,8 +18,19 @@ local HasChatTagsClient = setmetatable({}, HasChatTagsBase)
 HasChatTagsClient.ClassName = "HasChatTagsClient"
 HasChatTagsClient.__index = HasChatTagsClient
 
-function HasChatTagsClient.new(player: Player, serviceBag: ServiceBag.ServiceBag)
-	local self = setmetatable(HasChatTagsBase.new(player), HasChatTagsClient)
+export type HasChatTagsClient =
+	typeof(setmetatable(
+		{} :: {
+			_serviceBag: ServiceBag.ServiceBag,
+			_chatTagBinder: Binder.Binder<ChatTagClient.ChatTagClient>,
+			_translator: typeof(ChatProviderTranslator),
+		},
+		{} :: typeof({ __index = HasChatTagsClient })
+	))
+	& HasChatTagsBase.HasChatTagsBase
+
+function HasChatTagsClient.new(player: Player, serviceBag: ServiceBag.ServiceBag): HasChatTagsClient
+	local self: HasChatTagsClient = setmetatable(HasChatTagsBase.new(player) :: any, HasChatTagsClient)
 
 	self._serviceBag = assert(serviceBag, "No serviceBag")
 	self._chatTagBinder = self._serviceBag:GetService(ChatTagClient)
@@ -28,11 +39,11 @@ function HasChatTagsClient.new(player: Player, serviceBag: ServiceBag.ServiceBag
 	return self
 end
 
-function HasChatTagsClient:GetChatTagBinder()
+function HasChatTagsClient.GetChatTagBinder(self: HasChatTagsClient): Binder.Binder<ChatTagClient.ChatTagClient>
 	return self._chatTagBinder
 end
 
-function HasChatTagsClient:GetAsRichText(): string?
+function HasChatTagsClient.GetAsRichText(self: HasChatTagsClient): string?
 	local lastChatTags = self._lastChatTags.Value
 	if not (lastChatTags and #lastChatTags > 0) then
 		return nil
@@ -42,7 +53,7 @@ function HasChatTagsClient:GetAsRichText(): string?
 	for index, tagData in lastChatTags do
 		output = output .. string.format("<font color='%s'>", Color3Utils.toWebHexString(tagData.TagColor))
 
-		local translatedText
+		local translatedText: string
 		if tagData.TagLocalizedText then
 			translatedText = LocalizedTextUtils.localizedTextToString(self._translator, tagData.TagLocalizedText)
 		else
@@ -63,4 +74,4 @@ function HasChatTagsClient:GetAsRichText(): string?
 	return output
 end
 
-return Binder.new("HasChatTags", HasChatTagsClient)
+return Binder.new("HasChatTags", HasChatTagsClient :: any) :: Binder.Binder<HasChatTagsClient>

--- a/src/chatproviderservice/src/Client/Commands/ChatProviderCommandServiceClient.lua
+++ b/src/chatproviderservice/src/Client/Commands/ChatProviderCommandServiceClient.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class ChatProviderCommandServiceClient
 ]=]
@@ -7,6 +7,8 @@ local require = require(script.Parent.loader).load(script)
 
 local Players = game:GetService("Players")
 
+local Binder = require("Binder")
+local ChatTagClient = require("ChatTagClient")
 local ChatTagCmdrUtils = require("ChatTagCmdrUtils")
 local Maid = require("Maid")
 local ServiceBag = require("ServiceBag")
@@ -16,17 +18,31 @@ local String = require("String")
 local ChatProviderCommandServiceClient = {}
 ChatProviderCommandServiceClient.ServiceName = "ChatProviderCommandServiceClient"
 
-function ChatProviderCommandServiceClient:Init(serviceBag: ServiceBag.ServiceBag)
-	assert(not self._serviceBag, "Already initialized")
+export type ChatProviderCommandServiceClient = typeof(setmetatable(
+	{} :: {
+		_serviceBag: ServiceBag.ServiceBag,
+		_maid: Maid.Maid,
+		_cmdrService: any, -- CmdrServiceClient (nonstrict, no exported type)
+		_chatProviderServiceClient: any, -- require cycle with ChatProviderServiceClient
+		_chatTagBinder: Binder.Binder<ChatTagClient.ChatTagClient>,
+	},
+	{} :: typeof({ __index = ChatProviderCommandServiceClient })
+))
+
+function ChatProviderCommandServiceClient.Init(
+	self: ChatProviderCommandServiceClient,
+	serviceBag: ServiceBag.ServiceBag
+)
+	assert(not (self :: any)._serviceBag, "Already initialized")
 	self._serviceBag = assert(serviceBag, "No serviceBag")
 	self._maid = Maid.new()
 
 	self._cmdrService = self._serviceBag:GetService(require("CmdrServiceClient"))
 	self._chatProviderServiceClient = self._serviceBag:GetService((require :: any)("ChatProviderServiceClient"))
-	self._chatTagBinder = self._serviceBag:GetService(require("ChatTagClient"))
+	self._chatTagBinder = self._serviceBag:GetService(ChatTagClient)
 end
 
-function ChatProviderCommandServiceClient:Start()
+function ChatProviderCommandServiceClient.Start(self: ChatProviderCommandServiceClient)
 	self._cmdrService:PromiseCmdr():Then(function(cmdr)
 		ChatTagCmdrUtils.registerChatTagKeys(cmdr, self)
 
@@ -34,7 +50,7 @@ function ChatProviderCommandServiceClient:Start()
 	end)
 end
 
-function ChatProviderCommandServiceClient:_registerChatCommand(cmdr)
+function ChatProviderCommandServiceClient._registerChatCommand(self: ChatProviderCommandServiceClient, cmdr: any)
 	self._maid:GiveTask(self._chatProviderServiceClient.MessageIncoming:Connect(function(textChatMessage)
 		if not (textChatMessage.TextSource and textChatMessage.TextSource.UserId == Players.LocalPlayer.UserId) then
 			return
@@ -46,8 +62,8 @@ function ChatProviderCommandServiceClient:_registerChatCommand(cmdr)
 	end))
 end
 
-function ChatProviderCommandServiceClient:GetChatTagKeyList()
-	local tagSet = {}
+function ChatProviderCommandServiceClient.GetChatTagKeyList(self: ChatProviderCommandServiceClient)
+	local tagSet: { [any]: boolean } = {}
 	for chatTag, _ in pairs(self._chatTagBinder:GetAllSet()) do
 		local tagKey = chatTag.ChatTagKey.Value
 		tagSet[tagKey] = true

--- a/src/chatproviderservice/src/Server/Binders/ChatTag.lua
+++ b/src/chatproviderservice/src/Server/Binders/ChatTag.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class ChatTag
 ]=]
@@ -13,8 +13,18 @@ local ChatTag = setmetatable({}, ChatTagBase)
 ChatTag.ClassName = "ChatTag"
 ChatTag.__index = ChatTag
 
-function ChatTag.new(folder: Folder, serviceBag: ServiceBag.ServiceBag)
-	local self = setmetatable(ChatTagBase.new(folder), ChatTag)
+export type ChatTag =
+	typeof(setmetatable(
+		{} :: {
+			_serviceBag: ServiceBag.ServiceBag,
+			_playerDataStoreService: any, -- PlayerDataStoreService (GetService returns the module type, not the instance type)
+		},
+		{} :: typeof({ __index = ChatTag })
+	))
+	& ChatTagBase.ChatTagBase
+
+function ChatTag.new(folder: Folder, serviceBag: ServiceBag.ServiceBag): ChatTag
+	local self: ChatTag = setmetatable(ChatTagBase.new(folder) :: any, ChatTag)
 
 	self._serviceBag = assert(serviceBag, "No serviceBag")
 	self._playerDataStoreService = self._serviceBag:GetService(require("PlayerDataStoreService"))
@@ -24,18 +34,18 @@ function ChatTag.new(folder: Folder, serviceBag: ServiceBag.ServiceBag)
 	return self
 end
 
-function ChatTag:_getPlayer(): Player
-	return self._obj:FindFirstAncestorWhichIsA("Player")
+function ChatTag._getPlayer(self: ChatTag): Player?
+	return self._obj:FindFirstAncestorWhichIsA("Player") :: Player?
 end
 
-function ChatTag:_loadData()
+function ChatTag._loadData(self: ChatTag)
 	local player = self:_getPlayer()
 	if not player then
 		return
 	end
 
 	local tagKey = self.ChatTagKey.Value
-	if not tagKey then
+	if tagKey == "" then
 		return
 	end
 
@@ -53,4 +63,4 @@ function ChatTag:_loadData()
 		end)
 end
 
-return Binder.new("ChatTag", ChatTag)
+return Binder.new("ChatTag", ChatTag :: any) :: Binder.Binder<ChatTag>

--- a/src/chatproviderservice/src/Server/Binders/HasChatTags.lua
+++ b/src/chatproviderservice/src/Server/Binders/HasChatTags.lua
@@ -1,11 +1,13 @@
---!nonstrict
+--!strict
 --[=[
 	@class HasChatTags
 ]=]
 
 local require = require(script.Parent.loader).load(script)
 
+local Binder = require("Binder")
 local BinderUtils = require("BinderUtils")
+local ChatTag = require("ChatTag")
 local ChatTagConstants = require("ChatTagConstants")
 local ChatTagDataUtils = require("ChatTagDataUtils")
 local HasChatTagsBase = require("HasChatTagsBase")
@@ -22,8 +24,10 @@ HasChatTags.__index = HasChatTags
 export type HasChatTags =
 	typeof(setmetatable(
 		{} :: {
+			_serviceBag: ServiceBag.ServiceBag,
+			_chatProviderService: any, -- require cycle with ChatProviderService
 			_chatTagsContainer: Folder,
-			_chatTagBinder: any,
+			_chatTagBinder: Binder.Binder<ChatTag.ChatTag>,
 		},
 		{} :: typeof({ __index = HasChatTags })
 	))
@@ -34,7 +38,7 @@ function HasChatTags.new(player: Player, serviceBag: ServiceBag.ServiceBag): Has
 
 	self._serviceBag = assert(serviceBag, "No serviceBag")
 	self._chatProviderService = self._serviceBag:GetService((require :: any)("ChatProviderService"))
-	self._chatTagBinder = self._serviceBag:GetService(require("ChatTag"))
+	self._chatTagBinder = self._serviceBag:GetService(ChatTag)
 
 	self._chatTagsContainer = Instance.new("Folder")
 	self._chatTagsContainer.Name = HasChatTagsConstants.TAG_CONTAINER_NAME
@@ -50,7 +54,7 @@ function HasChatTags.new(player: Player, serviceBag: ServiceBag.ServiceBag): Has
 	return self
 end
 
-function HasChatTags:GetChatTagBinder()
+function HasChatTags.GetChatTagBinder(self: HasChatTags): Binder.Binder<ChatTag.ChatTag>
 	return self._chatTagBinder
 end
 
@@ -58,8 +62,9 @@ end
 	Adds chat tags to the player
 
 	@param chatTagData ChatTagData
+	@return Instance
 ]=]
-function HasChatTags:AddChatTag(chatTagData: ChatTagDataUtils.ChatTagData)
+function HasChatTags.AddChatTag(self: HasChatTags, chatTagData: ChatTagDataUtils.ChatTagData): Instance
 	assert(ChatTagDataUtils.isChatTagData(chatTagData), "Bad chatTagData")
 
 	local tag = self._chatTagBinder:Create("Folder")
@@ -81,12 +86,13 @@ function HasChatTags:AddChatTag(chatTagData: ChatTagDataUtils.ChatTagData)
 	return tag
 end
 
-function HasChatTags:GetChatTagByKey(chatTagKey: string): ChatTagDataUtils.ChatTagData?
+function HasChatTags.GetChatTagByKey(self: HasChatTags, chatTagKey: string): ChatTag.ChatTag?
 	assert(type(chatTagKey) == "string", "Bad chatTagKey")
 
 	for _, item in BinderUtils.getChildren(self._chatTagBinder, self._chatTagsContainer) do
 		if item.ChatTagKey.Value == chatTagKey then
-			return item
+			-- cast dodges an old-solver recursive-type blowup on ChatTagData; value is already ChatTag.ChatTag
+			return item :: any
 		end
 	end
 
@@ -96,7 +102,7 @@ end
 --[=[
 	Removes all chat tags from the player
 ]=]
-function HasChatTags:ClearTags()
+function HasChatTags.ClearTags(self: HasChatTags)
 	for _, item in self._chatTagsContainer:GetChildren() do
 		if self._chatTagBinder:Get(item) then
 			item:Destroy()
@@ -104,4 +110,4 @@ function HasChatTags:ClearTags()
 	end
 end
 
-return PlayerBinder.new("HasChatTags", HasChatTags)
+return PlayerBinder.new("HasChatTags", HasChatTags :: any) :: Binder.Binder<HasChatTags>

--- a/src/chatproviderservice/src/Server/ChatProviderService.lua
+++ b/src/chatproviderservice/src/Server/ChatProviderService.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	Wrapper around Roblox chat service on the server
 	@class ChatProviderService
@@ -9,8 +9,10 @@ local require = require(script.Parent.loader).load(script)
 local ServerScriptService = game:GetService("ServerScriptService")
 local TextChatService = game:GetService("TextChatService")
 
+local Binder = require("Binder")
 local Brio = require("Brio")
 local ChatTagDataUtils = require("ChatTagDataUtils")
+local HasChatTags = require("HasChatTags")
 local LocalizedTextUtils = require("LocalizedTextUtils")
 local Maid = require("Maid")
 local Observable = require("Observable")
@@ -25,7 +27,19 @@ local Signal = require("Signal")
 local ChatProviderService = {}
 ChatProviderService.ServiceName = "ChatProviderService"
 
-function ChatProviderService:Init(serviceBag: ServiceBag.ServiceBag)
+export type ChatProviderService = typeof(setmetatable(
+	{} :: {
+		_serviceBag: ServiceBag.ServiceBag,
+		_maid: Maid.Maid,
+		MessageIncoming: Signal.Signal<any>,
+		_hasChatTagsBinder: Binder.Binder<HasChatTags.HasChatTags>,
+		_chatService: any, -- legacy ChatServiceRunner.ChatService (untyped)
+		_chatServicePromise: any, -- Promise.Promise<any>
+	},
+	{} :: typeof({ __index = ChatProviderService })
+))
+
+function ChatProviderService.Init(self: ChatProviderService, serviceBag: ServiceBag.ServiceBag)
 	self._serviceBag = assert(serviceBag, "No serviceBag")
 	self._maid = Maid.new()
 
@@ -43,25 +57,25 @@ function ChatProviderService:Init(serviceBag: ServiceBag.ServiceBag)
 
 	-- Binders
 	self._serviceBag:GetService(require("ChatTag"))
-	self._hasChatTagsBinder = self._serviceBag:GetService(require("HasChatTags"))
+	self._hasChatTagsBinder = self._serviceBag:GetService(HasChatTags)
 
 	-- note: normally we don't expose default API surfaces like this with defaults, however, because this only affects developers and this
 	-- tends to significantly improve feedback we're leaving this default configuration in place.
 	self:SetDeveloperTag(ChatTagDataUtils.createChatTagData({
 		TagText = "(dev)",
-		LocalizedText = LocalizedTextUtils.create("chatTags.dev"),
+		TagLocalizedText = LocalizedTextUtils.create("chatTags.dev"),
 		TagPriority = 15,
 		TagColor = Color3.fromRGB(245, 163, 27),
 	}))
 	self:SetAdminTag(ChatTagDataUtils.createChatTagData({
 		TagText = "(mod)",
-		LocalizedText = LocalizedTextUtils.create("chatTags.mod"),
+		TagLocalizedText = LocalizedTextUtils.create("chatTags.mod"),
 		TagPriority = 10,
 		TagColor = Color3.fromRGB(78, 205, 196),
 	}))
 end
 
-function ChatProviderService:AddChatCommand(textChatCommand: TextChatCommand)
+function ChatProviderService.AddChatCommand(_self: ChatProviderService, textChatCommand: TextChatCommand)
 	assert(typeof(textChatCommand) == "Instance", "Bad textChatCommand")
 
 	textChatCommand.Parent = PreferredParentUtils.getPreferredParent(TextChatService, "ChatProviderCommands")
@@ -73,11 +87,11 @@ end
 	@param chatTagData ChatTagData?
 	@return Maid
 ]=]
-function ChatProviderService:SetDeveloperTag(chatTagData: ChatTagDataUtils.ChatTagData)
+function ChatProviderService.SetDeveloperTag(self: ChatProviderService, chatTagData: ChatTagDataUtils.ChatTagData?)
 	assert(ChatTagDataUtils.isChatTagData(chatTagData) or chatTagData == nil, "Bad chatTagData")
 
 	if chatTagData then
-		local permissionService = self._serviceBag:GetService(require("PermissionService"))
+		local permissionService: any = self._serviceBag:GetService(require("PermissionService"))
 		local observeBrio = permissionService:ObservePermissionedPlayersBrio(PermissionLevel.CREATOR)
 
 		self._maid._developer = self:_addObservablePlayerTag(observeBrio, chatTagData)
@@ -92,24 +106,24 @@ end
 	@param chatTagData ChatTagData?
 	@return Maid
 ]=]
-function ChatProviderService:SetAdminTag(chatTagData: ChatTagDataUtils.ChatTagData?)
+function ChatProviderService.SetAdminTag(self: ChatProviderService, chatTagData: ChatTagDataUtils.ChatTagData?)
 	assert(ChatTagDataUtils.isChatTagData(chatTagData) or chatTagData == nil, "Bad chatTagData")
 
 	if chatTagData then
-		local permissionService = self._serviceBag:GetService(require("PermissionService"))
+		local permissionService: any = self._serviceBag:GetService(require("PermissionService"))
 		local observeBrio = permissionService:ObservePermissionedPlayersBrio(PermissionLevel.ADMIN):Pipe({
 			RxBrioUtils.flatMapBrio(function(player: Player)
 				return Rx.fromPromise(permissionService:PromiseIsPermissionLevel(player, PermissionLevel.CREATOR))
 					:Pipe({
-						Rx.switchMap(function(isAlsoCreator)
+						Rx.switchMap(function(isAlsoCreator): any
 							if not isAlsoCreator then
 								return Rx.of(player)
 							else
 								return Rx.EMPTY
 							end
-						end),
+						end) :: any,
 					})
-			end),
+			end) :: any,
 		})
 
 		self._maid._admin = self:_addObservablePlayerTag(observeBrio, chatTagData)
@@ -118,10 +132,11 @@ function ChatProviderService:SetAdminTag(chatTagData: ChatTagDataUtils.ChatTagDa
 	end
 end
 
-function ChatProviderService:_addObservablePlayerTag(
+function ChatProviderService._addObservablePlayerTag(
+	self: ChatProviderService,
 	observePlayersBrio: Observable.Observable<Brio.Brio<Player>>,
 	chatTagData: ChatTagDataUtils.ChatTagData
-)
+): Maid.Maid
 	assert(ChatTagDataUtils.isChatTagData(chatTagData), "Bad chatTagData")
 
 	local topMaid = Maid.new()
@@ -153,14 +168,15 @@ end
 	@param chatTagData ChatTagData
 	@return Promise<Instance>
 ]=]
-function ChatProviderService:PromiseAddChatTag(
+function ChatProviderService.PromiseAddChatTag(
+	self: ChatProviderService,
 	player: Player,
 	chatTagData: ChatTagDataUtils.ChatTagData
 ): Promise.Promise<Instance>
 	assert(typeof(player) == "Instance" and player:IsA("Player"), "Bad player")
 	assert(ChatTagDataUtils.isChatTagData(chatTagData), "Bad chatTagData")
 
-	local hasChatTagBinder = self._serviceBag:GetService(require("HasChatTags"))
+	local hasChatTagBinder = self._serviceBag:GetService(HasChatTags)
 
 	return hasChatTagBinder:Promise(player):Then(function(hasChatTag)
 		return hasChatTag:AddChatTag(chatTagData)
@@ -172,10 +188,10 @@ end
 
 	@param player Player
 ]=]
-function ChatProviderService:ClearChatTags(player: Player)
+function ChatProviderService.ClearChatTags(self: ChatProviderService, player: Player)
 	assert(typeof(player) == "Instance" and player:IsA("Player"), "Bad player")
 
-	local hasChatTagBinder = self._serviceBag:GetService(require("HasChatTags"))
+	local hasChatTagBinder = self._serviceBag:GetService(HasChatTags)
 	local hasChatTags = hasChatTagBinder:Get(player)
 
 	if hasChatTags then
@@ -190,7 +206,8 @@ end
 	@param chatTagDataList { ChatTagData }
 	@return Promise
 ]=]
-function ChatProviderService:PromiseSetSpeakerTags(
+function ChatProviderService.PromiseSetSpeakerTags(
+	self: ChatProviderService,
 	speakerName: string,
 	chatTagDataList: { ChatTagDataUtils.ChatTagData }
 ): Promise.Promise<()>
@@ -208,7 +225,7 @@ function ChatProviderService:PromiseSetSpeakerTags(
 	end)
 end
 
-function ChatProviderService:_getChatServiceAsync()
+function ChatProviderService._getChatServiceAsync(self: ChatProviderService): any
 	if self._chatService then
 		return self._chatService
 	end
@@ -219,13 +236,13 @@ function ChatProviderService:_getChatServiceAsync()
 		return nil
 	end
 
-	local chatService = require(chatServiceRunner:WaitForChild("ChatService"))
+	local chatService = (require :: any)(chatServiceRunner:WaitForChild("ChatService"))
 	self._chatService = chatService or error("No chatService retrieved")
 
 	return self._chatService
 end
 
-function ChatProviderService:_promiseChatService(): Promise.Promise<any>
+function ChatProviderService._promiseChatService(self: ChatProviderService): Promise.Promise<any>
 	if self._chatService then
 		return Promise.resolved(self._chatService)
 	end
@@ -241,7 +258,7 @@ function ChatProviderService:_promiseChatService(): Promise.Promise<any>
 	return Promise.resolved(self._chatServicePromise)
 end
 
-function ChatProviderService:_promiseSpeaker(speakerName: string)
+function ChatProviderService._promiseSpeaker(self: ChatProviderService, speakerName: string): Promise.Promise<any>
 	assert(type(speakerName) == "string", "Bad speakerName")
 
 	return self:_promiseChatService():Then(function(chatService)

--- a/src/chatproviderservice/src/Server/Commands/ChatProviderCommandService.lua
+++ b/src/chatproviderservice/src/Server/Commands/ChatProviderCommandService.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class ChatProviderCommandService
 ]=]
@@ -7,8 +7,11 @@ local require = require(script.Parent.loader).load(script)
 
 local Players = game:GetService("Players")
 
+local Binder = require("Binder")
+local ChatTag = require("ChatTag")
 local ChatTagCmdrUtils = require("ChatTagCmdrUtils")
 local ChatTagDataUtils = require("ChatTagDataUtils")
+local HasChatTags = require("HasChatTags")
 local Maid = require("Maid")
 local PlayerUtils = require("PlayerUtils")
 local ServiceBag = require("ServiceBag")
@@ -17,8 +20,22 @@ local Set = require("Set")
 local ChatProviderCommandService = {}
 ChatProviderCommandService.ServiceName = "ChatProviderCommandService"
 
-function ChatProviderCommandService:Init(serviceBag: ServiceBag.ServiceBag)
-	assert(not self._serviceBag, "Already initialized")
+export type ChatProviderCommandService = typeof(setmetatable(
+	{} :: {
+		_serviceBag: ServiceBag.ServiceBag,
+		_maid: Maid.Maid,
+		_cmdrService: any, -- CmdrService (GetService returns the module type, not the instance type)
+		_permissionService: any, -- PermissionService (GetService returns the module type, not the instance type)
+		_chatProviderService: any, -- require cycle with ChatProviderService
+		_chatTagBinder: Binder.Binder<ChatTag.ChatTag>,
+		_hasChatTagsBinder: Binder.Binder<HasChatTags.HasChatTags>,
+		_remoting: any, -- never assigned in this service (pre-existing)
+	},
+	{} :: typeof({ __index = ChatProviderCommandService })
+))
+
+function ChatProviderCommandService.Init(self: ChatProviderCommandService, serviceBag: ServiceBag.ServiceBag)
+	assert(not (self :: any)._serviceBag, "Already initialized")
 	self._serviceBag = assert(serviceBag, "No serviceBag")
 	self._maid = Maid.new()
 
@@ -28,16 +45,16 @@ function ChatProviderCommandService:Init(serviceBag: ServiceBag.ServiceBag)
 
 	-- Internal
 	self._chatProviderService = self._serviceBag:GetService((require :: any)("ChatProviderService"))
-	self._chatTagBinder = self._serviceBag:GetService(require("ChatTag"))
-	self._hasChatTagsBinder = self._serviceBag:GetService(require("HasChatTags"))
+	self._chatTagBinder = self._serviceBag:GetService(ChatTag)
+	self._hasChatTagsBinder = self._serviceBag:GetService(HasChatTags)
 end
 
-function ChatProviderCommandService:Start()
+function ChatProviderCommandService.Start(self: ChatProviderCommandService)
 	self:_registerCommands()
 	self:_createActivateChatCommand()
 end
 
-function ChatProviderCommandService:_createActivateChatCommand()
+function ChatProviderCommandService._createActivateChatCommand(self: ChatProviderCommandService)
 	local command = Instance.new("TextChatCommand")
 	command.Name = "OpenCmdrCommand"
 	command.PrimaryAlias = "/cmdr"
@@ -59,8 +76,8 @@ function ChatProviderCommandService:_createActivateChatCommand()
 	self._chatProviderService:AddChatCommand(command)
 end
 
-function ChatProviderCommandService:GetChatTagKeyList()
-	local tagSet = {}
+function ChatProviderCommandService.GetChatTagKeyList(self: ChatProviderCommandService)
+	local tagSet: { [any]: boolean } = {}
 	for chatTag, _ in pairs(self._chatTagBinder:GetAllSet()) do
 		local tagKey = chatTag.ChatTagKey.Value
 		tagSet[tagKey] = true
@@ -69,7 +86,7 @@ function ChatProviderCommandService:GetChatTagKeyList()
 	return Set.toList(tagSet)
 end
 
-function ChatProviderCommandService:_registerCommands()
+function ChatProviderCommandService._registerCommands(self: ChatProviderCommandService)
 	self._cmdrService:PromiseCmdr():Then(function(cmdr)
 		ChatTagCmdrUtils.registerChatTagKeys(cmdr, self)
 	end)
@@ -95,17 +112,17 @@ function ChatProviderCommandService:_registerCommands()
 				Type = "color3",
 				Description = "Color for the tag to have",
 				Optional = true,
-				Default = Color3.fromRGB(255, 170, 0),
+				Default = Color3.fromRGB(255, 170, 0) :: any,
 			},
 			{
 				Name = "TagPriority",
 				Type = "number",
 				Description = "Priority for the tag to have",
 				Optional = true,
-				Default = 0,
+				Default = 0 :: any,
 			},
 		},
-	}, function(_context, player, tagText, tagColor, priority)
+	}, function(_context, player: Player, tagText, tagColor, priority)
 		self._chatProviderService:PromiseAddChatTag(
 			player,
 			ChatTagDataUtils.createChatTagData({
@@ -130,7 +147,7 @@ function ChatProviderCommandService:_registerCommands()
 				Description = "Player to add a tag for",
 			},
 		},
-	}, function(_context, player)
+	}, function(_context, player: Player)
 		self._chatProviderService:ClearChatTags(player)
 
 		return string.format("Cleared chat tags on a player %q", PlayerUtils.formatName(player))
@@ -159,7 +176,7 @@ function ChatProviderCommandService:_registerCommands()
 				Default = true,
 			},
 		},
-	}, function(_context, player, chatTagKey, chatTagDisabled)
+	}, function(_context, player: Player, chatTagKey, chatTagDisabled)
 		local hasChatTags = self._hasChatTagsBinder:Get(player)
 
 		if not hasChatTags then
@@ -182,7 +199,7 @@ function ChatProviderCommandService:_registerCommands()
 	end)
 end
 
-function ChatProviderCommandService:Destroy()
+function ChatProviderCommandService.Destroy(self: ChatProviderCommandService)
 	self._maid:DoCleaning()
 end
 

--- a/src/chatproviderservice/src/Shared/Binders/ChatTagBase.lua
+++ b/src/chatproviderservice/src/Shared/Binders/ChatTagBase.lua
@@ -28,7 +28,7 @@ export type ChatTagBase =
 
 			-- Public
 			UserDisabled: AttributeValue.AttributeValue<boolean>,
-			ChatTagKey: AttributeValue.AttributeValue<boolean>,
+			ChatTagKey: AttributeValue.AttributeValue<string>,
 		},
 		{} :: typeof({ __index = ChatTagBase })
 	))
@@ -43,7 +43,7 @@ function ChatTagBase.new(obj: Folder): ChatTagBase
 	self._chatTagPriority = AttributeValue.new(self._obj, ChatTagConstants.TAG_PRIORITY_ATTRIBUTE, 0)
 
 	self.UserDisabled = AttributeValue.new(self._obj, ChatTagConstants.USER_DISABLED_ATTRIBUTE, false)
-	self.ChatTagKey = AttributeValue.new(self._obj, ChatTagConstants.TAG_KEY_ATTRIBUTE, false)
+	self.ChatTagKey = AttributeValue.new(self._obj, ChatTagConstants.TAG_KEY_ATTRIBUTE, "")
 
 	return self
 end

--- a/src/chatproviderservice/src/Shared/Data/ChatTagDataUtils.lua
+++ b/src/chatproviderservice/src/Shared/Data/ChatTagDataUtils.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class ChatTagDataUtils
 ]=]


### PR DESCRIPTION
Converts the remaining ChatProviderService package modules from --!nonstrict to --!strict with explicit Nevermore-style type annotations. Along the way it fixes two latent bugs the type checker surfaced: the developer and admin tags were built with a misnamed LocalizedText field (now TagLocalizedText) so their localized text was silently dropped, and ChatTagBase typed ChatTagKey as a boolean even though it stores the string tag key. No public API behavior changes otherwise.