### PR TITLE
fix(saveslot): bind the client HasSaveSlots for a mocked local player

### DIFF
--- a/src/saveslot/src/Client/Binders/HasSaveSlotsClient.lua
+++ b/src/saveslot/src/Client/Binders/HasSaveSlotsClient.lua
@@ -10,6 +10,7 @@ local Players = game:GetService("Players")
 local Binder = require("Binder")
 local HasSaveSlotsBase = require("HasSaveSlotsBase")
 local HasSaveSlotsInterface = require("HasSaveSlotsInterface")
+local PlayerMock = require("PlayerMock")
 local Promise = require("Promise")
 local Remoting = require("Remoting")
 local SaveSlotConstants = require("SaveSlotConstants")
@@ -34,7 +35,7 @@ export type HasSaveSlotsClient =
 	& HasSaveSlotsBase.HasSaveSlotsBase
 
 function HasSaveSlotsClient.new(player: Player, serviceBag: ServiceBag.ServiceBag): HasSaveSlotsClient
-	if player ~= Players.LocalPlayer then
+	if player ~= (Players.LocalPlayer or PlayerMock.getMockedLocalPlayer()) then
 		return nil :: any
 	end
 

--- a/src/saveslot/src/Client/Binders/HasSaveSlotsClient.spec.lua
+++ b/src/saveslot/src/Client/Binders/HasSaveSlotsClient.spec.lua
@@ -1,0 +1,111 @@
+--!strict
+--[[
+	@class HasSaveSlotsClient.spec
+]]
+local require = require(script.Parent.loader).load(script)
+
+local Workspace = game:GetService("Workspace")
+
+local HasSaveSlotsClient = require("HasSaveSlotsClient")
+local HasSaveSlotsInterface = require("HasSaveSlotsInterface")
+local Jest = require("Jest")
+local Maid = require("Maid")
+local PlayerMock = require("PlayerMock")
+local PromiseTestUtils = require("PromiseTestUtils")
+local SaveSlotDataService = require("SaveSlotDataService")
+local ServiceBag = require("ServiceBag")
+local TeleportDataServiceClient = require("TeleportDataServiceClient")
+local TieRealmService = require("TieRealmService")
+local TieRealms = require("TieRealms")
+
+local afterEach = Jest.Globals.afterEach
+local describe = Jest.Globals.describe
+local expect = Jest.Globals.expect
+local it = Jest.Globals.it
+
+local FAKE_USER_ID = 424242
+
+local activeMaid: Maid.Maid? = nil
+
+afterEach(function()
+	if activeMaid then
+		local maid = activeMaid
+		activeMaid = nil
+		maid:DoCleaning()
+	end
+	PlayerMock.setMockedLocalPlayer(nil)
+end)
+
+local function setup(): (Maid.Maid, any, any)
+	local maid = Maid.new()
+	activeMaid = maid
+
+	local serviceBag = maid:Add(ServiceBag.new())
+	local tieRealmService = serviceBag:GetService(TieRealmService) :: any
+	tieRealmService:SetTieRealm(TieRealms.CLIENT)
+	local binder = serviceBag:GetService(HasSaveSlotsClient) :: any
+	local dataService = serviceBag:GetService(SaveSlotDataService) :: any
+	serviceBag:GetService(TeleportDataServiceClient)
+	serviceBag:Init()
+	serviceBag:Start()
+
+	return maid, binder, dataService
+end
+
+local function newPlayerMock(maid: Maid.Maid, isLocalPlayer: boolean): Player
+	local playerMock = PlayerMock.new({ UserId = FAKE_USER_ID })
+	playerMock.Parent = Workspace
+	maid:GiveTask(function()
+		playerMock:Destroy()
+	end)
+	if isLocalPlayer then
+		PlayerMock.setMockedLocalPlayer(playerMock)
+	end
+	return playerMock
+end
+
+describe("HasSaveSlotsClient local-player gate", function()
+	it("creates no client implementation for a mock that is not the local player", function()
+		local maid, binder = setup()
+		local playerMock = newPlayerMock(maid, false)
+
+		binder:Bind(playerMock)
+
+		expect(HasSaveSlotsInterface:Find(playerMock, TieRealms.CLIENT)).toBeNil()
+	end)
+
+	it("creates the client implementation for the local-player mock", function()
+		local maid, binder = setup()
+		local playerMock = newPlayerMock(maid, true)
+
+		binder:Bind(playerMock)
+
+		expect(HasSaveSlotsInterface:Find(playerMock, TieRealms.CLIENT)).never.toBeNil()
+	end)
+end)
+
+describe("HasSaveSlotsClient active-slot observation", function()
+	it("emits the active slot id client-side, and updates as it changes", function()
+		local maid, binder, dataService = setup()
+		local playerMock = newPlayerMock(maid, true)
+		binder:Bind(playerMock)
+
+		playerMock:SetAttribute("ActiveSlotId", "slot-a")
+
+		local observed: string? = nil
+		maid:GiveTask(dataService:ObserveActiveSlotId(playerMock):Subscribe(function(slotId: string?)
+			observed = slotId
+		end))
+
+		PromiseTestUtils.awaitValue(function()
+			return observed == "slot-a"
+		end, 5)
+		expect(observed).toEqual("slot-a")
+
+		playerMock:SetAttribute("ActiveSlotId", "slot-b")
+		PromiseTestUtils.awaitValue(function()
+			return observed == "slot-b"
+		end, 5)
+		expect(observed).toEqual("slot-b")
+	end)
+end)


### PR DESCRIPTION
## Problem

`HasSaveSlotsClient.new` gated construction on `player ~= Players.LocalPlayer`:

```lua
if player ~= Players.LocalPlayer then
    return nil :: any
end
```

A `PlayerMock` is a `Folder` and can never be the engine's real `Players.LocalPlayer`, so in a dual-realm test (server bag + client bag + a mock as the local player) the client-realm `HasSaveSlots` Tie was never implemented for the mock. As a result `SaveSlotDataService:ObserveActiveSlotId` — and anything built on it, e.g. a client menu's slot-resume flow — never emitted for the mock, even though the server was writing the shared `ActiveSlotId` attribute on that very instance. The client save-slot flow was effectively untestable headless.

## Fix

Resolve the gate through the `PlayerMock` fallback, the same pattern used across the engine's other client seams (`Players.LocalPlayer or PlayerMock.getMockedLocalPlayer()`):

```lua
if player ~= (Players.LocalPlayer or PlayerMock.getMockedLocalPlayer()) then
    return nil :: any
end
```

No behavior change for real clients — `getMockedLocalPlayer()` returns `nil` when nothing is designated, so the expression collapses to `Players.LocalPlayer`. `@quenty/playermock` is already a dependency of this package.

## Tests

New `HasSaveSlotsClient.spec` (the package's first client-binder / client-realm coverage), verified with `nevermore test --cloud` — **90/90** in the saveslot suite:
- creates **no** client implementation for a mock that isn't the local player (gate rejects → `HasSaveSlotsInterface:Find(mock, CLIENT)` is nil);
- creates the client implementation for the designated local-player mock;
- `SaveSlotDataService:ObserveActiveSlotId` then emits the active slot id and tracks it as the `ActiveSlotId` attribute changes.

stylua, selene, and `luau-lsp analyze` are clean.