### PR TITLE
fix: Fix attribute replication for server-only prompting

### DIFF
--- a/src/gameproductservice/src/Server/Manager/PlayerProductManager.lua
+++ b/src/gameproductservice/src/Server/Manager/PlayerProductManager.lua
@@ -61,7 +61,10 @@ function PlayerProductManager.new(player: Player, serviceBag: ServiceBag.Service
 
 	-- Initialize attributes
 
-	self.ServerOnlyPrompting = self._serviceBag:GetService(GameProductDataService):GetServerOnlyPromptingValue()
+	local serverOnlyPrompting = self._serviceBag:GetService(GameProductDataService):GetServerOnlyPromptingValue()
+	self._maid:GiveTask(serverOnlyPrompting:Observe():Subscribe(function(value)
+		self._obj:SetAttribute(GameProductDataService.ServerOnlyPromptingAttribute, value)
+	end))
 
 	-- Implement
 	local impl = self._maid:Add(PlayerProductManagerInterface.Server:Implement(self._obj, self))

--- a/src/gameproductservice/src/Shared/GameProductDataService.lua
+++ b/src/gameproductservice/src/Shared/GameProductDataService.lua
@@ -13,6 +13,7 @@ local Observable = require("Observable")
 local PlayerProductManagerInterface = require("PlayerProductManagerInterface")
 local Promise = require("Promise")
 local Rx = require("Rx")
+local RxAttributeUtils = require("RxAttributeUtils")
 local RxBrioUtils = require("RxBrioUtils")
 local ServiceBag = require("ServiceBag")
 local Signal = require("Signal")
@@ -22,6 +23,8 @@ local ValueObject = require("ValueObject")
 
 local GameProductDataService = {}
 GameProductDataService.ServiceName = "GameProductDataService"
+
+GameProductDataService.ServerOnlyPromptingAttribute = "GameProductServerOnlyPrompting"
 
 export type GameProductDataService = typeof(setmetatable(
 	{} :: {
@@ -137,19 +140,17 @@ function GameProductDataService.ObserveServerOnlyPrompting(
 
 	-- Always read the server-authoritative value (the server implementation), which
 	-- replicates down to clients as an attribute on the PlayerProductManager folder.
-	return PlayerProductManagerInterface:Observe(player, TieRealms.SERVER):Pipe({
-		Rx.switchMap(function(interface: any): any
-			if interface then
-				return interface.ServerOnlyPrompting:Observe()
-			else
-				return Rx.of(false)
-			end
-		end) :: any,
-		Rx.map(function(value: any)
-			return value == true
-		end) :: any,
-		Rx.distinct() :: any,
-	}) :: any
+	return RxAttributeUtils.observeAttribute(
+			player,
+			GameProductDataService.ServerOnlyPromptingAttribute,
+			false
+		)
+			:Pipe({
+				Rx.map(function(value: any)
+					return value == true
+				end) :: any,
+				Rx.distinct() :: any,
+			}) :: any
 end
 
 --[=[

--- a/src/gameproductservice/src/Shared/Interfaces/PlayerProductManagerInterface.lua
+++ b/src/gameproductservice/src/Shared/Interfaces/PlayerProductManagerInterface.lua
@@ -14,8 +14,4 @@ return TieDefinition.new("PlayerProductManager", {
 	PromisePlayerPromptClosed = TieDefinition.Types.METHOD,
 	GetAssetTrackerOrError = TieDefinition.Types.METHOD,
 	GetOwnershipTrackerOrError = TieDefinition.Types.METHOD,
-
-	[TieDefinition.Realms.SERVER] = {
-		ServerOnlyPrompting = false,
-	},
 })


### PR DESCRIPTION
previously was not properly replicating the state of the function we added from #721 