### PR TITLE
feat: PlayerMock seams for GuiService.SelectedObject and rich input firing

### DIFF
--- a/src/player-mock/src/Shared/PlayerMock.lua
+++ b/src/player-mock/src/Shared/PlayerMock.lua
@@ -1164,6 +1164,13 @@ end
 -- handler, so like the other backings it is inspectable and self-cleaning.
 local ACTION_NAME_PREFIX = "PlayerMockAction_"
 
+-- The raw Lua callback for each bind, keyed by its marker BindableFunction so [PlayerMock.fireInput]
+-- can invoke it *directly*. Firing through the BindableFunction itself (as this once did) crosses the
+-- bindable boundary, which strips a stand-in InputObject's methods/signals -- and real handlers read
+-- `inputObject:GetPropertyChangedSignal(...)` (e.g. KeymapControls tracking the input's end). Weak keys
+-- so an entry drops with its child; also cleared explicitly on unbind/rebind.
+local boundActionCallbacks: { [BindableFunction]: (...any) -> ...any } = setmetatable({}, { __mode = "k" }) :: any
+
 local function findActionBindable(player: Player, actionName: string): BindableFunction?
 	return (player :: Instance):FindFirstChild(ACTION_NAME_PREFIX .. actionName) :: BindableFunction?
 end
@@ -1179,7 +1186,7 @@ local function bindActionCallback(player: Player, actionName: string, functionTo
 		bindableFunction = created
 	end
 
-	(bindableFunction :: BindableFunction).OnInvoke = functionToBind
+	boundActionCallbacks[bindableFunction :: BindableFunction] = functionToBind
 end
 
 -- Context-restricted input-binding engine calls a mock stands in for, keyed by the canonical
@@ -1212,6 +1219,7 @@ local INPUT_DOMAINS: { [string]: (player: Player, actionName: string, ...any) ->
 	["ContextActionService.UnbindAction"] = function(player, actionName)
 		local bindableFunction = findActionBindable(player, actionName)
 		if bindableFunction ~= nil then
+			boundActionCallbacks[bindableFunction] = nil
 			bindableFunction:Destroy()
 		end
 	end,
@@ -1282,14 +1290,15 @@ end
 	Errors when the action is not bound: with no engine sink logic modeled, firing an unbound
 	action can only be a test mistake (typo'd name, or firing after the production unbind).
 
-	The invocation goes through the backing `BindableFunction`, so a stand-in `inputObject` must be
-	bindable-safe -- a real `InputObject` reference, or a plain metatable-free table of the fields
-	the callback reads (e.g. `UserInputType`, `Position`, `Delta`).
+	The bound callback is invoked directly (not through the marker BindableFunction), so `inputObject`
+	is passed by reference: hand it a real `InputObject`, a plain table of the fields the callback reads
+	(`UserInputType`, `Position`, `Delta`, ...), or a [PlayerMock.makeInputObject] stand-in when the
+	callback also needs `:GetPropertyChangedSignal(...)` (e.g. a KeymapControls handler).
 
 	@param player Player -- must be a PlayerMock
 	@param actionName string
 	@param userInputState Enum.UserInputState
-	@param inputObject any? -- a real InputObject or a bindable-safe stand-in table
+	@param inputObject any? -- a real InputObject, a plain stand-in table, or a makeInputObject stand-in
 	@return Enum.ContextActionResult?
 ]=]
 function PlayerMock.fireInput(
@@ -1308,7 +1317,171 @@ function PlayerMock.fireInput(
 	local bindableFunction =
 		assert(findActionBindable(player, actionName), string.format("%q is not a bound action", actionName))
 
-	return bindableFunction:Invoke(actionName, userInputState, inputObject)
+	local callback = boundActionCallbacks[bindableFunction]
+	if callback == nil then
+		-- Bound before this mock carried a raw callback (or by foreign code): fall back to the bindable.
+		return bindableFunction:Invoke(actionName, userInputState, inputObject)
+	end
+
+	return callback(actionName, userInputState, inputObject)
+end
+
+--[=[
+	Builds a stand-in `InputObject` for [PlayerMock.fireInput] to hand a bound action -- for handlers
+	that read more than the raw fields, in particular `:GetPropertyChangedSignal("UserInputState")`
+	(KeymapControls connects it to learn when the press ends). A real `InputObject` cannot be
+	`Instance.new`'d, so this is a plain table exposing the fields and that one method; drive the press
+	lifecycle with `:SetUserInputState(...)`, which updates the field and fires the signal.
+
+	```lua
+	local input = PlayerMock.makeInputObject({ UserInputType = Enum.UserInputType.Gamepad1, KeyCode = Enum.KeyCode.ButtonA })
+	PlayerMock.fireInput(mock, actionName, Enum.UserInputState.Begin, input)
+	input:SetUserInputState(Enum.UserInputState.End) -- releases the press
+	```
+
+	@param props { UserInputType: Enum.UserInputType?, KeyCode: Enum.KeyCode?, UserInputState: Enum.UserInputState?, Position: Vector3?, Delta: Vector3? }?
+	@return table -- an InputObject stand-in
+]=]
+function PlayerMock.makeInputObject(props: {
+	UserInputType: Enum.UserInputType?,
+	KeyCode: Enum.KeyCode?,
+	UserInputState: Enum.UserInputState?,
+	Position: Vector3?,
+	Delta: Vector3?,
+}?): any
+	local resolved = props or {}
+	assert(
+		resolved.UserInputType == nil
+			or (typeof(resolved.UserInputType) == "EnumItem" and resolved.UserInputType.EnumType == Enum.UserInputType),
+		"Bad UserInputType"
+	)
+
+	-- One lightweight signal per observed property (only UserInputState is driven today). A local
+	-- implementation keeps player-mock free of a Signal dependency; it exposes the Connect/Disconnect
+	-- shape a Maid accepts.
+	local signals: { [string]: any } = {}
+	local function signalFor(propertyName: string)
+		local signal = signals[propertyName]
+		if signal then
+			return signal
+		end
+
+		local connections: { [(...any) -> ()]: boolean } = {}
+		signal = {
+			Connect = function(_self, callback)
+				connections[callback] = true
+				return {
+					Connected = true,
+					Disconnect = function(self)
+						self.Connected = false
+						connections[callback] = nil
+					end,
+				}
+			end,
+			Fire = function(_self, ...)
+				for callback in connections do
+					callback(...)
+				end
+			end,
+		}
+		signals[propertyName] = signal
+		return signal
+	end
+
+	local inputObject: any = {
+		UserInputType = resolved.UserInputType or Enum.UserInputType.Keyboard,
+		KeyCode = resolved.KeyCode or Enum.KeyCode.None,
+		UserInputState = resolved.UserInputState or Enum.UserInputState.Begin,
+		Position = resolved.Position or Vector3.zero,
+		Delta = resolved.Delta or Vector3.zero,
+	}
+
+	function inputObject.GetPropertyChangedSignal(_self, propertyName: string)
+		assert(type(propertyName) == "string", "Bad propertyName")
+		return signalFor(propertyName)
+	end
+
+	function inputObject.SetUserInputState(self, userInputState: Enum.UserInputState)
+		assert(
+			typeof(userInputState) == "EnumItem" and userInputState.EnumType == Enum.UserInputState,
+			"Bad userInputState"
+		)
+		self.UserInputState = userInputState
+		signalFor("UserInputState"):Fire()
+	end
+
+	return inputObject
+end
+
+-- ObjectValue child standing in for the client-global `GuiService.SelectedObject` (gamepad/keyboard
+-- focus). A headless server has no PlayerGui, so the engine refuses `GuiService.SelectedObject = obj`
+-- ("not a descendant of a PlayerGui"); selection code branches to store/read it on the mock local
+-- player instead, which is inspectable and self-cleaning like the other backings. Global focus maps to
+-- the single mocked local player.
+local SELECTED_GUI_OBJECT_NAME = "PlayerMockSelectedGuiObject"
+
+local function getOrCreateSelectedGuiObjectValue(player: Player): ObjectValue
+	local existing = (player :: Instance):FindFirstChild(SELECTED_GUI_OBJECT_NAME)
+	if existing ~= nil then
+		return existing :: ObjectValue
+	end
+
+	local objectValue = Instance.new("ObjectValue")
+	objectValue.Name = SELECTED_GUI_OBJECT_NAME
+	objectValue.Parent = player :: Instance
+	return objectValue
+end
+
+--[=[
+	Sets the mock's stand-in for `GuiService.SelectedObject` (or clears it with nil). Selection code
+	branches to this when the local player is a mock, since the engine's `GuiService.SelectedObject`
+	rejects any object not under a real PlayerGui (which a headless run has none of):
+
+	```lua
+	local localPlayer = Players.LocalPlayer or PlayerMock.getMockedLocalPlayer()
+	if localPlayer ~= nil and PlayerMock.isMock(localPlayer) then
+		PlayerMock.setSelectedGuiObject(localPlayer, button)
+	else
+		GuiService.SelectedObject = button
+	end
+	```
+
+	@param player Player -- must be a PlayerMock
+	@param guiObject GuiObject? -- the focused object, or nil to clear
+]=]
+function PlayerMock.setSelectedGuiObject(player: Player, guiObject: GuiObject?)
+	assert(PlayerMock.isMock(player), "Not a PlayerMock")
+	assert(guiObject == nil or (typeof(guiObject) == "Instance" and guiObject:IsA("GuiObject")), "Bad guiObject")
+
+	getOrCreateSelectedGuiObjectValue(player).Value = guiObject
+end
+
+--[=[
+	Reads the mock's stand-in for `GuiService.SelectedObject`, or nil when nothing is selected. The
+	read side of the same branch as [PlayerMock.setSelectedGuiObject].
+
+	@param player Player -- must be a PlayerMock
+	@return GuiObject?
+]=]
+function PlayerMock.getSelectedGuiObject(player: Player): GuiObject?
+	assert(PlayerMock.isMock(player), "Not a PlayerMock")
+
+	local objectValue = (player :: Instance):FindFirstChild(SELECTED_GUI_OBJECT_NAME)
+	return if objectValue ~= nil then (objectValue :: ObjectValue).Value :: GuiObject? else nil
+end
+
+--[=[
+	Returns the signal that fires when the mock's stand-in for `GuiService.SelectedObject` changes --
+	the backing ObjectValue's Value-changed signal. Lets a test (or a production observer that mirrors
+	`GuiService:GetPropertyChangedSignal("SelectedObject")`) react to selection moving.
+
+	@param player Player -- must be a PlayerMock
+	@return RBXScriptSignal
+]=]
+function PlayerMock.getSelectedGuiObjectChangedSignal(player: Player): RBXScriptSignal
+	assert(PlayerMock.isMock(player), "Not a PlayerMock")
+
+	return getOrCreateSelectedGuiObjectValue(player):GetPropertyChangedSignal("Value")
 end
 
 --[=[

--- a/src/player-mock/src/Shared/PlayerMock.lua
+++ b/src/player-mock/src/Shared/PlayerMock.lua
@@ -1326,6 +1326,14 @@ function PlayerMock.fireInput(
 	return callback(actionName, userInputState, inputObject)
 end
 
+export type InputObjectProps = {
+	UserInputType: Enum.UserInputType?,
+	KeyCode: Enum.KeyCode?,
+	UserInputState: Enum.UserInputState?,
+	Position: Vector3?,
+	Delta: Vector3?,
+}
+
 --[=[
 	Builds a stand-in `InputObject` for [PlayerMock.fireInput] to hand a bound action -- for handlers
 	that read more than the raw fields, in particular `:GetPropertyChangedSignal("UserInputState")`
@@ -1339,17 +1347,11 @@ end
 	input:SetUserInputState(Enum.UserInputState.End) -- releases the press
 	```
 
-	@param props { UserInputType: Enum.UserInputType?, KeyCode: Enum.KeyCode?, UserInputState: Enum.UserInputState?, Position: Vector3?, Delta: Vector3? }?
+	@param props InputObjectProps?
 	@return table -- an InputObject stand-in
 ]=]
-function PlayerMock.makeInputObject(props: {
-	UserInputType: Enum.UserInputType?,
-	KeyCode: Enum.KeyCode?,
-	UserInputState: Enum.UserInputState?,
-	Position: Vector3?,
-	Delta: Vector3?,
-}?): any
-	local resolved = props or {}
+function PlayerMock.makeInputObject(props: InputObjectProps?): any
+	local resolved: InputObjectProps = props or {}
 	assert(
 		resolved.UserInputType == nil
 			or (typeof(resolved.UserInputType) == "EnumItem" and resolved.UserInputType.EnumType == Enum.UserInputType),

--- a/src/player-mock/src/Shared/PlayerMock.spec.lua
+++ b/src/player-mock/src/Shared/PlayerMock.spec.lua
@@ -1490,6 +1490,119 @@ describe("PlayerMock.fireInput", function()
 
 		player:Destroy()
 	end)
+
+	it("passes the inputObject by reference, so a stand-in's methods survive", function()
+		local player = PlayerMock.new()
+		local seenInput
+		PlayerMock.bindInput(player, "ContextActionService.BindAction", "Fire", function(_name, _state, inputObject)
+			seenInput = inputObject
+			return nil
+		end, false)
+
+		local input = PlayerMock.makeInputObject({
+			UserInputType = Enum.UserInputType.Gamepad1,
+			KeyCode = Enum.KeyCode.ButtonA,
+		})
+		PlayerMock.fireInput(player, "Fire", Enum.UserInputState.Begin, input)
+
+		-- Same object (not a bindable copy): the method a handler needs is still callable.
+		expect(seenInput).toBe(input)
+		expect(typeof(seenInput:GetPropertyChangedSignal("UserInputState"))).toBe("table")
+
+		player:Destroy()
+	end)
+end)
+
+describe("PlayerMock.makeInputObject", function()
+	it("exposes the read fields with sensible defaults", function()
+		local input = PlayerMock.makeInputObject({
+			UserInputType = Enum.UserInputType.Gamepad1,
+			KeyCode = Enum.KeyCode.ButtonA,
+		})
+
+		expect(input.UserInputType).toBe(Enum.UserInputType.Gamepad1)
+		expect(input.KeyCode).toBe(Enum.KeyCode.ButtonA)
+		expect(input.UserInputState).toBe(Enum.UserInputState.Begin)
+		expect(input.Position).toBe(Vector3.zero)
+	end)
+
+	it("fires GetPropertyChangedSignal('UserInputState') on SetUserInputState", function()
+		local input = PlayerMock.makeInputObject({ UserInputType = Enum.UserInputType.Gamepad1 })
+
+		local fired = 0
+		local connection = input:GetPropertyChangedSignal("UserInputState"):Connect(function()
+			fired += 1
+		end)
+
+		input:SetUserInputState(Enum.UserInputState.End)
+
+		expect(fired).toBe(1)
+		expect(input.UserInputState).toBe(Enum.UserInputState.End)
+
+		connection:Disconnect()
+	end)
+
+	it("returns the same signal per property and rejects a bad UserInputType", function()
+		local input = PlayerMock.makeInputObject()
+		expect(input:GetPropertyChangedSignal("UserInputState")).toBe(input:GetPropertyChangedSignal("UserInputState"))
+		expect(function()
+			PlayerMock.makeInputObject({ UserInputType = Enum.KeyCode.ButtonA :: any })
+		end).toThrow()
+	end)
+end)
+
+describe("PlayerMock selected GUI object", function()
+	it("defaults to nil and round-trips a set value", function()
+		local player = PlayerMock.new()
+		local screenGui = Instance.new("ScreenGui")
+		local frame = Instance.new("Frame")
+		frame.Parent = screenGui
+
+		expect(PlayerMock.getSelectedGuiObject(player)).toBeNil()
+
+		PlayerMock.setSelectedGuiObject(player, frame)
+		expect(PlayerMock.getSelectedGuiObject(player)).toBe(frame)
+
+		PlayerMock.setSelectedGuiObject(player, nil)
+		expect(PlayerMock.getSelectedGuiObject(player)).toBeNil()
+
+		screenGui:Destroy()
+		player:Destroy()
+	end)
+
+	it("fires the changed signal when the selection moves", function()
+		local player = PlayerMock.new()
+		local screenGui = Instance.new("ScreenGui")
+		local frame = Instance.new("Frame")
+		frame.Parent = screenGui
+
+		local fired = 0
+		local connection = PlayerMock.getSelectedGuiObjectChangedSignal(player):Connect(function()
+			fired += 1
+		end)
+
+		PlayerMock.setSelectedGuiObject(player, frame)
+		expect(fired).toBe(1)
+
+		connection:Disconnect()
+		screenGui:Destroy()
+		player:Destroy()
+	end)
+
+	it("rejects a non-GuiObject and a non-mock", function()
+		local player = PlayerMock.new()
+		expect(function()
+			PlayerMock.setSelectedGuiObject(player, Instance.new("Folder") :: any)
+		end).toThrow()
+
+		local folder = Instance.new("Folder")
+		expect(function()
+			PlayerMock.getSelectedGuiObject(folder :: any)
+		end).toThrow()
+		folder:Destroy()
+
+		player:Destroy()
+	end)
 end)
 
 describe("PlayerMock local player", function()


### PR DESCRIPTION
## Why

Headless (Open Cloud) tests drive UI through a `PlayerMock` local player, but two gamepad/keyboard paths can't be reached that way today:

1. **`GuiService.SelectedObject`** — the engine rejects `GuiService.SelectedObject = obj` for any object *"not a descendant of a PlayerGui"*, and a headless server has no PlayerGui. So a selection controller's focus assignment (the thing that makes gamepad navigation work) can't be asserted.
2. **Firing a `ContextActionService` bind that reads a rich `InputObject`** — `fireInput` dispatched through the marker `BindableFunction`, whose boundary strips a stand-in's methods/signals. Handlers like `KeymapControls` read `inputObject:GetPropertyChangedSignal("UserInputState")`, so they couldn't be fired.

## What

Both localize to `PlayerMock`, following its existing explicit-branch philosophy:

- **`setSelectedGuiObject` / `getSelectedGuiObject` / `getSelectedGuiObjectChangedSignal`** — an `ObjectValue`-backed stand-in for the client-global `GuiService.SelectedObject`. Selection code branches `if PlayerMock.isMock(localPlayer) then PlayerMock.setSelectedGuiObject(...) else GuiService.SelectedObject = ...`, letting focus be driven and asserted.
- **`makeInputObject` + direct-callback firing** — `fireInput` now invokes the bound callback *directly* (not via the `BindableFunction`), so `inputObject` is passed **by reference** and its methods survive. `makeInputObject` builds a stand-in with `UserInputType`/`KeyCode`/`Position`/`Delta`, a settable `UserInputState`, and `GetPropertyChangedSignal` — the shape a `KeymapControls` handler reads to track a press. The `BindableFunction` is kept purely as the inspectable `isInputBound` marker (weak-keyed raw-callback table, cleared on unbind).

## Tests

`PlayerMock.spec` covers `makeInputObject` (fields/defaults, `SetUserInputState` firing its signal, per-property signal identity, bad-type rejection), rich `fireInput` (by-reference pass-through), and the selection seam (round-trip, nil clear, changed signal, non-GuiObject/non-mock rejection). The existing `fireInput` behavior (plain-table `inputObject`) is preserved.

These seams are exercised end-to-end downstream (egg-hunt's save-slot gamepad selection controller + KeymapControls firing), validated against this branch via a linked worktree.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/adorneeboundingbox@8.43.1-canary.750.30064021947.0
  npm install @quenty/adorneevalue@10.42.1-canary.750.30064021947.0
  npm install @quenty/animationprovider@11.44.1-canary.750.30064021947.0
  npm install @quenty/avatareditorutils@7.44.1-canary.750.30064021947.0
  npm install @quenty/bindtocloseservice@8.37.1-canary.750.30064021947.0
  npm install @quenty/blend@12.41.1-canary.750.30064021947.0
  npm install @quenty/bodycolorsutils@7.41.1-canary.750.30064021947.0
  npm install @quenty/brine@1.11.1-canary.750.30064021947.0
  npm install @quenty/buttondragmodel@1.34.1-canary.750.30064021947.0
  npm install @quenty/buttonhighlightmodel@14.41.1-canary.750.30064021947.0
  npm install @quenty/camera@14.47.1-canary.750.30064021947.0
  npm install @quenty/camerastoryutils@10.26.1-canary.750.30064021947.0
  npm install @quenty/characterutils@12.37.1-canary.750.30064021947.0
  npm install @quenty/chatproviderservice@9.63.1-canary.750.30064021947.0
  npm install @quenty/clienttranslator@14.43.1-canary.750.30064021947.0
  npm install @quenty/clipcharacters@12.47.1-canary.750.30064021947.0
  npm install @quenty/cmdrservice@13.52.1-canary.750.30064021947.0
  npm install @quenty/color3utils@11.41.1-canary.750.30064021947.0
  npm install @quenty/colorpalette@10.44.1-canary.750.30064021947.0
  npm install @quenty/colorpicker@10.42.1-canary.750.30064021947.0
  npm install @quenty/cooldown@11.44.1-canary.750.30064021947.0
  npm install @quenty/coreguienabler@12.38.1-canary.750.30064021947.0
  npm install @quenty/datastore@13.47.1-canary.750.30064021947.0
  npm install @quenty/deathreport@10.52.1-canary.750.30064021947.0
  npm install @quenty/depthoffield@11.43.1-canary.750.30064021947.0
  npm install @quenty/elo@7.42.1-canary.750.30064021947.0
  npm install @quenty/equippedtracker@13.39.1-canary.750.30064021947.0
  npm install @quenty/fakeskybox@11.23.1-canary.750.30064021947.0
  npm install @quenty/firstpersoncharactertransparency@14.39.1-canary.750.30064021947.0
  npm install @quenty/flipbook@9.37.1-canary.750.30064021947.0
  npm install @quenty/friendutils@12.34.1-canary.750.30064021947.0
  npm install @quenty/funnels@1.31.1-canary.750.30064021947.0
  npm install @quenty/gameconfig@12.58.1-canary.750.30064021947.0
  npm install @quenty/gameproductservice@14.62.1-canary.750.30064021947.0
  npm install @quenty/gamescalingutils@13.41.1-canary.750.30064021947.0
  npm install @quenty/genericscreenguiprovider@13.44.1-canary.750.30064021947.0
  npm install @quenty/grouputils@10.24.1-canary.750.30064021947.0
  npm install @quenty/highlight@10.45.1-canary.750.30064021947.0
  npm install @quenty/hintscoringutils@14.48.1-canary.750.30064021947.0
  npm install @quenty/humanoiddescriptionutils@10.22.1-canary.750.30064021947.0
  npm install @quenty/humanoidspeed@12.57.1-canary.750.30064021947.0
  npm install @quenty/humanoidtracker@13.35.1-canary.750.30064021947.0
  npm install @quenty/idleservice@13.60.1-canary.750.30064021947.0
  npm install @quenty/ik@15.61.1-canary.750.30064021947.0
  npm install @quenty/inputkeymaputils@14.49.1-canary.750.30064021947.0
  npm install @quenty/inputobjectutils@4.34.1-canary.750.30064021947.0
  npm install @quenty/lipsum@14.41.1-canary.750.30064021947.0
  npm install @quenty/marketplaceutils@11.26.1-canary.750.30064021947.0
  npm install @quenty/motor6d@7.48.1-canary.750.30064021947.0
  npm install @quenty/observablecollection@12.43.1-canary.750.30064021947.0
  npm install @quenty/particleengine@13.39.1-canary.750.30064021947.0
  npm install @quenty/parttouchingcalculator@14.47.1-canary.750.30064021947.0
  npm install @quenty/permissionprovider@14.45.1-canary.750.30064021947.0
  npm install @quenty/playermock@1.2.1-canary.750.30064021947.0
  npm install @quenty/playerbinder@14.42.1-canary.750.30064021947.0
  npm install @quenty/playerhumanoidbinder@14.43.1-canary.750.30064021947.0
  npm install @quenty/playerinputmode@9.45.1-canary.750.30064021947.0
  npm install @quenty/playersservicepromises@10.22.1-canary.750.30064021947.0
  npm install @quenty/playerthumbnailutils@10.22.1-canary.750.30064021947.0
  npm install @quenty/playerutils@8.37.1-canary.750.30064021947.0
  npm install @quenty/promptqueue@1.42.1-canary.750.30064021947.0
  npm install @quenty/qframe@10.27.1-canary.750.30064021947.0
  npm install @quenty/radial-image@9.42.1-canary.750.30064021947.0
  npm install @quenty/ragdoll@15.60.1-canary.750.30064021947.0
  npm install @quenty/receiptprocessing@7.38.1-canary.750.30064021947.0
  npm install @quenty/remoting@12.37.1-canary.750.30064021947.0
  npm install @quenty/resetservice@11.42.1-canary.750.30064021947.0
  npm install @quenty/rigbuilderutils@10.39.1-canary.750.30064021947.0
  npm install @quenty/roblox-api-dump@8.27.1-canary.750.30064021947.0
  npm install @quenty/rogue-humanoid@10.57.1-canary.750.30064021947.0
  npm install @quenty/rogue-properties@11.53.1-canary.750.30064021947.0
  npm install @quenty/saveslot@1.14.3-canary.750.30064021947.0
  npm install @quenty/scoredactionservice@16.50.1-canary.750.30064021947.0
  npm install @quenty/seatutils@7.39.1-canary.750.30064021947.0
  npm install @quenty/secrets@7.60.1-canary.750.30064021947.0
  npm install @quenty/settings@11.63.1-canary.750.30064021947.0
  npm install @quenty/settings-inputkeymap@10.66.1-canary.750.30064021947.0
  npm install @quenty/snackbar@11.47.1-canary.750.30064021947.0
  npm install @quenty/softshutdown@9.60.1-canary.750.30064021947.0
  npm install @quenty/soundgroup@1.48.1-canary.750.30064021947.0
  npm install @quenty/soundplayer@7.49.1-canary.750.30064021947.0
  npm install @quenty/spawning@10.54.1-canary.750.30064021947.0
  npm install @quenty/sprites@13.34.1-canary.750.30064021947.0
  npm install @quenty/streamingutils@10.24.1-canary.750.30064021947.0
  npm install @quenty/sunpositionutils@2.12.1-canary.750.30064021947.0
  npm install @quenty/teleportserviceutils@9.39.1-canary.750.30064021947.0
  npm install @quenty/templateprovider@11.44.1-canary.750.30064021947.0
  npm install @quenty/textfilterservice@13.37.1-canary.750.30064021947.0
  npm install @quenty/textserviceutils@13.41.1-canary.750.30064021947.0
  npm install @quenty/timedtween@7.41.1-canary.750.30064021947.0
  npm install @quenty/timesyncservice@13.38.1-canary.750.30064021947.0
  npm install @quenty/toolutils@1.21.1-canary.750.30064021947.0
  npm install @quenty/transitionmodel@7.43.1-canary.750.30064021947.0
  npm install @quenty/uiobjectutils@6.33.1-canary.750.30064021947.0
  npm install @quenty/userserviceutils@9.36.1-canary.750.30064021947.0
  npm install @quenty/viewport@11.48.1-canary.750.30064021947.0
  # or 
  yarn add @quenty/adorneeboundingbox@8.43.1-canary.750.30064021947.0
  yarn add @quenty/adorneevalue@10.42.1-canary.750.30064021947.0
  yarn add @quenty/animationprovider@11.44.1-canary.750.30064021947.0
  yarn add @quenty/avatareditorutils@7.44.1-canary.750.30064021947.0
  yarn add @quenty/bindtocloseservice@8.37.1-canary.750.30064021947.0
  yarn add @quenty/blend@12.41.1-canary.750.30064021947.0
  yarn add @quenty/bodycolorsutils@7.41.1-canary.750.30064021947.0
  yarn add @quenty/brine@1.11.1-canary.750.30064021947.0
  yarn add @quenty/buttondragmodel@1.34.1-canary.750.30064021947.0
  yarn add @quenty/buttonhighlightmodel@14.41.1-canary.750.30064021947.0
  yarn add @quenty/camera@14.47.1-canary.750.30064021947.0
  yarn add @quenty/camerastoryutils@10.26.1-canary.750.30064021947.0
  yarn add @quenty/characterutils@12.37.1-canary.750.30064021947.0
  yarn add @quenty/chatproviderservice@9.63.1-canary.750.30064021947.0
  yarn add @quenty/clienttranslator@14.43.1-canary.750.30064021947.0
  yarn add @quenty/clipcharacters@12.47.1-canary.750.30064021947.0
  yarn add @quenty/cmdrservice@13.52.1-canary.750.30064021947.0
  yarn add @quenty/color3utils@11.41.1-canary.750.30064021947.0
  yarn add @quenty/colorpalette@10.44.1-canary.750.30064021947.0
  yarn add @quenty/colorpicker@10.42.1-canary.750.30064021947.0
  yarn add @quenty/cooldown@11.44.1-canary.750.30064021947.0
  yarn add @quenty/coreguienabler@12.38.1-canary.750.30064021947.0
  yarn add @quenty/datastore@13.47.1-canary.750.30064021947.0
  yarn add @quenty/deathreport@10.52.1-canary.750.30064021947.0
  yarn add @quenty/depthoffield@11.43.1-canary.750.30064021947.0
  yarn add @quenty/elo@7.42.1-canary.750.30064021947.0
  yarn add @quenty/equippedtracker@13.39.1-canary.750.30064021947.0
  yarn add @quenty/fakeskybox@11.23.1-canary.750.30064021947.0
  yarn add @quenty/firstpersoncharactertransparency@14.39.1-canary.750.30064021947.0
  yarn add @quenty/flipbook@9.37.1-canary.750.30064021947.0
  yarn add @quenty/friendutils@12.34.1-canary.750.30064021947.0
  yarn add @quenty/funnels@1.31.1-canary.750.30064021947.0
  yarn add @quenty/gameconfig@12.58.1-canary.750.30064021947.0
  yarn add @quenty/gameproductservice@14.62.1-canary.750.30064021947.0
  yarn add @quenty/gamescalingutils@13.41.1-canary.750.30064021947.0
  yarn add @quenty/genericscreenguiprovider@13.44.1-canary.750.30064021947.0
  yarn add @quenty/grouputils@10.24.1-canary.750.30064021947.0
  yarn add @quenty/highlight@10.45.1-canary.750.30064021947.0
  yarn add @quenty/hintscoringutils@14.48.1-canary.750.30064021947.0
  yarn add @quenty/humanoiddescriptionutils@10.22.1-canary.750.30064021947.0
  yarn add @quenty/humanoidspeed@12.57.1-canary.750.30064021947.0
  yarn add @quenty/humanoidtracker@13.35.1-canary.750.30064021947.0
  yarn add @quenty/idleservice@13.60.1-canary.750.30064021947.0
  yarn add @quenty/ik@15.61.1-canary.750.30064021947.0
  yarn add @quenty/inputkeymaputils@14.49.1-canary.750.30064021947.0
  yarn add @quenty/inputobjectutils@4.34.1-canary.750.30064021947.0
  yarn add @quenty/lipsum@14.41.1-canary.750.30064021947.0
  yarn add @quenty/marketplaceutils@11.26.1-canary.750.30064021947.0
  yarn add @quenty/motor6d@7.48.1-canary.750.30064021947.0
  yarn add @quenty/observablecollection@12.43.1-canary.750.30064021947.0
  yarn add @quenty/particleengine@13.39.1-canary.750.30064021947.0
  yarn add @quenty/parttouchingcalculator@14.47.1-canary.750.30064021947.0
  yarn add @quenty/permissionprovider@14.45.1-canary.750.30064021947.0
  yarn add @quenty/playermock@1.2.1-canary.750.30064021947.0
  yarn add @quenty/playerbinder@14.42.1-canary.750.30064021947.0
  yarn add @quenty/playerhumanoidbinder@14.43.1-canary.750.30064021947.0
  yarn add @quenty/playerinputmode@9.45.1-canary.750.30064021947.0
  yarn add @quenty/playersservicepromises@10.22.1-canary.750.30064021947.0
  yarn add @quenty/playerthumbnailutils@10.22.1-canary.750.30064021947.0
  yarn add @quenty/playerutils@8.37.1-canary.750.30064021947.0
  yarn add @quenty/promptqueue@1.42.1-canary.750.30064021947.0
  yarn add @quenty/qframe@10.27.1-canary.750.30064021947.0
  yarn add @quenty/radial-image@9.42.1-canary.750.30064021947.0
  yarn add @quenty/ragdoll@15.60.1-canary.750.30064021947.0
  yarn add @quenty/receiptprocessing@7.38.1-canary.750.30064021947.0
  yarn add @quenty/remoting@12.37.1-canary.750.30064021947.0
  yarn add @quenty/resetservice@11.42.1-canary.750.30064021947.0
  yarn add @quenty/rigbuilderutils@10.39.1-canary.750.30064021947.0
  yarn add @quenty/roblox-api-dump@8.27.1-canary.750.30064021947.0
  yarn add @quenty/rogue-humanoid@10.57.1-canary.750.30064021947.0
  yarn add @quenty/rogue-properties@11.53.1-canary.750.30064021947.0
  yarn add @quenty/saveslot@1.14.3-canary.750.30064021947.0
  yarn add @quenty/scoredactionservice@16.50.1-canary.750.30064021947.0
  yarn add @quenty/seatutils@7.39.1-canary.750.30064021947.0
  yarn add @quenty/secrets@7.60.1-canary.750.30064021947.0
  yarn add @quenty/settings@11.63.1-canary.750.30064021947.0
  yarn add @quenty/settings-inputkeymap@10.66.1-canary.750.30064021947.0
  yarn add @quenty/snackbar@11.47.1-canary.750.30064021947.0
  yarn add @quenty/softshutdown@9.60.1-canary.750.30064021947.0
  yarn add @quenty/soundgroup@1.48.1-canary.750.30064021947.0
  yarn add @quenty/soundplayer@7.49.1-canary.750.30064021947.0
  yarn add @quenty/spawning@10.54.1-canary.750.30064021947.0
  yarn add @quenty/sprites@13.34.1-canary.750.30064021947.0
  yarn add @quenty/streamingutils@10.24.1-canary.750.30064021947.0
  yarn add @quenty/sunpositionutils@2.12.1-canary.750.30064021947.0
  yarn add @quenty/teleportserviceutils@9.39.1-canary.750.30064021947.0
  yarn add @quenty/templateprovider@11.44.1-canary.750.30064021947.0
  yarn add @quenty/textfilterservice@13.37.1-canary.750.30064021947.0
  yarn add @quenty/textserviceutils@13.41.1-canary.750.30064021947.0
  yarn add @quenty/timedtween@7.41.1-canary.750.30064021947.0
  yarn add @quenty/timesyncservice@13.38.1-canary.750.30064021947.0
  yarn add @quenty/toolutils@1.21.1-canary.750.30064021947.0
  yarn add @quenty/transitionmodel@7.43.1-canary.750.30064021947.0
  yarn add @quenty/uiobjectutils@6.33.1-canary.750.30064021947.0
  yarn add @quenty/userserviceutils@9.36.1-canary.750.30064021947.0
  yarn add @quenty/viewport@11.48.1-canary.750.30064021947.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
