### PR TITLE
fix(saveslot): selection chain consumes loads that settle after the player leaves

### DIFF
--- a/src/saveslot/src/Server/SaveSlotLateSettle.spec.lua
+++ b/src/saveslot/src/Server/SaveSlotLateSettle.spec.lua
@@ -1,0 +1,122 @@
+--!strict
+--[[
+	The per-player selection chain (slots loaded -> teleport read -> default slot) runs against
+	datastore reads that can settle long after the player left — session-lock and datastore
+	retries outlive a leave. A continuation that then calls into the destroyed
+	(metatable-stripped) HasSaveSlots binder throws "attempt to call missing method ..." as a
+	stray error that fails the whole run. The chain must consume a late settle silently: every
+	hop is maid-owned (cancelled with the binder's brio) and re-checks the binder is alive.
+
+	@class SaveSlotLateSettle.spec.lua
+]]
+local require = require(script.Parent.loader).load(script)
+
+local Workspace = game:GetService("Workspace")
+
+local DataStoreMock = require("DataStoreMock")
+local Jest = require("Jest")
+local Maid = require("Maid")
+local PlayerMock = require("PlayerMock")
+local PromiseTestUtils = require("PromiseTestUtils")
+local ServiceBag = require("ServiceBag")
+
+local afterEach = Jest.Globals.afterEach
+local describe = Jest.Globals.describe
+local expect = Jest.Globals.expect
+local it = Jest.Globals.it
+
+local USER_ID = 636363
+
+-- Every datastore read yields this long, so the spec can land the unbind inside a chosen
+-- read's in-flight window.
+local READ_YIELD_SECONDS = 0.5
+
+local activeController: any = nil
+
+afterEach(function()
+	-- Safety net for a failing test: destroy is idempotent, so this is a no-op after the test's
+	-- own controller:destroy() and a full teardown when an assertion threw before reaching it.
+	if activeController then
+		local controller = activeController
+		activeController = nil
+		controller:destroy()
+	end
+end)
+
+local function setup()
+	local maid = Maid.new()
+
+	local mock = DataStoreMock.new()
+	mock:SetYieldTime(READ_YIELD_SECONDS)
+
+	local serviceBag = maid:Add(ServiceBag.new())
+	local playerDataStoreService: any = serviceBag:GetService(require("PlayerDataStoreService"))
+	local hasSaveSlotsBinder: any = serviceBag:GetService(require("HasSaveSlots"))
+	serviceBag:GetService(require("SaveSlotService"))
+	serviceBag:Init()
+	playerDataStoreService:SetRobloxDataStore(mock)
+	serviceBag:Start()
+
+	local fakePlayer = maid:Add(PlayerMock.new({ UserId = USER_ID }))
+	fakePlayer.Parent = Workspace
+
+	local destroyed = false
+	local controller: any
+	controller = {
+		hasSaveSlotsBinder = hasSaveSlotsBinder,
+		fakePlayer = fakePlayer,
+		destroy = function(self: any)
+			if destroyed then
+				return
+			end
+			destroyed = true
+			if activeController == self then
+				activeController = nil
+			end
+			serviceBag:Destroy()
+			maid:DoCleaning()
+			-- Any straggler continuation blows up here, inside the test that owns it, rather
+			-- than as flake in a later suite.
+			task.wait(READ_YIELD_SECONDS * 3)
+		end,
+	}
+	activeController = controller
+
+	return controller
+end
+
+describe("SaveSlotService selection chain vs a player who leaves mid-load", function()
+	it("consumes a slots-load still pending when the binder dies", function()
+		local controller = setup()
+
+		local hasSaveSlots =
+			assert(controller.hasSaveSlotsBinder:Bind(controller.fakePlayer), "Failed to bind HasSaveSlots")
+		local slotsLoaded = hasSaveSlots:PromiseSlotsLoaded()
+
+		-- Let the service's chain attach to the (still pending) load, then "leave".
+		task.wait()
+		expect(PromiseTestUtils.awaitSettled(slotsLoaded, 0)).toEqual(false)
+		controller.hasSaveSlotsBinder:Unbind(controller.fakePlayer)
+
+		controller:destroy()
+	end)
+
+	it("consumes a default-slot read that settles after the binder died", function()
+		local controller = setup()
+
+		local hasSaveSlots =
+			assert(controller.hasSaveSlotsBinder:Bind(controller.fakePlayer), "Failed to bind HasSaveSlots")
+
+		-- Play the chain forward to the default-slot resolution: slots loaded, teleport read
+		-- consumed, and the last-active-slot datastore read now in its in-flight window.
+		expect(PromiseTestUtils.awaitSettled(hasSaveSlots:PromiseSlotsLoaded(), 10)).toEqual(true)
+		task.wait()
+
+		-- The player leaves inside that window; the read settles after the binder is gone.
+		-- With the regression, the settle's continuation calls the destroyed binder and a
+		-- stray "attempt to call missing method" error fails the run.
+		controller.hasSaveSlotsBinder:Unbind(controller.fakePlayer)
+
+		controller:destroy()
+	end)
+end)

--- a/src/saveslot/src/Server/SaveSlotService.lua
+++ b/src/saveslot/src/Server/SaveSlotService.lua
@@ -107,13 +107,13 @@ function SaveSlotService.Start(self: SaveSlotService)
 		-- continuation re-checks the binder is alive: a continuation queued before the maid
 		-- died still runs, and calling any method on the destroyed (metatable-stripped)
 		-- binder throws.
-		maid:GivePromise(hasSaveSlots:PromiseSlotsLoaded()):Then(function()
+		maid:GivePromise(hasSaveSlots:PromiseSlotsLoaded()):Then(function(): any
 			if not hasSaveSlots.Destroy then
 				return nil -- The binder died while the load settled
 			end
-			return maid:GivePromise(hasSaveSlots:PromiseLoadSaveSlotFromTeleport()):Then(function(loadedSlotId)
+			return maid:GivePromise(hasSaveSlots:PromiseLoadSaveSlotFromTeleport()):Then(function(loadedSlotId): any
 				if loadedSlotId then
-					return -- Teleported in with a valid slot; it is now selected
+					return nil -- Teleported in with a valid slot; it is now selected
 				end
 				if not hasSaveSlots.Destroy then
 					return nil -- The binder died while the teleport read settled
@@ -133,7 +133,7 @@ end
 ]=]
 function SaveSlotService._promiseSelectDefaultSlot(
 	self: SaveSlotService,
-	maid: Maid.Maid,
+	maid: any,
 	hasSaveSlots: any
 ): Promise.Promise<any>?
 	if self._selectionRequired then
@@ -141,37 +141,38 @@ function SaveSlotService._promiseSelectDefaultSlot(
 	end
 
 	return maid:GivePromise(hasSaveSlots:PromiseLastActiveSlotId())
-		:Then(function(lastActiveSlotId: SaveSlotData.SlotId?)
+		:Then(function(lastActiveSlotId: SaveSlotData.SlotId?): any
 			if not hasSaveSlots.Destroy then
 				return nil
 			end
-			return maid:GivePromise(hasSaveSlots:PromiseHasSlot(lastActiveSlotId)):Then(function(hasLastSlot: boolean)
-				if not hasSaveSlots.Destroy then
-					return nil
-				end
-				if hasLastSlot then
-					return hasSaveSlots:PromiseSelectSlot(lastActiveSlotId)
-				end
+			return maid:GivePromise(hasSaveSlots:PromiseHasSlot(lastActiveSlotId))
+				:Then(function(hasLastSlot: boolean): any
+					if not hasSaveSlots.Destroy then
+						return nil
+					end
+					if hasLastSlot then
+						return hasSaveSlots:PromiseSelectSlot(lastActiveSlotId)
+					end
 
-				-- Or create and select default slot
-				return maid:GivePromise(hasSaveSlots:PromiseSlotIdFromIndex(SaveSlotConstants.DEFAULT_SLOT_INDEX))
-					:Then(function(defaultSlotId: SaveSlotData.SlotId?)
-						if not hasSaveSlots.Destroy then
-							return nil
-						end
-						if defaultSlotId then
-							return defaultSlotId
-						else
-							return hasSaveSlots:PromiseCreateSlot(SaveSlotConstants.DEFAULT_SLOT_INDEX)
-						end
-					end)
-					:Then(function(slotId: SaveSlotData.SlotId?)
-						if not slotId or not hasSaveSlots.Destroy then
-							return nil
-						end
-						return hasSaveSlots:PromiseSelectSlot(slotId)
-					end)
-			end)
+					-- Or create and select default slot
+					return maid:GivePromise(hasSaveSlots:PromiseSlotIdFromIndex(SaveSlotConstants.DEFAULT_SLOT_INDEX))
+						:Then(function(defaultSlotId: SaveSlotData.SlotId?): any
+							if not hasSaveSlots.Destroy then
+								return nil
+							end
+							if defaultSlotId then
+								return defaultSlotId
+							else
+								return hasSaveSlots:PromiseCreateSlot(SaveSlotConstants.DEFAULT_SLOT_INDEX)
+							end
+						end)
+						:Then(function(slotId: SaveSlotData.SlotId?): any
+							if not slotId or not hasSaveSlots.Destroy then
+								return nil
+							end
+							return hasSaveSlots:PromiseSelectSlot(slotId)
+						end)
+				end)
 		end)
 end
 

--- a/src/saveslot/src/Server/SaveSlotService.lua
+++ b/src/saveslot/src/Server/SaveSlotService.lua
@@ -140,38 +140,39 @@ function SaveSlotService._promiseSelectDefaultSlot(
 		return nil -- Consumer handles selection
 	end
 
-	return maid:GivePromise(hasSaveSlots:PromiseLastActiveSlotId()):Then(function(lastActiveSlotId: SaveSlotData.SlotId?)
-		if not hasSaveSlots.Destroy then
-			return nil
-		end
-		return maid:GivePromise(hasSaveSlots:PromiseHasSlot(lastActiveSlotId)):Then(function(hasLastSlot: boolean)
+	return maid:GivePromise(hasSaveSlots:PromiseLastActiveSlotId())
+		:Then(function(lastActiveSlotId: SaveSlotData.SlotId?)
 			if not hasSaveSlots.Destroy then
 				return nil
 			end
-			if hasLastSlot then
-				return hasSaveSlots:PromiseSelectSlot(lastActiveSlotId)
-			end
+			return maid:GivePromise(hasSaveSlots:PromiseHasSlot(lastActiveSlotId)):Then(function(hasLastSlot: boolean)
+				if not hasSaveSlots.Destroy then
+					return nil
+				end
+				if hasLastSlot then
+					return hasSaveSlots:PromiseSelectSlot(lastActiveSlotId)
+				end
 
-			-- Or create and select default slot
-			return maid:GivePromise(hasSaveSlots:PromiseSlotIdFromIndex(SaveSlotConstants.DEFAULT_SLOT_INDEX))
-				:Then(function(defaultSlotId: SaveSlotData.SlotId?)
-					if not hasSaveSlots.Destroy then
-						return nil
-					end
-					if defaultSlotId then
-						return defaultSlotId
-					else
-						return hasSaveSlots:PromiseCreateSlot(SaveSlotConstants.DEFAULT_SLOT_INDEX)
-					end
-				end)
-				:Then(function(slotId: SaveSlotData.SlotId?)
-					if not slotId or not hasSaveSlots.Destroy then
-						return nil
-					end
-					return hasSaveSlots:PromiseSelectSlot(slotId)
-				end)
+				-- Or create and select default slot
+				return maid:GivePromise(hasSaveSlots:PromiseSlotIdFromIndex(SaveSlotConstants.DEFAULT_SLOT_INDEX))
+					:Then(function(defaultSlotId: SaveSlotData.SlotId?)
+						if not hasSaveSlots.Destroy then
+							return nil
+						end
+						if defaultSlotId then
+							return defaultSlotId
+						else
+							return hasSaveSlots:PromiseCreateSlot(SaveSlotConstants.DEFAULT_SLOT_INDEX)
+						end
+					end)
+					:Then(function(slotId: SaveSlotData.SlotId?)
+						if not slotId or not hasSaveSlots.Destroy then
+							return nil
+						end
+						return hasSaveSlots:PromiseSelectSlot(slotId)
+					end)
+			end)
 		end)
-	end)
 end
 
 --[=[

--- a/src/saveslot/src/Server/SaveSlotService.lua
+++ b/src/saveslot/src/Server/SaveSlotService.lua
@@ -101,13 +101,24 @@ function SaveSlotService.Start(self: SaveSlotService)
 			pairMaid:GiveTask(hasSaveSlots:RegisterSummaryProvider(name, provider))
 		end))
 
-		-- Select the slot the player teleported in with, or proceed with the default flow
+		-- Select the slot the player teleported in with, or proceed with the default flow.
+		-- The loads can settle long after this player is gone (session-lock or datastore
+		-- retries outlive a leave), so the maid must own the INNER promise too, and each
+		-- continuation re-checks the binder is alive: a continuation queued before the maid
+		-- died still runs, and calling any method on the destroyed (metatable-stripped)
+		-- binder throws.
 		maid:GivePromise(hasSaveSlots:PromiseSlotsLoaded()):Then(function()
-			return hasSaveSlots:PromiseLoadSaveSlotFromTeleport():Then(function(loadedSlotId)
+			if not hasSaveSlots.Destroy then
+				return nil -- The binder died while the load settled
+			end
+			return maid:GivePromise(hasSaveSlots:PromiseLoadSaveSlotFromTeleport()):Then(function(loadedSlotId)
 				if loadedSlotId then
 					return -- Teleported in with a valid slot; it is now selected
 				end
-				return self:_promiseSelectDefaultSlot(hasSaveSlots)
+				if not hasSaveSlots.Destroy then
+					return nil -- The binder died while the teleport read settled
+				end
+				return self:_promiseSelectDefaultSlot(maid, hasSaveSlots)
 			end)
 		end)
 	end))
@@ -116,29 +127,47 @@ end
 --[=[
 	Selects the player's last active slot, or creates and selects the default slot.
 	Does nothing when explicit selection is required.
+
+	Every hop is maid-owned and re-checks the binder for the same reason as the caller: any of
+	these reads can settle after the player left, and continuing into the destroyed binder throws.
 ]=]
-function SaveSlotService._promiseSelectDefaultSlot(self: SaveSlotService, hasSaveSlots: any): Promise.Promise<any>?
+function SaveSlotService._promiseSelectDefaultSlot(
+	self: SaveSlotService,
+	maid: Maid.Maid,
+	hasSaveSlots: any
+): Promise.Promise<any>?
 	if self._selectionRequired then
 		return nil -- Consumer handles selection
 	end
 
-	return hasSaveSlots:PromiseLastActiveSlotId():Then(function(lastActiveSlotId: SaveSlotData.SlotId?)
-		return hasSaveSlots:PromiseHasSlot(lastActiveSlotId):Then(function(hasLastSlot: boolean)
+	return maid:GivePromise(hasSaveSlots:PromiseLastActiveSlotId()):Then(function(lastActiveSlotId: SaveSlotData.SlotId?)
+		if not hasSaveSlots.Destroy then
+			return nil
+		end
+		return maid:GivePromise(hasSaveSlots:PromiseHasSlot(lastActiveSlotId)):Then(function(hasLastSlot: boolean)
+			if not hasSaveSlots.Destroy then
+				return nil
+			end
 			if hasLastSlot then
 				return hasSaveSlots:PromiseSelectSlot(lastActiveSlotId)
 			end
 
 			-- Or create and select default slot
-			return hasSaveSlots
-				:PromiseSlotIdFromIndex(SaveSlotConstants.DEFAULT_SLOT_INDEX)
+			return maid:GivePromise(hasSaveSlots:PromiseSlotIdFromIndex(SaveSlotConstants.DEFAULT_SLOT_INDEX))
 				:Then(function(defaultSlotId: SaveSlotData.SlotId?)
+					if not hasSaveSlots.Destroy then
+						return nil
+					end
 					if defaultSlotId then
 						return defaultSlotId
 					else
 						return hasSaveSlots:PromiseCreateSlot(SaveSlotConstants.DEFAULT_SLOT_INDEX)
 					end
 				end)
-				:Then(function(slotId: SaveSlotData.SlotId)
+				:Then(function(slotId: SaveSlotData.SlotId?)
+					if not slotId or not hasSaveSlots.Destroy then
+						return nil
+					end
 					return hasSaveSlots:PromiseSelectSlot(slotId)
 				end)
 		end)


### PR DESCRIPTION
## Problem

The per-player selection chain in `SaveSlotService` (slots loaded → teleport read → default slot) runs against datastore reads that can settle long after the player is gone — session-lock and datastore retries outlive a leave. Only the outermost promise was maid-owned, so a late settle ran continuations that called into the destroyed (metatable-stripped) `HasSaveSlots` binder:

```
SaveSlotService:125: attempt to call missing method 'PromiseLastActiveSlotId' of table
```

egg-hunt-2026's cloud test suite hit this as a run-failing stray error (currently worked around with a `pnpm patch`, which this PR replaces); on a live server it's the same crash-trace noise on every mid-load leave.

## Fix

- Every hop in the chain — including all of `_promiseSelectDefaultSlot` — is now **maid-owned**, so pending reads cancel with the binder's brio.
- Each continuation **re-checks the binder is alive** (`hasSaveSlots.Destroy`) before calling into it: a continuation queued in the same frame the binder dies still executes, so cancellation alone doesn't close the window.

## Testing

New `SaveSlotLateSettle.spec.lua` pins both windows with a yield-injected `DataStoreMock`: unbinding while the slots-load is still pending, and unbinding inside the default-slot read's in-flight window so the settle lands on the dead binder. `nevermore test --cloud` for the saveslot package: **87/87 passed**, no stray errors.

https://claude.ai/code/session_01LQCjTHuCgwir8JZzeAeySJ