### PR TITLE
feat(deathreport): convert package to --!strict

### DIFF
--- a/src/deathreport/src/Client/DeathReportBindersClient.lua
+++ b/src/deathreport/src/Client/DeathReportBindersClient.lua
@@ -7,11 +7,14 @@ local require = require(script.Parent.loader).load(script)
 
 local Binder = require("Binder")
 local BinderProvider = require("BinderProvider")
+local PlayerDeathTrackerClient = require("PlayerDeathTrackerClient")
+local PlayerKillTrackerClient = require("PlayerKillTrackerClient")
 local ServiceBag = require("ServiceBag")
+local TeamKillTrackerClient = require("TeamKillTrackerClient")
 
 return BinderProvider.new(script.Name, function(self, serviceBag: ServiceBag.ServiceBag)
 	-- Stats
-	self:Add(Binder.new("TeamKillTracker", require("TeamKillTrackerClient"), serviceBag))
-	self:Add(Binder.new("PlayerKillTracker", require("PlayerKillTrackerClient"), serviceBag))
-	self:Add(Binder.new("PlayerDeathTracker", require("PlayerDeathTrackerClient"), serviceBag))
+	self:Add(Binder.new("TeamKillTracker", TeamKillTrackerClient :: any, serviceBag))
+	self:Add(Binder.new("PlayerKillTracker", PlayerKillTrackerClient :: any, serviceBag))
+	self:Add(Binder.new("PlayerDeathTracker", PlayerDeathTrackerClient :: any, serviceBag))
 end)

--- a/src/deathreport/src/Client/DeathReportServiceClient.lua
+++ b/src/deathreport/src/Client/DeathReportServiceClient.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	Centralized death reporting service which can be used to track
 	deaths.
@@ -105,7 +105,7 @@ end
 	@param character Model
 	@return Observable<DeathReport>
 ]=]
-function DeathReportServiceClient:ObserveCharacterKillerReports(character)
+function DeathReportServiceClient:ObserveCharacterKillerReports(character: Model)
 	assert(typeof(character) == "Instance" and character:IsA("Model"), "Bad character")
 
 	return self._reportProcessor:ObserveCharacterKillerReports(character)
@@ -117,7 +117,7 @@ end
 	@param character Model
 	@return Observable<DeathReport>
 ]=]
-function DeathReportServiceClient:ObserveCharacterDeathReports(character)
+function DeathReportServiceClient:ObserveCharacterDeathReports(character: Model)
 	assert(typeof(character) == "Instance" and character:IsA("Model"), "Bad character")
 
 	return self._reportProcessor:ObserveCharacterDeathReports(character)
@@ -131,7 +131,7 @@ function DeathReportServiceClient:GetLastDeathReports()
 	return self._lastDeathReports
 end
 
-function DeathReportServiceClient:_handleClientEvent(deathReport)
+function DeathReportServiceClient:_handleClientEvent(deathReport: DeathReportUtils.DeathReport)
 	assert(DeathReportUtils.isDeathReport(deathReport), "Bad deathreport")
 
 	if typeof(deathReport.adornee) ~= "Instance" then

--- a/src/deathreport/src/Client/Stats/PlayerDeathTrackerClient.lua
+++ b/src/deathreport/src/Client/Stats/PlayerDeathTrackerClient.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class PlayerDeathTrackerClient
 ]=]
@@ -12,26 +12,36 @@ local PlayerDeathTrackerClient = setmetatable({}, BaseObject)
 PlayerDeathTrackerClient.ClassName = "PlayerDeathTrackerClient"
 PlayerDeathTrackerClient.__index = PlayerDeathTrackerClient
 
-function PlayerDeathTrackerClient.new(tracker, serviceBag: ServiceBag.ServiceBag)
-	local self = setmetatable(BaseObject.new(tracker), PlayerDeathTrackerClient)
+export type PlayerDeathTrackerClient =
+	typeof(setmetatable(
+		{} :: {
+			_serviceBag: ServiceBag.ServiceBag,
+			DeathsChanged: RBXScriptSignal,
+		},
+		{} :: typeof({ __index = PlayerDeathTrackerClient })
+	))
+	& BaseObject.BaseObject
+
+function PlayerDeathTrackerClient.new(tracker: IntValue, serviceBag: ServiceBag.ServiceBag): PlayerDeathTrackerClient
+	local self: PlayerDeathTrackerClient = setmetatable(BaseObject.new(tracker) :: any, PlayerDeathTrackerClient)
 
 	self._serviceBag = assert(serviceBag, "No serviceBag")
 
-	self.DeathsChanged = self._obj.Changed
+	self.DeathsChanged = (self._obj :: IntValue).Changed
 
 	return self
 end
 
-function PlayerDeathTrackerClient:GetDeathValue()
-	return self._obj
+function PlayerDeathTrackerClient.GetDeathValue(self: PlayerDeathTrackerClient): IntValue
+	return self._obj :: IntValue
 end
 
-function PlayerDeathTrackerClient:GetPlayer()
-	return self._obj.Parent
+function PlayerDeathTrackerClient.GetPlayer(self: PlayerDeathTrackerClient): Instance?
+	return (self._obj :: IntValue).Parent
 end
 
-function PlayerDeathTrackerClient:GetKills()
-	return self._obj.Value
+function PlayerDeathTrackerClient.GetKills(self: PlayerDeathTrackerClient): number
+	return (self._obj :: IntValue).Value
 end
 
 return PlayerDeathTrackerClient

--- a/src/deathreport/src/Client/Stats/PlayerKillTrackerClient.lua
+++ b/src/deathreport/src/Client/Stats/PlayerKillTrackerClient.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class PlayerKillTrackerClient
 ]=]
@@ -12,8 +12,19 @@ local PlayerKillTrackerClient = setmetatable({}, BaseObject)
 PlayerKillTrackerClient.ClassName = "PlayerKillTrackerClient"
 PlayerKillTrackerClient.__index = PlayerKillTrackerClient
 
-function PlayerKillTrackerClient.new(tracker, serviceBag: ServiceBag.ServiceBag)
-	local self = setmetatable(BaseObject.new(tracker), PlayerKillTrackerClient)
+export type PlayerKillTrackerClient =
+	typeof(setmetatable(
+		{} :: {
+			_obj: IntValue,
+			_serviceBag: ServiceBag.ServiceBag,
+			KillsChanged: RBXScriptSignal,
+		},
+		{} :: typeof({ __index = PlayerKillTrackerClient })
+	))
+	& BaseObject.BaseObject
+
+function PlayerKillTrackerClient.new(tracker: IntValue, serviceBag: ServiceBag.ServiceBag): PlayerKillTrackerClient
+	local self: PlayerKillTrackerClient = setmetatable(BaseObject.new(tracker) :: any, PlayerKillTrackerClient)
 
 	self._serviceBag = assert(serviceBag, "No serviceBag")
 
@@ -22,15 +33,15 @@ function PlayerKillTrackerClient.new(tracker, serviceBag: ServiceBag.ServiceBag)
 	return self
 end
 
-function PlayerKillTrackerClient:GetKillValue()
+function PlayerKillTrackerClient.GetKillValue(self: PlayerKillTrackerClient): IntValue
 	return self._obj
 end
 
-function PlayerKillTrackerClient:GetPlayer()
+function PlayerKillTrackerClient.GetPlayer(self: PlayerKillTrackerClient): Instance?
 	return self._obj.Parent
 end
 
-function PlayerKillTrackerClient:GetKills()
+function PlayerKillTrackerClient.GetKills(self: PlayerKillTrackerClient): number
 	return self._obj.Value
 end
 

--- a/src/deathreport/src/Client/Stats/TeamKillTrackerClient.lua
+++ b/src/deathreport/src/Client/Stats/TeamKillTrackerClient.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class TeamKillTrackerClient
 ]=]
@@ -11,24 +11,33 @@ local TeamKillTrackerClient = setmetatable({}, BaseObject)
 TeamKillTrackerClient.ClassName = "TeamKillTrackerClient"
 TeamKillTrackerClient.__index = TeamKillTrackerClient
 
-function TeamKillTrackerClient.new(tracker)
-	local self = setmetatable(BaseObject.new(tracker), TeamKillTrackerClient)
+export type TeamKillTrackerClient =
+	typeof(setmetatable(
+		{} :: {
+			KillsChanged: RBXScriptSignal,
+		},
+		{} :: typeof({ __index = TeamKillTrackerClient })
+	))
+	& BaseObject.BaseObject
 
-	self.KillsChanged = self._obj.Changed
+function TeamKillTrackerClient.new(tracker: IntValue): TeamKillTrackerClient
+	local self: TeamKillTrackerClient = setmetatable(BaseObject.new(tracker) :: any, TeamKillTrackerClient)
+
+	self.KillsChanged = self:GetKillValue().Changed
 
 	return self
 end
 
-function TeamKillTrackerClient:GetKillValue()
-	return self._obj
+function TeamKillTrackerClient.GetKillValue(self: TeamKillTrackerClient): IntValue
+	return self._obj :: IntValue
 end
 
-function TeamKillTrackerClient:GetTeam()
-	return self._obj.Parent
+function TeamKillTrackerClient.GetTeam(self: TeamKillTrackerClient): Instance?
+	return self:GetKillValue().Parent
 end
 
-function TeamKillTrackerClient:GetKills()
-	return self._obj.Value
+function TeamKillTrackerClient.GetKills(self: TeamKillTrackerClient): number
+	return self:GetKillValue().Value
 end
 
 return TeamKillTrackerClient

--- a/src/deathreport/src/Server/DeathReportBindersServer.lua
+++ b/src/deathreport/src/Server/DeathReportBindersServer.lua
@@ -7,11 +7,14 @@ local require = require(script.Parent.loader).load(script)
 
 local Binder = require("Binder")
 local BinderProvider = require("BinderProvider")
+local PlayerDeathTracker = require("PlayerDeathTracker")
+local PlayerKillTracker = require("PlayerKillTracker")
 local ServiceBag = require("ServiceBag")
+local TeamKillTracker = require("TeamKillTracker")
 
 return BinderProvider.new(script.Name, function(self, serviceBag: ServiceBag.ServiceBag)
 	-- Stats
-	self:Add(Binder.new("TeamKillTracker", require("TeamKillTracker"), serviceBag))
-	self:Add(Binder.new("PlayerKillTracker", require("PlayerKillTracker"), serviceBag))
-	self:Add(Binder.new("PlayerDeathTracker", require("PlayerDeathTracker"), serviceBag))
+	self:Add(Binder.new("TeamKillTracker", TeamKillTracker :: any, serviceBag))
+	self:Add(Binder.new("PlayerKillTracker", PlayerKillTracker :: any, serviceBag))
+	self:Add(Binder.new("PlayerDeathTracker", PlayerDeathTracker :: any, serviceBag))
 end)

--- a/src/deathreport/src/Server/DeathTrackedHumanoid.lua
+++ b/src/deathreport/src/Server/DeathTrackedHumanoid.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class DeathTrackedHumanoid
 ]=]
@@ -14,11 +14,22 @@ local DeathTrackedHumanoid = setmetatable({}, BaseObject)
 DeathTrackedHumanoid.ClassName = "DeathTrackedHumanoid"
 DeathTrackedHumanoid.__index = DeathTrackedHumanoid
 
-function DeathTrackedHumanoid.new(humanoid: Humanoid, serviceBag: ServiceBag.ServiceBag)
-	local self = setmetatable(BaseObject.new(humanoid), DeathTrackedHumanoid)
+export type DeathTrackedHumanoid =
+	typeof(setmetatable(
+		{} :: {
+			_obj: Humanoid,
+			_serviceBag: ServiceBag.ServiceBag,
+			_deathReportService: DeathReportService.DeathReportService,
+		},
+		{} :: typeof({ __index = DeathTrackedHumanoid })
+	))
+	& BaseObject.BaseObject
+
+function DeathTrackedHumanoid.new(humanoid: Humanoid, serviceBag: ServiceBag.ServiceBag): DeathTrackedHumanoid
+	local self: DeathTrackedHumanoid = setmetatable(BaseObject.new(humanoid) :: any, DeathTrackedHumanoid)
 
 	self._serviceBag = assert(serviceBag, "No serviceBag")
-	self._deathReportService = self._serviceBag:GetService(DeathReportService)
+	self._deathReportService = self._serviceBag:GetService(DeathReportService) :: any
 
 	self._maid._diedEvent = self._obj:GetPropertyChangedSignal("Health"):Connect(function()
 		self:_handleDeath()
@@ -27,7 +38,7 @@ function DeathTrackedHumanoid.new(humanoid: Humanoid, serviceBag: ServiceBag.Ser
 	return self
 end
 
-function DeathTrackedHumanoid:_handleDeath()
+function DeathTrackedHumanoid._handleDeath(self: DeathTrackedHumanoid)
 	-- make sure we haven't already reported and this is a deferred event.
 	if not self._maid._diedEvent then
 		return

--- a/src/deathreport/src/Server/Stats/PlayerDeathTracker.lua
+++ b/src/deathreport/src/Server/Stats/PlayerDeathTracker.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class PlayerDeathTracker
 ]=]
@@ -13,15 +13,27 @@ local PlayerDeathTracker = setmetatable({}, BaseObject)
 PlayerDeathTracker.ClassName = "PlayerDeathTracker"
 PlayerDeathTracker.__index = PlayerDeathTracker
 
-function PlayerDeathTracker.new(scoreObject, serviceBag: ServiceBag.ServiceBag)
-	local self = setmetatable(BaseObject.new(scoreObject), PlayerDeathTracker)
+export type PlayerDeathTracker =
+	typeof(setmetatable(
+		{} :: {
+			_obj: IntValue,
+			_serviceBag: ServiceBag.ServiceBag,
+			_deathReportService: DeathReportService.DeathReportService,
+			_player: Player,
+		},
+		{} :: typeof({ __index = PlayerDeathTracker })
+	))
+	& BaseObject.BaseObject
+
+function PlayerDeathTracker.new(scoreObject: IntValue, serviceBag: ServiceBag.ServiceBag): PlayerDeathTracker
+	local self: PlayerDeathTracker = setmetatable(BaseObject.new(scoreObject) :: any, PlayerDeathTracker)
 
 	self._serviceBag = assert(serviceBag, "No serviceBag")
-	self._deathReportService = self._serviceBag:GetService(DeathReportService)
+	self._deathReportService = self._serviceBag:GetService(DeathReportService) :: any
 
-	self._player = self._obj.Parent
-
-	assert(self._player and self._player:IsA("Player"), "Bad player")
+	local player = self._obj.Parent
+	assert(player and player:IsA("Player"), "Bad player")
+	self._player = player
 
 	self._maid:GiveTask(self._deathReportService:ObservePlayerDeathReports(self._player):Subscribe(function(deathReport)
 		assert(deathReport.player == self._player, "Bad player")

--- a/src/deathreport/src/Server/Stats/PlayerKillTracker.lua
+++ b/src/deathreport/src/Server/Stats/PlayerKillTracker.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class PlayerKillTracker
 ]=]
@@ -16,22 +16,24 @@ PlayerKillTracker.__index = PlayerKillTracker
 export type PlayerKillTracker =
 	typeof(setmetatable(
 		{} :: {
+			_obj: IntValue,
 			_serviceBag: ServiceBag.ServiceBag,
-			_deathReportService: any,
+			_deathReportService: DeathReportService.DeathReportService,
 			_player: Player,
 		},
 		{} :: typeof({ __index = PlayerKillTracker })
 	))
 	& BaseObject.BaseObject
 
-function PlayerKillTracker.new(scoreObject, serviceBag: ServiceBag.ServiceBag): PlayerKillTracker
+function PlayerKillTracker.new(scoreObject: IntValue, serviceBag: ServiceBag.ServiceBag): PlayerKillTracker
 	local self: PlayerKillTracker = setmetatable(BaseObject.new(scoreObject) :: any, PlayerKillTracker)
 
 	self._serviceBag = assert(serviceBag, "No serviceBag")
-	self._deathReportService = self._serviceBag:GetService(DeathReportService)
+	self._deathReportService = self._serviceBag:GetService(DeathReportService) :: any
 
-	self._player = self._obj.Parent
-	assert(self._player and self._player:IsA("Player"), "Bad player")
+	local player = self._obj.Parent
+	assert(player and player:IsA("Player"), "Bad player")
+	self._player = player
 
 	self._maid:GiveTask(
 		self._deathReportService:ObservePlayerKillerReports(self._player):Subscribe(function(deathReport)
@@ -43,15 +45,15 @@ function PlayerKillTracker.new(scoreObject, serviceBag: ServiceBag.ServiceBag): 
 	return self
 end
 
-function PlayerKillTracker:GetKillValue()
+function PlayerKillTracker.GetKillValue(self: PlayerKillTracker): IntValue
 	return self._obj
 end
 
-function PlayerKillTracker:GetPlayer(): Player
-	return self._obj.Parent
+function PlayerKillTracker.GetPlayer(self: PlayerKillTracker): Player
+	return self._player
 end
 
-function PlayerKillTracker:GetKills(): number
+function PlayerKillTracker.GetKills(self: PlayerKillTracker): number
 	return self._obj.Value
 end
 

--- a/src/deathreport/src/Server/Stats/TeamKillTracker.lua
+++ b/src/deathreport/src/Server/Stats/TeamKillTracker.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class TeamKillTracker
 ]=]
@@ -7,42 +7,56 @@ local require = require(script.Parent.loader).load(script)
 
 local BaseObject = require("BaseObject")
 local DeathReportService = require("DeathReportService")
+local DeathReportUtils = require("DeathReportUtils")
 local ServiceBag = require("ServiceBag")
 
 local TeamKillTracker = setmetatable({}, BaseObject)
 TeamKillTracker.ClassName = "TeamKillTracker"
 TeamKillTracker.__index = TeamKillTracker
 
-function TeamKillTracker.new(scoreObject, serviceBag: ServiceBag.ServiceBag)
-	local self = setmetatable(BaseObject.new(scoreObject), TeamKillTracker)
+export type TeamKillTracker =
+	typeof(setmetatable(
+		{} :: {
+			_serviceBag: ServiceBag.ServiceBag,
+			_deathReportService: DeathReportService.DeathReportService,
+			_team: Team,
+		},
+		{} :: typeof({ __index = TeamKillTracker })
+	))
+	& BaseObject.BaseObject
+
+function TeamKillTracker.new(scoreObject: IntValue, serviceBag: ServiceBag.ServiceBag): TeamKillTracker
+	local self: TeamKillTracker = setmetatable(BaseObject.new(scoreObject) :: any, TeamKillTracker)
 
 	self._serviceBag = assert(serviceBag, "No serviceBag")
-	self._deathReportService = self._serviceBag:GetService(DeathReportService)
+	self._deathReportService = self._serviceBag:GetService(DeathReportService) :: any
 
 	-- Hm.... this is suppose to be generic, but this is not....
 	self._maid:GiveTask(self._deathReportService.NewDeathReport:Connect(function(deathReport)
 		self:_handleDeathReport(deathReport)
 	end))
 
-	self._team = self._obj.Parent
-	assert(self._team and self._team:IsA("Team"), "Bad team")
+	local team = (self._obj :: IntValue).Parent
+	assert(team and team:IsA("Team"), "Bad team")
+	self._team = team
 
 	return self
 end
 
-function TeamKillTracker:GetTeam()
-	return self._obj.Parent
+function TeamKillTracker.GetTeam(self: TeamKillTracker): Instance?
+	return (self._obj :: IntValue).Parent
 end
 
-function TeamKillTracker:GetKills()
-	return self._obj.Value
+function TeamKillTracker.GetKills(self: TeamKillTracker): number
+	return (self._obj :: IntValue).Value
 end
 
-function TeamKillTracker:_handleDeathReport(deathReport)
+function TeamKillTracker._handleDeathReport(self: TeamKillTracker, deathReport: DeathReportUtils.DeathReport)
 	if deathReport.killerPlayer then
 		if deathReport.killerPlayer.Team == self._team then
 			-- increment kills
-			self._obj.Value = self._obj.Value + 1
+			local obj = self._obj :: IntValue
+			obj.Value = obj.Value + 1
 		end
 	end
 end

--- a/src/deathreport/src/Shared/DeathReportUtils.lua
+++ b/src/deathreport/src/Shared/DeathReportUtils.lua
@@ -1,4 +1,4 @@
---!nonstrict
+--!strict
 --[=[
 	@class DeathReportUtils
 ]=]
@@ -19,11 +19,11 @@ local DeathReportUtils = {}
 	@param weaponData WeaponData
 	@return DeathReport
 ]=]
-function DeathReportUtils.fromDeceasedHumanoid(humanoid: Humanoid, weaponData: WeaponData?)
+function DeathReportUtils.fromDeceasedHumanoid(humanoid: Humanoid, weaponData: WeaponData?): DeathReport
 	assert(DeathReportUtils.isWeaponData(weaponData) or weaponData == nil, "Bad weaponData")
 
 	local killerHumanoid = HumanoidKillerUtils.getKillerHumanoidOfHumanoid(humanoid)
-	local character = humanoid.Parent
+	local character = assert(humanoid.Parent, "No character for humanoid")
 	return DeathReportUtils.create(character, killerHumanoid, weaponData)
 end
 
@@ -44,7 +44,7 @@ export type DeathReport = {
 function DeathReportUtils.create(adornee: Instance, killerAdornee: Instance?, weaponData: WeaponData?): DeathReport
 	assert(typeof(adornee) == "Instance", "Bad adornee")
 
-	local humanoid
+	local humanoid: Humanoid?
 	if adornee:IsA("Humanoid") then
 		humanoid = adornee
 	else
@@ -79,7 +79,7 @@ end
 	@param weaponData any
 	@return boolean
 ]=]
-function DeathReportUtils.isWeaponData(weaponData): boolean
+function DeathReportUtils.isWeaponData(weaponData: any): boolean
 	return type(weaponData) == "table"
 		and (typeof(weaponData.weaponInstance) == "Instance" or weaponData.weaponInstance == nil)
 end


### PR DESCRIPTION
Converts every non-strict source file in the deathreport package to --!strict, adding explicit type annotations across the death, kill, and team tracker classes, DeathReportUtils, and the client service. Binder registrations hoist their class requires to locals so the sanctioned any cast doesn't trip luau-lsp's require resolver. There are no runtime behavior changes.