### PR TITLE
feat(nevermore-cli): pin and promote base place versions in deploy config

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,6 +197,8 @@ nevermore deploy version upgrade         # re-pin base place versions to latest
 | `--yes` | Skip the confirmation prompt (for scripting/CI). |
 | `--api-key <key>` | Open Cloud API key. Otherwise resolved from login/env. |
 
+**`nevermore deploy version promote <from> <to>`** — copies base-place version pins from one target to another (e.g. promote validated `production-demo` pins to `production`). Places are matched by base place id, so content lines up even when the targets name their places differently. Pure config edit — no network. Supports `--dryrun` and `--yes`. See [Promoting pins between targets](deploy.md#promoting-pins-between-targets).
+
 ### `nevermore batch`
 
 Runs `test` or `deploy` across many packages at once, using git change detection so PRs only touch what changed. Scans the pnpm workspace for packages with a matching deploy target. See [Test Infrastructure](testing/testing.md) and [Deploying](deploy.md) for how targets are configured.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -157,13 +157,14 @@ nevermore test --cloud --script-text 'print("hi")'    # run arbitrary Luau to de
 
 ### `nevermore deploy`
 
-Builds a Rojo project and uploads it to a Roblox place. `deploy` has two subcommands; `run` is the default, so `nevermore deploy` and `nevermore deploy <target>` both deploy. Full walkthrough in [Deploying with the CLI](deploy.md).
+Builds a Rojo project and uploads it to a Roblox place. `run` is the default subcommand, so `nevermore deploy` and `nevermore deploy <target>` both deploy. Full walkthrough in [Deploying with the CLI](deploy.md).
 
 ```bash
-nevermore deploy init                  # create deploy.nevermore.json (interactive)
-nevermore deploy run                   # build + upload, saved (not live)
-nevermore deploy run --publish         # build + upload and publish live
-nevermore deploy production --publish  # 'run' is implied; deploy the 'production' target
+nevermore deploy init                    # create deploy.nevermore.json (interactive)
+nevermore deploy run                     # build + upload, saved (not live)
+nevermore deploy run --publish           # build + upload and publish live
+nevermore deploy production --publish    # 'run' is implied; deploy the 'production' target
+nevermore deploy version upgrade         # re-pin base place versions to latest
 ```
 
 **`nevermore deploy init`** — writes a `deploy.nevermore.json` for the current package.
@@ -187,6 +188,14 @@ nevermore deploy production --publish  # 'run' is implied; deploy the 'productio
 | `--place-file <path>` | Upload a pre-built `.rbxl` instead of building via rojo (single-place targets only). |
 | `--output <file>` | Write JSON results to a file. |
 | `--logs` | Show build/upload logs even on success. |
+
+**`nevermore deploy version upgrade [target]`** — re-pins every `basePlace` in `deploy.nevermore.json` to its current latest published version, so deploys pull a fixed, git-tracked base place instead of whatever is live. Without a target it walks every target. See [Pinning base place versions](deploy.md#pinning-base-place-versions).
+
+| Flag | Description |
+|------|-------------|
+| `--dryrun` | Print the old → new version table without writing. |
+| `--yes` | Skip the confirmation prompt (for scripting/CI). |
+| `--api-key <key>` | Open Cloud API key. Otherwise resolved from login/env. |
 
 ### `nevermore batch`
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -277,6 +277,20 @@ Commit the updated `deploy.nevermore.json`, then deploy as usual. This gives you
 
 Resolving the latest version uses the same `legacy-asset:manage` scope already required for `basePlace` downloads, so no extra credentials are needed.
 
+### Promoting pins between targets
+
+Once you've validated a target — say a `production-demo` universe — you usually want to ship those exact same base-place versions to `production`, not re-pin to whatever is newest. `promote` copies the pins across:
+
+```bash
+# Copy every base place pin from production-demo onto production
+nevermore deploy version promote production-demo production
+
+# Preview without writing
+nevermore deploy version promote production-demo production --dryrun
+```
+
+Places are matched by **base place id**, not by name, so the same source content lines up even when the two targets name their places differently (e.g. a demo `chapter6` and a prod `chapter8` that share one base place). Places in the destination with no matching pin in the source are left untouched and reported. This is a pure edit of `deploy.nevermore.json` — no network calls — so it's safe to run offline and review as a diff.
+
 ## Batch deploys
 
 If you want to deploy every game affected by a code change (for example, on every PR), use `nevermore batch deploy` instead. It scans the pnpm workspace for packages with a matching deploy target, uses `pnpm ls --filter` to figure out which ones changed since `origin/main`, and runs them in parallel.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -155,6 +155,7 @@ Other flags:
 | `targets.<name>.project` | yes | Path to the Rojo project file, relative to the package directory. |
 | `targets.<name>.scriptTemplate` | no | Luau file `nevermore test` executes via Open Cloud after upload. Not used by `nevermore deploy` itself. |
 | `targets.<name>.basePlace` | no | Universe/place to download and merge with the rojo build before uploading. See [Merging with an existing place](testing/integration-testing.md#merging-with-an-existing-place-baseplace). |
+| `targets.<name>.basePlace.version` | no | Pin the base place to a specific published version instead of pulling the latest. See [Pinning base place versions](#pinning-base-place-versions). |
 
 You can declare any number of targets. A common setup is one `test` target for CI and a separate `production` or `staging` target for live deploys:
 
@@ -229,6 +230,52 @@ nevermore deploy run --place-file ./build/my-place.rbxl
 ```
 
 The `project` field in `deploy.nevermore.json` is ignored when `--place-file` is set, but `universeId` and `placeId` are still required.
+
+## Pinning base place versions
+
+If a target uses a [`basePlace`](testing/integration-testing.md#merging-with-an-existing-place-baseplace), `nevermore deploy` downloads that place and merges your rojo build into it. By default it pulls **the latest published version** of the base place — so a broken Studio edit to the base place ships on the very next deploy, even when your code hasn't changed.
+
+To make deploys reproducible, pin the base place to a specific version with an optional `version` field:
+
+```json
+{
+  "targets": {
+    "production": {
+      "universeId": 12345,
+      "placeId": 67890,
+      "project": "default.project.json",
+      "basePlace": {
+        "universeId": 12345,
+        "placeId": 11111,
+        "version": 42
+      }
+    }
+  }
+}
+```
+
+With `version` set, the deploy downloads exactly that version of the base place. Omit it to keep pulling the latest (the previous behaviour — nothing changes for configs that don't opt in).
+
+### Bumping the pin
+
+When you actually want to roll base places forward, run:
+
+```bash
+# Re-pin every basePlace in the config to its current latest published version
+nevermore deploy version upgrade
+
+# Only upgrade one target
+nevermore deploy version upgrade production
+
+# Preview the change set without writing
+nevermore deploy version upgrade --dryrun
+```
+
+`upgrade` walks every `basePlace` in `deploy.nevermore.json` (or just the named target), resolves each place's current latest published version, prints an old → new table, and — after a confirmation prompt — writes the new `version` values back into the file. Base places shared by several targets are resolved once. Pass `--yes` to skip the prompt (for scripting), or `--dryrun` to preview only.
+
+Commit the updated `deploy.nevermore.json`, then deploy as usual. This gives you a reviewable, git-tracked record of exactly which base-place content each deploy shipped.
+
+Resolving the latest version uses the same `legacy-asset:manage` scope already required for `basePlace` downloads, so no extra credentials are needed.
 
 ## Batch deploys
 

--- a/docs/testing/integration-testing.md
+++ b/docs/testing/integration-testing.md
@@ -218,6 +218,8 @@ Add `basePlace` to your deploy target:
 
 The `basePlace` place is the source of truth for Studio-authored content. The target `placeId` is where the merged result gets uploaded. These can be in the same universe or different ones.
 
+By default the CLI downloads the **latest published version** of the base place on every deploy. To make deploys reproducible — so a broken Studio edit can't leak into a deploy — pin a specific version with an optional `basePlace.version`, and bump it deliberately with `nevermore deploy version upgrade`. See [Pinning base place versions](../deploy.md#pinning-base-place-versions).
+
 ### How the merge works
 
 The merge is driven by your rojo project file. Each entry in the tree is treated as one of two kinds:

--- a/tools/nevermore-cli/src/commands/deploy-command/index.ts
+++ b/tools/nevermore-cli/src/commands/deploy-command/index.ts
@@ -36,6 +36,7 @@ import {
   resolveDeployTargetPlaces,
 } from '../../utils/build/deploy-config.js';
 import { handleInitAsync } from './deploy-init.js';
+import { handleVersionUpgradeAsync } from './version-command.js';
 import { selectTargetAsync } from './select-target.js';
 
 const MULTI_PLACE_CONCURRENCY = 10;
@@ -107,6 +108,44 @@ export class DeployCommand<T> implements CommandModule<T, DeployArgs> {
           process.exit(1);
         }
       }
+    );
+
+    args.command(
+      'version',
+      'Manage pinned base place versions in deploy.nevermore.json',
+      (yargs) => {
+        return yargs
+          .command(
+            'upgrade [target]',
+            'Re-pin every basePlace to its latest published version',
+            (upgradeYargs) => {
+              return upgradeYargs
+                .positional('target', {
+                  describe:
+                    'Only upgrade this target (default: all targets in the config)',
+                  type: 'string',
+                })
+                .option('api-key', {
+                  describe: 'Roblox Open Cloud API key',
+                  type: 'string',
+                });
+            },
+            async (upgradeArgs) => {
+              try {
+                await handleVersionUpgradeAsync(
+                  upgradeArgs as unknown as DeployArgs
+                );
+              } catch (err) {
+                OutputHelper.error(
+                  err instanceof Error ? err.message : String(err)
+                );
+                process.exit(1);
+              }
+            }
+          )
+          .demandCommand(1, 'Specify a version action, e.g. "upgrade".');
+      },
+      () => {}
     );
 
     args.command(

--- a/tools/nevermore-cli/src/commands/deploy-command/index.ts
+++ b/tools/nevermore-cli/src/commands/deploy-command/index.ts
@@ -36,7 +36,11 @@ import {
   resolveDeployTargetPlaces,
 } from '../../utils/build/deploy-config.js';
 import { handleInitAsync } from './deploy-init.js';
-import { handleVersionUpgradeAsync } from './version-command.js';
+import {
+  handleVersionUpgradeAsync,
+  handleVersionPromoteAsync,
+  type VersionPromoteArgs,
+} from './version-command.js';
 import { selectTargetAsync } from './select-target.js';
 
 const MULTI_PLACE_CONCURRENCY = 10;
@@ -134,6 +138,34 @@ export class DeployCommand<T> implements CommandModule<T, DeployArgs> {
               try {
                 await handleVersionUpgradeAsync(
                   upgradeArgs as unknown as DeployArgs
+                );
+              } catch (err) {
+                OutputHelper.error(
+                  err instanceof Error ? err.message : String(err)
+                );
+                process.exit(1);
+              }
+            }
+          )
+          .command(
+            'promote <from> <to>',
+            'Promote base place version pins from one target to another',
+            (promoteYargs) => {
+              return promoteYargs
+                .positional('from', {
+                  describe:
+                    'Target to promote pins from (e.g. production-demo)',
+                  type: 'string',
+                })
+                .positional('to', {
+                  describe: 'Target to promote pins to (e.g. production)',
+                  type: 'string',
+                });
+            },
+            async (promoteArgs) => {
+              try {
+                await handleVersionPromoteAsync(
+                  promoteArgs as unknown as VersionPromoteArgs
                 );
               } catch (err) {
                 OutputHelper.error(

--- a/tools/nevermore-cli/src/commands/deploy-command/version-command.ts
+++ b/tools/nevermore-cli/src/commands/deploy-command/version-command.ts
@@ -11,6 +11,7 @@ import {
   resolveDeployConfigPath,
   resolveDeployTargetPlaces,
   type BasePlaceConfig,
+  type DeployConfig,
 } from '../../utils/build/deploy-config.js';
 import { OpenCloudClient } from '../../utils/open-cloud/open-cloud-client.js';
 import { RateLimiter } from '../../utils/open-cloud/rate-limiter.js';
@@ -22,11 +23,111 @@ interface BasePlaceRef {
   basePlace: BasePlaceConfig;
 }
 
-interface UpgradeRow {
+/** A pending change: set `ref.basePlace.version` to `to`. */
+interface PinChange {
   ref: BasePlaceRef;
   from?: number;
   to: number;
-  changed: boolean;
+}
+
+export interface VersionPromoteArgs extends DeployArgs {
+  from?: string;
+  to?: string;
+}
+
+function _plural(count: number): string {
+  return count === 1 ? '' : 's';
+}
+
+function _requireTarget(config: DeployConfig, targetName: string): void {
+  if (!config.targets[targetName]) {
+    throw new Error(
+      [
+        `Target "${targetName}" not found in deploy.nevermore.json.`,
+        `Available targets: ${Object.keys(config.targets).join(', ')}`,
+      ].join('\n')
+    );
+  }
+}
+
+/** Collect every basePlace across the given targets, keeping live references. */
+function _collectBasePlaceRefs(
+  config: DeployConfig,
+  targetNames: string[]
+): BasePlaceRef[] {
+  const refs: BasePlaceRef[] = [];
+  for (const targetName of targetNames) {
+    for (const place of resolveDeployTargetPlaces(config, targetName)) {
+      if (place.basePlace) {
+        refs.push({
+          targetName,
+          placeLabel: place.name ?? targetName,
+          basePlace: place.basePlace,
+        });
+      }
+    }
+  }
+  return refs;
+}
+
+/**
+ * Gate the change set on --dryrun / confirmation, apply it in place, and write
+ * the config back. `changes` may include no-op entries; only entries whose
+ * version actually differs are counted and applied. Returns nothing — messaging
+ * is handled here so the two commands stay consistent.
+ */
+async function _commitPinChangesAsync(
+  configPath: string,
+  config: DeployConfig,
+  changes: PinChange[],
+  args: { dryrun?: boolean; yes?: boolean }
+): Promise<void> {
+  const changed = changes.filter((c) => c.from !== c.to);
+  if (changed.length === 0) {
+    OutputHelper.info('Nothing to change — pins are already up to date.');
+    return;
+  }
+
+  if (args.dryrun) {
+    OutputHelper.info(
+      `[DRYRUN] Would update ${changed.length} pin${_plural(
+        changed.length
+      )} in ${configPath}`
+    );
+    return;
+  }
+
+  if (!args.yes) {
+    const { confirm } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'confirm',
+        message: `Update ${changed.length} version pin${_plural(
+          changed.length
+        )} in deploy.nevermore.json?`,
+        default: true,
+      },
+    ]);
+    if (!confirm) {
+      OutputHelper.info('Aborted — no changes written.');
+      return;
+    }
+  }
+
+  // Mutate in place — every ref.basePlace points into `config`.
+  for (const change of changed) {
+    change.ref.basePlace.version = change.to;
+  }
+
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2) + '\n');
+  OutputHelper.info(
+    `Updated ${changed.length} version pin${_plural(
+      changed.length
+    )} in ${configPath}`
+  );
+  OutputHelper.hint(
+    'Commit deploy.nevermore.json, then deploy to roll base places forward.'
+  );
 }
 
 /**
@@ -42,31 +143,12 @@ export async function handleVersionUpgradeAsync(
   const configPath = resolveDeployConfigPath(cwd);
   const config = await loadDeployConfigAsync(configPath);
 
-  if (args.target && !config.targets[args.target]) {
-    throw new Error(
-      [
-        `Target "${args.target}" not found in deploy.nevermore.json.`,
-        `Available targets: ${Object.keys(config.targets).join(', ')}`,
-      ].join('\n')
-    );
+  if (args.target) {
+    _requireTarget(config, args.target);
   }
 
   const targetNames = args.target ? [args.target] : Object.keys(config.targets);
-
-  // Collect every basePlace across the selected targets. Each entry keeps a
-  // live reference into the parsed config so we can mutate it in place.
-  const refs: BasePlaceRef[] = [];
-  for (const targetName of targetNames) {
-    for (const place of resolveDeployTargetPlaces(config, targetName)) {
-      if (place.basePlace) {
-        refs.push({
-          targetName,
-          placeLabel: place.name ?? targetName,
-          basePlace: place.basePlace,
-        });
-      }
-    }
-  }
+  const refs = _collectBasePlaceRefs(config, targetNames);
 
   if (refs.length === 0) {
     OutputHelper.warn(
@@ -81,9 +163,9 @@ export async function handleVersionUpgradeAsync(
   // (e.g. integration/prod) commonly point at the same base place.
   const uniquePlaceIds = [...new Set(refs.map((r) => r.basePlace.placeId))];
   OutputHelper.info(
-    `Resolving latest version for ${uniquePlaceIds.length} base place${
-      uniquePlaceIds.length === 1 ? '' : 's'
-    }...`
+    `Resolving latest version for ${uniquePlaceIds.length} base place${_plural(
+      uniquePlaceIds.length
+    )}...`
   );
 
   const apiKey = await getApiKeyAsync(args);
@@ -104,75 +186,126 @@ export async function handleVersionUpgradeAsync(
     })
   );
 
-  const rows: UpgradeRow[] = refs.map((ref) => {
-    const to = latestByPlaceId.get(ref.basePlace.placeId)!;
-    const from = ref.basePlace.version;
-    return { ref, from, to, changed: from !== to };
-  });
+  const changes: PinChange[] = refs.map((ref) => ({
+    ref,
+    from: ref.basePlace.version,
+    to: latestByPlaceId.get(ref.basePlace.placeId)!,
+  }));
 
-  const columns: TableColumn<UpgradeRow>[] = [
-    { header: 'Target', value: (r) => r.ref.targetName },
-    { header: 'Place', value: (r) => r.ref.placeLabel },
-    { header: 'Base place', value: (r) => String(r.ref.basePlace.placeId) },
-    {
-      header: 'Version',
-      value: (r) =>
-        `${r.from != null ? `v${r.from}` : '(latest)'} → v${r.to}${
-          r.changed ? '' : '  (unchanged)'
-        }`,
-    },
+  const columns: TableColumn<PinChange>[] = [
+    { header: 'Target', value: (c) => c.ref.targetName },
+    { header: 'Place', value: (c) => c.ref.placeLabel },
+    { header: 'Base place', value: (c) => String(c.ref.basePlace.placeId) },
+    { header: 'Version', value: (c) => _formatChange(c) },
   ];
 
   console.log('');
-  console.log(formatTable(rows, columns, { indent: '  ' }));
+  console.log(formatTable(changes, columns, { indent: '  ' }));
   console.log('');
 
-  const changedRows = rows.filter((r) => r.changed);
-  if (changedRows.length === 0) {
-    OutputHelper.info(
-      'All base places are already pinned to their latest version.'
+  await _commitPinChangesAsync(configPath, config, changes, args);
+}
+
+/**
+ * `nevermore deploy version promote <from> <to>` — copy the base-place version
+ * pins from one target to another (e.g. promote validated `production-demo`
+ * pins to `production`). Places are matched by their base place id, so the same
+ * source content lines up even when the two targets name their places
+ * differently. Pure config edit — no network. `--dryrun` previews.
+ */
+export async function handleVersionPromoteAsync(
+  args: VersionPromoteArgs
+): Promise<void> {
+  const fromTarget = args.from;
+  const toTarget = args.to;
+  if (!fromTarget || !toTarget) {
+    throw new Error(
+      'Usage: nevermore deploy version copy <from-target> <to-target>'
     );
-    return;
+  }
+  if (fromTarget === toTarget) {
+    throw new Error('The <from> and <to> targets must be different.');
   }
 
-  if (args.dryrun) {
-    OutputHelper.info(
-      `[DRYRUN] Would update ${changedRows.length} pin${
-        changedRows.length === 1 ? '' : 's'
-      } in ${configPath}`
-    );
-    return;
-  }
+  const cwd = process.cwd();
+  const configPath = resolveDeployConfigPath(cwd);
+  const config = await loadDeployConfigAsync(configPath);
 
-  if (!args.yes) {
-    const { confirm } = await inquirer.prompt([
-      {
-        type: 'confirm',
-        name: 'confirm',
-        message: `Update ${changedRows.length} version pin${
-          changedRows.length === 1 ? '' : 's'
-        } in deploy.nevermore.json?`,
-        default: true,
-      },
-    ]);
-    if (!confirm) {
-      OutputHelper.info('Aborted — no changes written.');
-      return;
+  _requireTarget(config, fromTarget);
+  _requireTarget(config, toTarget);
+
+  // Map base place id -> pinned version from the source target. A source with
+  // the same base place pinned to two different versions is inconsistent, so
+  // fail loudly rather than pick one arbitrarily.
+  const versionByPlaceId = new Map<number, number>();
+  for (const ref of _collectBasePlaceRefs(config, [fromTarget])) {
+    const version = ref.basePlace.version;
+    if (version == null) {
+      continue;
     }
+    const existing = versionByPlaceId.get(ref.basePlace.placeId);
+    if (existing != null && existing !== version) {
+      throw new Error(
+        `Target "${fromTarget}" pins base place ${ref.basePlace.placeId} to ` +
+          `two different versions (v${existing} and v${version}). ` +
+          `Run "nevermore deploy version upgrade ${fromTarget}" to make it consistent first.`
+      );
+    }
+    versionByPlaceId.set(ref.basePlace.placeId, version);
   }
 
-  // Mutate in place — every ref.basePlace points into `config`.
-  for (const row of changedRows) {
-    row.ref.basePlace.version = row.to;
+  if (versionByPlaceId.size === 0) {
+    OutputHelper.warn(
+      `Target "${fromTarget}" has no pinned base place versions to copy. ` +
+        `Run "nevermore deploy version upgrade ${fromTarget}" first.`
+    );
+    return;
   }
 
-  await fs.writeFile(configPath, JSON.stringify(config, null, 2) + '\n');
-  OutputHelper.info(
-    `Updated ${changedRows.length} version pin${
-      changedRows.length === 1 ? '' : 's'
-    } in ${configPath}`
-  );
-  OutputHelper.hint(
-    'Commit deploy.nevermore.json, then deploy to roll base places forward.'
-  );
+  const toRefs = _collectBasePlaceRefs(config, [toTarget]);
+  if (toRefs.length === 0) {
+    OutputHelper.warn(`Target "${toTarget}" has no basePlace to copy pins to.`);
+    return;
+  }
+
+  const changes: PinChange[] = [];
+  const unmatched: BasePlaceRef[] = [];
+  for (const ref of toRefs) {
+    const source = versionByPlaceId.get(ref.basePlace.placeId);
+    if (source == null) {
+      unmatched.push(ref);
+      continue;
+    }
+    changes.push({ ref, from: ref.basePlace.version, to: source });
+  }
+
+  const columns: TableColumn<PinChange>[] = [
+    { header: 'Place', value: (c) => c.ref.placeLabel },
+    { header: 'Base place', value: (c) => String(c.ref.basePlace.placeId) },
+    { header: 'Version', value: (c) => _formatChange(c) },
+  ];
+
+  console.log('');
+  OutputHelper.info(`Promoting pins from "${fromTarget}" to "${toTarget}":`);
+  console.log(formatTable(changes, columns, { indent: '  ' }));
+  console.log('');
+
+  if (unmatched.length > 0) {
+    OutputHelper.warn(
+      `${unmatched.length} place${_plural(
+        unmatched.length
+      )} in "${toTarget}" had no matching pin in "${fromTarget}" (left unchanged): ` +
+        unmatched
+          .map((r) => `${r.placeLabel} (${r.basePlace.placeId})`)
+          .join(', ')
+    );
+  }
+
+  await _commitPinChangesAsync(configPath, config, changes, args);
+}
+
+function _formatChange(change: PinChange): string {
+  const from = change.from != null ? `v${change.from}` : '(latest)';
+  const unchanged = change.from === change.to ? '  (unchanged)' : '';
+  return `${from} → v${change.to}${unchanged}`;
 }

--- a/tools/nevermore-cli/src/commands/deploy-command/version-command.ts
+++ b/tools/nevermore-cli/src/commands/deploy-command/version-command.ts
@@ -1,0 +1,178 @@
+import inquirer from 'inquirer';
+import * as fs from 'fs/promises';
+import { OutputHelper } from '@quenty/cli-output-helpers';
+import {
+  formatTable,
+  type TableColumn,
+} from '@quenty/cli-output-helpers/reporting';
+import { getApiKeyAsync } from '@quenty/nevermore-cli-helpers';
+import {
+  loadDeployConfigAsync,
+  resolveDeployConfigPath,
+  resolveDeployTargetPlaces,
+  type BasePlaceConfig,
+} from '../../utils/build/deploy-config.js';
+import { OpenCloudClient } from '../../utils/open-cloud/open-cloud-client.js';
+import { RateLimiter } from '../../utils/open-cloud/rate-limiter.js';
+import { DeployArgs } from './index.js';
+
+interface BasePlaceRef {
+  targetName: string;
+  placeLabel: string;
+  basePlace: BasePlaceConfig;
+}
+
+interface UpgradeRow {
+  ref: BasePlaceRef;
+  from?: number;
+  to: number;
+  changed: boolean;
+}
+
+/**
+ * `nevermore deploy version upgrade [target]` — re-pin every `basePlace` in
+ * deploy.nevermore.json to its current latest published version. Without a
+ * target it walks every target; pass one to scope it. `--dryrun` previews the
+ * change set without writing.
+ */
+export async function handleVersionUpgradeAsync(
+  args: DeployArgs
+): Promise<void> {
+  const cwd = process.cwd();
+  const configPath = resolveDeployConfigPath(cwd);
+  const config = await loadDeployConfigAsync(configPath);
+
+  if (args.target && !config.targets[args.target]) {
+    throw new Error(
+      [
+        `Target "${args.target}" not found in deploy.nevermore.json.`,
+        `Available targets: ${Object.keys(config.targets).join(', ')}`,
+      ].join('\n')
+    );
+  }
+
+  const targetNames = args.target ? [args.target] : Object.keys(config.targets);
+
+  // Collect every basePlace across the selected targets. Each entry keeps a
+  // live reference into the parsed config so we can mutate it in place.
+  const refs: BasePlaceRef[] = [];
+  for (const targetName of targetNames) {
+    for (const place of resolveDeployTargetPlaces(config, targetName)) {
+      if (place.basePlace) {
+        refs.push({
+          targetName,
+          placeLabel: place.name ?? targetName,
+          basePlace: place.basePlace,
+        });
+      }
+    }
+  }
+
+  if (refs.length === 0) {
+    OutputHelper.warn(
+      args.target
+        ? `Target "${args.target}" has no basePlace to pin.`
+        : 'No basePlace found in deploy.nevermore.json — nothing to pin.'
+    );
+    return;
+  }
+
+  // Resolve the latest version once per unique base place id — several targets
+  // (e.g. integration/prod) commonly point at the same base place.
+  const uniquePlaceIds = [...new Set(refs.map((r) => r.basePlace.placeId))];
+  OutputHelper.info(
+    `Resolving latest version for ${uniquePlaceIds.length} base place${
+      uniquePlaceIds.length === 1 ? '' : 's'
+    }...`
+  );
+
+  const apiKey = await getApiKeyAsync(args);
+  const client = new OpenCloudClient({
+    apiKey,
+    rateLimiter: new RateLimiter(),
+  });
+
+  const latestByPlaceId = new Map<number, number>();
+  await Promise.all(
+    uniquePlaceIds.map(async (placeId) => {
+      const ref = refs.find((r) => r.basePlace.placeId === placeId)!;
+      const latest = await client.getLatestPlaceVersionAsync(
+        ref.basePlace.universeId,
+        placeId
+      );
+      latestByPlaceId.set(placeId, latest);
+    })
+  );
+
+  const rows: UpgradeRow[] = refs.map((ref) => {
+    const to = latestByPlaceId.get(ref.basePlace.placeId)!;
+    const from = ref.basePlace.version;
+    return { ref, from, to, changed: from !== to };
+  });
+
+  const columns: TableColumn<UpgradeRow>[] = [
+    { header: 'Target', value: (r) => r.ref.targetName },
+    { header: 'Place', value: (r) => r.ref.placeLabel },
+    { header: 'Base place', value: (r) => String(r.ref.basePlace.placeId) },
+    {
+      header: 'Version',
+      value: (r) =>
+        `${r.from != null ? `v${r.from}` : '(latest)'} → v${r.to}${
+          r.changed ? '' : '  (unchanged)'
+        }`,
+    },
+  ];
+
+  console.log('');
+  console.log(formatTable(rows, columns, { indent: '  ' }));
+  console.log('');
+
+  const changedRows = rows.filter((r) => r.changed);
+  if (changedRows.length === 0) {
+    OutputHelper.info(
+      'All base places are already pinned to their latest version.'
+    );
+    return;
+  }
+
+  if (args.dryrun) {
+    OutputHelper.info(
+      `[DRYRUN] Would update ${changedRows.length} pin${
+        changedRows.length === 1 ? '' : 's'
+      } in ${configPath}`
+    );
+    return;
+  }
+
+  if (!args.yes) {
+    const { confirm } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'confirm',
+        message: `Update ${changedRows.length} version pin${
+          changedRows.length === 1 ? '' : 's'
+        } in deploy.nevermore.json?`,
+        default: true,
+      },
+    ]);
+    if (!confirm) {
+      OutputHelper.info('Aborted — no changes written.');
+      return;
+    }
+  }
+
+  // Mutate in place — every ref.basePlace points into `config`.
+  for (const row of changedRows) {
+    row.ref.basePlace.version = row.to;
+  }
+
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2) + '\n');
+  OutputHelper.info(
+    `Updated ${changedRows.length} version pin${
+      changedRows.length === 1 ? '' : 's'
+    } in ${configPath}`
+  );
+  OutputHelper.hint(
+    'Commit deploy.nevermore.json, then deploy to roll base places forward.'
+  );
+}

--- a/tools/nevermore-cli/src/utils/build/deploy-config.test.ts
+++ b/tools/nevermore-cli/src/utils/build/deploy-config.test.ts
@@ -1,9 +1,20 @@
 import { describe, it, expect } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 import {
   type DeployConfig,
   type DeployTarget,
+  loadDeployConfigAsync,
   resolveDefaultTargetName,
 } from './deploy-config.js';
+
+async function writeTempConfigAsync(config: unknown): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'deploy-config-test-'));
+  const configPath = path.join(dir, 'deploy.nevermore.json');
+  await fs.writeFile(configPath, JSON.stringify(config));
+  return configPath;
+}
 
 function makeTarget(placeId: number): DeployTarget {
   return {
@@ -47,5 +58,92 @@ describe('resolveDefaultTargetName', () => {
   it('throws when no preferred target exists and multiple options are present', () => {
     const config = makeConfig({ foo: makeTarget(1), bar: makeTarget(2) });
     expect(() => resolveDefaultTargetName(config)).toThrowError(/foo, bar/);
+  });
+});
+
+describe('loadDeployConfigAsync basePlace.version', () => {
+  it('accepts an omitted version pin', async () => {
+    const configPath = await writeTempConfigAsync({
+      targets: {
+        test: {
+          universeId: 1,
+          placeId: 2,
+          project: 'default.project.json',
+          basePlace: { universeId: 1, placeId: 3 },
+        },
+      },
+    });
+    const config = await loadDeployConfigAsync(configPath);
+    const target = config.targets['test'] as DeployTarget;
+    expect(target.basePlace?.version).toBeUndefined();
+  });
+
+  it('accepts a positive integer version pin', async () => {
+    const configPath = await writeTempConfigAsync({
+      targets: {
+        test: {
+          universeId: 1,
+          placeId: 2,
+          project: 'default.project.json',
+          basePlace: { universeId: 1, placeId: 3, version: 42 },
+        },
+      },
+    });
+    const config = await loadDeployConfigAsync(configPath);
+    const target = config.targets['test'] as DeployTarget;
+    expect(target.basePlace?.version).toBe(42);
+  });
+
+  it('rejects a non-integer version pin', async () => {
+    const configPath = await writeTempConfigAsync({
+      targets: {
+        test: {
+          universeId: 1,
+          placeId: 2,
+          project: 'default.project.json',
+          basePlace: { universeId: 1, placeId: 3, version: 1.5 },
+        },
+      },
+    });
+    await expect(loadDeployConfigAsync(configPath)).rejects.toThrowError(
+      /version.*positive integer/
+    );
+  });
+
+  it('rejects a zero or negative version pin', async () => {
+    const configPath = await writeTempConfigAsync({
+      targets: {
+        test: {
+          universeId: 1,
+          placeId: 2,
+          project: 'default.project.json',
+          basePlace: { universeId: 1, placeId: 3, version: 0 },
+        },
+      },
+    });
+    await expect(loadDeployConfigAsync(configPath)).rejects.toThrowError(
+      /version.*positive integer/
+    );
+  });
+
+  it('validates version pins on multi-place targets too', async () => {
+    const configPath = await writeTempConfigAsync({
+      targets: {
+        prod: {
+          places: [
+            {
+              name: 'chapter0',
+              universeId: 1,
+              placeId: 2,
+              project: 'default.project.json',
+              basePlace: { universeId: 1, placeId: 3, version: -1 },
+            },
+          ],
+        },
+      },
+    });
+    await expect(loadDeployConfigAsync(configPath)).rejects.toThrowError(
+      /chapter0.*version.*positive integer/
+    );
   });
 });

--- a/tools/nevermore-cli/src/utils/build/deploy-config.ts
+++ b/tools/nevermore-cli/src/utils/build/deploy-config.ts
@@ -4,6 +4,14 @@ import * as path from 'path';
 export interface BasePlaceConfig {
   universeId: number;
   placeId: number;
+  /**
+   * Pin the base place to a specific published version. When set, the deploy
+   * downloads exactly this version instead of whatever is currently live, so
+   * builds are reproducible and a broken Studio edit can't leak into a deploy.
+   * Omit to always pull the latest version. Bump it with
+   * `nevermore deploy version upgrade`.
+   */
+  version?: number;
 }
 
 export interface DeployTarget {
@@ -52,6 +60,15 @@ function _validatePlace(label: string, place: DeployTarget): void {
     }
     if (typeof place.basePlace.placeId !== 'number') {
       throw new Error(`${label} basePlace is missing or has invalid "placeId"`);
+    }
+    if (
+      place.basePlace.version != null &&
+      (!Number.isInteger(place.basePlace.version) ||
+        place.basePlace.version < 1)
+    ) {
+      throw new Error(
+        `${label} basePlace "version" must be a positive integer when set`
+      );
     }
   }
 }

--- a/tools/nevermore-cli/src/utils/job-context/base-job-context.ts
+++ b/tools/nevermore-cli/src/utils/job-context/base-job-context.ts
@@ -193,7 +193,11 @@ export abstract class BaseJobContext implements JobContext {
     const resolvedName = options.packageName ?? '';
 
     this._reporter.onPackagePhaseChange(resolvedName, 'downloading');
-    OutputHelper.verbose('Downloading base place for merge...');
+    OutputHelper.verbose(
+      basePlace.version != null
+        ? `Downloading base place (pinned v${basePlace.version}) for merge...`
+        : 'Downloading base place (latest) for merge...'
+    );
     const buffer = await this._openCloudClient.downloadPlaceAsync(
       basePlace.universeId,
       basePlace.placeId,
@@ -203,7 +207,8 @@ export abstract class BaseJobContext implements JobContext {
           transferredBytes: transferred,
           totalBytes: total,
         });
-      }
+      },
+      basePlace.version
     );
     const basePath = mergeContext.resolvePath('base.rbxl');
     await fs.writeFile(basePath, buffer);

--- a/tools/nevermore-cli/src/utils/open-cloud/open-cloud-client.test.ts
+++ b/tools/nevermore-cli/src/utils/open-cloud/open-cloud-client.test.ts
@@ -116,3 +116,135 @@ describe('OpenCloudClient.uploadPlaceAsync', () => {
     expect(urls[1]).toContain('versionType=Saved');
   });
 });
+
+describe('OpenCloudClient.downloadPlaceAsync', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('downloads the latest version when no version is pinned', async () => {
+    const urls: string[] = [];
+    const fakeLimiter = {
+      fetchAsync: vi.fn(async (url: string | URL) => {
+        urls.push(String(url));
+        return new Response(JSON.stringify({ location: 'https://cdn/x' }), {
+          status: 200,
+        });
+      }),
+    } as unknown as RateLimiter;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(Buffer.from([1, 2, 3]), { status: 200 }))
+    );
+
+    const client = new OpenCloudClient({
+      apiKey: 'test-key',
+      rateLimiter: fakeLimiter,
+    });
+    const buffer = await client.downloadPlaceAsync(1, 22);
+
+    expect(urls[0]).toBe(
+      'https://apis.roblox.com/asset-delivery-api/v1/assetId/22'
+    );
+    expect(urls[0]).not.toContain('/version/');
+    expect([...buffer]).toEqual([1, 2, 3]);
+  });
+
+  it('downloads a specific version when pinned', async () => {
+    const urls: string[] = [];
+    const fakeLimiter = {
+      fetchAsync: vi.fn(async (url: string | URL) => {
+        urls.push(String(url));
+        return new Response(JSON.stringify({ location: 'https://cdn/x' }), {
+          status: 200,
+        });
+      }),
+    } as unknown as RateLimiter;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(Buffer.from([9]), { status: 200 }))
+    );
+
+    const client = new OpenCloudClient({
+      apiKey: 'test-key',
+      rateLimiter: fakeLimiter,
+    });
+    await client.downloadPlaceAsync(1, 22, undefined, 42);
+
+    expect(urls[0]).toBe(
+      'https://apis.roblox.com/asset-delivery-api/v1/assetId/22/version/42'
+    );
+  });
+
+  it('throws a clear error when a pinned version does not exist', async () => {
+    // The Asset Delivery API reports a missing version as HTTP 200 with an
+    // errors array and no location.
+    const fakeLimiter = {
+      fetchAsync: vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              errors: [{ code: 404, message: 'Request asset was not found' }],
+            }),
+            { status: 200 }
+          )
+      ),
+    } as unknown as RateLimiter;
+
+    const client = new OpenCloudClient({
+      apiKey: 'test-key',
+      rateLimiter: fakeLimiter,
+    });
+
+    await expect(
+      client.downloadPlaceAsync(1, 22, undefined, 999999)
+    ).rejects.toThrowError(/no version 999999/);
+  });
+});
+
+describe('OpenCloudClient.getLatestPlaceVersionAsync', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the numeric revisionId from the Assets API', async () => {
+    const urls: string[] = [];
+    const fakeLimiter = {
+      fetchAsync: vi.fn(async (url: string | URL) => {
+        urls.push(String(url));
+        return new Response(
+          JSON.stringify({ assetId: '22', revisionId: '5781' }),
+          { status: 200 }
+        );
+      }),
+    } as unknown as RateLimiter;
+
+    const client = new OpenCloudClient({
+      apiKey: 'test-key',
+      rateLimiter: fakeLimiter,
+    });
+    const version = await client.getLatestPlaceVersionAsync(1, 22);
+
+    expect(version).toBe(5781);
+    expect(urls[0]).toBe('https://apis.roblox.com/assets/v1/assets/22');
+  });
+
+  it('throws when the Assets API omits a revisionId', async () => {
+    const fakeLimiter = {
+      fetchAsync: vi.fn(
+        async () =>
+          new Response(JSON.stringify({ assetId: '22' }), { status: 200 })
+      ),
+    } as unknown as RateLimiter;
+
+    const client = new OpenCloudClient({
+      apiKey: 'test-key',
+      rateLimiter: fakeLimiter,
+    });
+
+    await expect(client.getLatestPlaceVersionAsync(1, 22)).rejects.toThrowError(
+      /no revisionId/
+    );
+  });
+});

--- a/tools/nevermore-cli/src/utils/open-cloud/open-cloud-client.ts
+++ b/tools/nevermore-cli/src/utils/open-cloud/open-cloud-client.ts
@@ -390,17 +390,26 @@ export class OpenCloudClient {
    * Requires the `legacy-asset:manage` scope on the API key.
    *
    * Two-step process: fetch a temporary CDN URL, then download the binary.
+   *
+   * Pass `version` to fetch a specific published version instead of the latest.
+   * This is how deploys pin a `basePlace` so a broken Studio edit can't leak in.
    */
   async downloadPlaceAsync(
     universeId: number,
     placeId: number,
-    onProgress?: (transferredBytes: number, totalBytes: number) => void
+    onProgress?: (transferredBytes: number, totalBytes: number) => void,
+    version?: number
   ): Promise<Buffer> {
     const apiKey = await this._resolveApiKeyAsync();
-    const url = `https://apis.roblox.com/asset-delivery-api/v1/assetId/${placeId}`;
+    const url =
+      version != null
+        ? `https://apis.roblox.com/asset-delivery-api/v1/assetId/${placeId}/version/${version}`
+        : `https://apis.roblox.com/asset-delivery-api/v1/assetId/${placeId}`;
 
     OutputHelper.verbose(
-      `Downloading base place from https://www.roblox.com/games/${placeId}/place ...`
+      `Downloading base place${
+        version != null ? ` v${version}` : ''
+      } from https://www.roblox.com/games/${placeId}/place ...`
     );
 
     const response = await this._rateLimiter.fetchAsync(url, {
@@ -432,13 +441,83 @@ export class OpenCloudClient {
       );
     }
 
-    const data = (await response.json()) as { location: string };
+    // The Asset Delivery API reports a missing asset/version as HTTP 200 with an
+    // `errors` array rather than an error status, so a bad `version` pin lands
+    // here instead of the block above.
+    const data = (await response.json()) as {
+      location?: string;
+      errors?: Array<{ code?: number; message?: string }>;
+    };
     if (!data.location) {
-      throw new Error('Download place failed: no CDN location in response');
+      const apiMessage = data.errors?.[0]?.message;
+      if (version != null) {
+        throw new Error(
+          `Base place ${placeId} has no version ${version}` +
+            (apiMessage ? ` (${apiMessage})` : '') +
+            `. Run "nevermore deploy version upgrade" to re-pin, or check the pinned version in deploy.nevermore.json.`
+        );
+      }
+      throw new Error(
+        `Download place failed: no CDN location in response` +
+          (apiMessage ? `: ${apiMessage}` : '')
+      );
     }
 
     OutputHelper.verbose('Fetching place binary from CDN...');
     return _fetchCdnBinaryAsync(data.location, onProgress);
+  }
+
+  /**
+   * Resolve the current latest published version number of a place, via the
+   * Open Cloud Assets API (`asset:read` scope; `legacy-asset:manage` also
+   * grants it). The returned number is the same value the Asset Delivery API's
+   * `/version/{n}` route expects, so it can be written straight into a
+   * `basePlace.version` pin.
+   */
+  async getLatestPlaceVersionAsync(
+    universeId: number,
+    placeId: number
+  ): Promise<number> {
+    const apiKey = await this._resolveApiKeyAsync();
+    const url = `https://apis.roblox.com/assets/v1/assets/${placeId}`;
+
+    const response = await this._rateLimiter.fetchAsync(url, {
+      method: 'GET',
+      headers: {
+        'x-api-key': apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      if (response.status === 401 || response.status === 403) {
+        throw new Error(
+          formatAuthError(
+            'Read place version',
+            'asset:read',
+            universeId,
+            placeId,
+            response.status,
+            response.statusText,
+            text,
+            'GET',
+            url
+          )
+        );
+      }
+      throw new Error(
+        `Read place version failed: ${response.status} ${response.statusText}: ${text}`
+      );
+    }
+
+    const data = (await response.json()) as { revisionId?: string };
+    const version = Number(data.revisionId);
+    if (!data.revisionId || !Number.isFinite(version)) {
+      throw new Error(
+        `Read place version failed: no revisionId for place ${placeId}`
+      );
+    }
+    return version;
   }
 }
 


### PR DESCRIPTION
Deploys that use a basePlace previously always pulled the latest published version of that place, so a broken Studio edit to a base place would ship on the next deploy even when the code hadn't changed. You can now pin a base place to a specific version in deploy.nevermore.json (add "version" inside basePlace), and deploys download exactly that version; omitting it keeps the old latest-pull behavior, so existing configs are unaffected.

Two new commands manage the pins: `nevermore deploy version upgrade [target]` bumps every basePlace to its current latest published version (via the Open Cloud Assets API, reusing the legacy-asset:manage scope), and `nevermore deploy version promote <from> <to>` copies the pins from one target onto another (e.g. production-demo to production), matching places by base place id so content lines up even when targets name their places differently. Both print an old to new table, gate writes behind --dryrun and a confirmation prompt, and were verified end-to-end against the egg-hunt-2026 config.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/nevermore-cli@4.38.0-canary.734.29546444548.0
  # or 
  yarn add @quenty/nevermore-cli@4.38.0-canary.734.29546444548.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
