### PR TITLE
fix(teleportserviceutils): hold one outstanding teleport request at a time

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5580,6 +5580,9 @@ importers:
       '@quenty/promise':
         specifier: workspace:*
         version: link:../promise
+      '@quenty/promisemaid':
+        specifier: workspace:*
+        version: link:../promisemaid
       '@quenty/remoting':
         specifier: workspace:*
         version: link:../remoting

--- a/src/player-mock/src/Shared/PlayerMock.lua
+++ b/src/player-mock/src/Shared/PlayerMock.lua
@@ -567,24 +567,36 @@ local LOOKUPS: { [string]: LookupSpec } = {
 			return HttpService:JSONDecode(value)
 		end,
 	},
-	-- TeleportService.TeleportInitFailed(player, teleportResult, message) -- the engine's refusal of a
-	-- teleport, which it can never fire for a mock, whose teleport never reaches the engine (see the
-	-- domain above). A test injects a refusal keyed by the destination placeId and the backing
+	-- TeleportService.TeleportInitFailed(player, teleportResult, message) -- what the engine says about
+	-- a teleport, which it can never say to a mock, whose teleport never reaches the engine (see the
+	-- domain above). A test injects a report keyed by the destination placeId and the backing
 	-- attribute's changed signal stands in for the event, the way "Player.IsFriendsWithAsync" stands in
-	-- for the friendship events. Attributes only fire on change, so consecutive refusals of the same
-	-- teleport must differ (an attempt number in the message, say) for a retrying consumer to see each
-	-- one. Default nil: the engine has refused nothing.
+	-- for the friendship events. Despite the name the event reports outcomes, not only failures: it
+	-- also carries Success and IsTeleporting, so `result` is required, and injecting one of those is
+	-- how a test says the hop is underway. Attributes only fire on change, so consecutive reports about
+	-- the same teleport must differ (an attempt number in the message, say) for a retrying consumer to
+	-- see each one. Default nil: the engine has said nothing.
 	["TeleportService.TeleportInitFailed"] = {
 		default = nil :: any,
 		valueType = "table",
 		validate = function(value: any)
+			assert(
+				typeof(value.result) == "EnumItem" and value.result.EnumType == Enum.TeleportResult,
+				"Bad teleportInitFailed.result"
+			)
 			assert(type(value.message) == "string", "Bad teleportInitFailed.message")
 		end,
+		-- Stored by name, an EnumItem being the one part of this record JSON cannot carry. Production
+		-- reads back the EnumItem the engine would have handed it.
 		encode = function(value: any): string
-			return HttpService:JSONEncode(value)
+			return HttpService:JSONEncode({ result = value.result.Name, message = value.message })
 		end,
 		decode = function(value: any): any
-			return HttpService:JSONDecode(value)
+			local decoded = HttpService:JSONDecode(value)
+			return {
+				result = (Enum.TeleportResult :: any)[decoded.result],
+				message = decoded.message,
+			}
 		end,
 	},
 	-- Players:GetFriendsAsync(userId) -> FriendPages, stored as the flat FriendData array the pages

--- a/src/teleportserviceutils/package.json
+++ b/src/teleportserviceutils/package.json
@@ -35,6 +35,7 @@
     "@quenty/nevermore-test-runner": "workspace:*",
     "@quenty/playermock": "workspace:*",
     "@quenty/promise": "workspace:*",
+    "@quenty/promisemaid": "workspace:*",
     "@quenty/remoting": "workspace:*",
     "@quenty/rx": "workspace:*",
     "@quenty/servicebag": "workspace:*",

--- a/src/teleportserviceutils/src/Shared/TeleportFailedReportUtils.lua
+++ b/src/teleportserviceutils/src/Shared/TeleportFailedReportUtils.lua
@@ -1,0 +1,103 @@
+--!strict
+--[=[
+	What the engine said about a client teleport, and what that means for what to do next.
+
+	`TeleportInitFailed` reports outcomes rather than only failures -- `Success` and `IsTeleporting`
+	arrive through the same event as the refusals do -- so a report is classified rather than assumed
+	to be one. Two questions are worth asking of one: whether the hop is still running
+	([TeleportFailedReportUtils.isInFlight]), and whether a refusal is worth another request
+	([TeleportFailedReportUtils.shouldRetry]).
+
+	All logic here is pure, so it is unit tested without a [Player] or a teleport.
+
+	@class TeleportFailedReportUtils
+]=]
+
+local TeleportFailedReportUtils = {}
+
+--[=[
+	The whole of `TeleportInitFailed`, kept together so a caller decides on `result` instead of parsing
+	`message`. Every rejection from [TeleportServiceUtils.promiseTeleportClientOnce] carries one, and it
+	renders itself when a consumer only wants text.
+
+	@interface TeleportReport
+	.result Enum.TeleportResult
+	.message string
+	.placeId number -- the destination the report is about
+	@within TeleportFailedReportUtils
+]=]
+export type TeleportReport = {
+	result: Enum.TeleportResult,
+	message: string,
+	placeId: number,
+}
+
+--[=[
+	A report that renders itself, so text-only consumers need not reach into it -- including
+	PromiseRetryUtils, which tostrings whatever an attempt rejected with.
+
+	@param placeId number
+	@param result Enum.TeleportResult
+	@param message string
+	@return TeleportReport
+]=]
+function TeleportFailedReportUtils.new(placeId: number, result: Enum.TeleportResult, message: string): TeleportReport
+	assert(type(placeId) == "number", "Bad placeId")
+	assert(typeof(result) == "EnumItem", "Bad result")
+	assert(type(message) == "string", "Bad message")
+
+	return setmetatable({
+		placeId = placeId,
+		result = result,
+		message = message,
+	}, {
+		__tostring = function(self: any): string
+			return string.format("Teleport to place %d refused (%s): %s", self.placeId, self.result.Name, self.message)
+		end,
+	}) :: any
+end
+
+--[=[
+	Whether a value is a report at all. A promise cancelled mid-teleport rejects with nothing rather
+	than a refusal, so a consumer reading rejections has to tell the two apart before classifying.
+
+	@param value any
+	@return boolean
+]=]
+function TeleportFailedReportUtils.isReport(value: any): boolean
+	return type(value) == "table" and typeof(value.result) == "EnumItem"
+end
+
+--[=[
+	Whether a report means the hop is still happening rather than refused. `Success` is the engine
+	confirming the request; `IsTeleporting` is it refusing a DUPLICATE while the original still runs,
+	which is to say the one result that proves a request is alive. Neither is a failure, and answering
+	either with another request is what stacks the concurrent teleports Roblox cannot hold.
+
+	@param report TeleportReport
+	@return boolean
+]=]
+function TeleportFailedReportUtils.isInFlight(report: TeleportReport): boolean
+	assert(type(report) == "table", "Bad report")
+
+	return report.result == Enum.TeleportResult.Success or report.result == Enum.TeleportResult.IsTeleporting
+end
+
+--[=[
+	Whether a refusal is worth another request: the request is gone and the reason may not recur.
+	False for the terminal refusals (`GameNotFound`, `Unauthorized`), which will refuse again however
+	long we wait, and for `Flooded`, where another request is precisely what the engine is objecting
+	to -- retrying either spends the player's time to reach the same refusal.
+
+	@param report TeleportReport
+	@return boolean
+]=]
+function TeleportFailedReportUtils.shouldRetry(report: TeleportReport): boolean
+	assert(type(report) == "table", "Bad report")
+
+	return report.result == Enum.TeleportResult.Failure
+		or report.result == Enum.TeleportResult.GameFull
+		or report.result == Enum.TeleportResult.GameEnded
+end
+
+return TeleportFailedReportUtils

--- a/src/teleportserviceutils/src/Shared/TeleportFailedReportUtils.spec.lua
+++ b/src/teleportserviceutils/src/Shared/TeleportFailedReportUtils.spec.lua
@@ -1,0 +1,116 @@
+--!strict
+--[[
+	@class TeleportFailedReportUtils.spec.lua
+]]
+
+local require = require(script.Parent.loader).load(script)
+
+local Jest = require("Jest")
+local TeleportFailedReportUtils = require("TeleportFailedReportUtils")
+
+local describe = Jest.Globals.describe
+local expect = Jest.Globals.expect
+local it = Jest.Globals.it
+
+-- Every result the engine can report, so a test over all of them cannot silently miss one.
+local ALL_RESULTS: { Enum.TeleportResult } = Enum.TeleportResult:GetEnumItems()
+
+local IN_FLIGHT: { Enum.TeleportResult } = {
+	Enum.TeleportResult.Success,
+	Enum.TeleportResult.IsTeleporting,
+}
+
+local RETRYABLE: { Enum.TeleportResult } = {
+	Enum.TeleportResult.Failure,
+	Enum.TeleportResult.GameFull,
+	Enum.TeleportResult.GameEnded,
+}
+
+local TERMINAL: { Enum.TeleportResult } = {
+	Enum.TeleportResult.GameNotFound,
+	Enum.TeleportResult.Unauthorized,
+	Enum.TeleportResult.Flooded,
+}
+
+local function contains(results: { Enum.TeleportResult }, result: Enum.TeleportResult): boolean
+	return table.find(results, result) ~= nil
+end
+
+describe("TeleportFailedReportUtils.new", function()
+	it("keeps the whole of what the engine said", function()
+		local report = TeleportFailedReportUtils.new(700, Enum.TeleportResult.GameFull, "server full")
+
+		expect(report.placeId).toEqual(700)
+		expect(report.result).toEqual(Enum.TeleportResult.GameFull)
+		expect(report.message).toEqual("server full")
+	end)
+
+	it("renders itself, for a consumer that only wants a message", function()
+		local report = TeleportFailedReportUtils.new(701, Enum.TeleportResult.Unauthorized, "not allowed")
+
+		expect(tostring(report)).toContain("701")
+		expect(tostring(report)).toContain("Unauthorized")
+		expect(tostring(report)).toContain("not allowed")
+	end)
+
+	it("errors on a bad placeId, result, or message", function()
+		expect(function()
+			TeleportFailedReportUtils.new("nope" :: any, Enum.TeleportResult.Failure, "message")
+		end).toThrow()
+		expect(function()
+			TeleportFailedReportUtils.new(702, "nope" :: any, "message")
+		end).toThrow()
+		expect(function()
+			TeleportFailedReportUtils.new(702, Enum.TeleportResult.Failure, nil :: any)
+		end).toThrow()
+	end)
+end)
+
+describe("TeleportFailedReportUtils.isReport", function()
+	it("tells a report from the empty rejection a cancelled teleport makes", function()
+		expect(TeleportFailedReportUtils.isReport(TeleportFailedReportUtils.new(703, Enum.TeleportResult.Failure, "x"))).toEqual(
+			true
+		)
+		expect(TeleportFailedReportUtils.isReport(nil)).toEqual(false)
+		expect(TeleportFailedReportUtils.isReport("a string rejection")).toEqual(false)
+		expect(TeleportFailedReportUtils.isReport({ message = "no result" })).toEqual(false)
+	end)
+end)
+
+describe("TeleportFailedReportUtils classification", function()
+	it("accounts for every result the engine can report", function()
+		-- Guards the tables above against a result nobody classified: a new enum item, or one of these
+		-- lists drifting. An unclassified result would silently fall through to "terminal".
+		expect(#ALL_RESULTS).toEqual(#IN_FLIGHT + #RETRYABLE + #TERMINAL)
+	end)
+
+	it("treats Success and IsTeleporting as the hop still running, never as a refusal", function()
+		for _, result in ALL_RESULTS do
+			local report = TeleportFailedReportUtils.new(704, result, "message")
+
+			expect({ result = result.Name, inFlight = TeleportFailedReportUtils.isInFlight(report) }).toEqual({
+				result = result.Name,
+				inFlight = contains(IN_FLIGHT, result),
+			})
+		end
+	end)
+
+	it("retries only refusals another request could clear", function()
+		for _, result in ALL_RESULTS do
+			local report = TeleportFailedReportUtils.new(705, result, "message")
+
+			expect({ result = result.Name, retry = TeleportFailedReportUtils.shouldRetry(report) }).toEqual({
+				result = result.Name,
+				retry = contains(RETRYABLE, result),
+			})
+		end
+	end)
+
+	it("never retries Flooded or IsTeleporting, the two results another request makes worse", function()
+		for _, result in { Enum.TeleportResult.Flooded, Enum.TeleportResult.IsTeleporting } do
+			local report = TeleportFailedReportUtils.new(706, result, "message")
+
+			expect(TeleportFailedReportUtils.shouldRetry(report)).toEqual(false)
+		end
+	end)
+end)

--- a/src/teleportserviceutils/src/Shared/TeleportServiceUtils.lua
+++ b/src/teleportserviceutils/src/Shared/TeleportServiceUtils.lua
@@ -9,22 +9,40 @@
 	local hop = PlayerMock.readLookup(mock, "TeleportService.Teleport", placeId)
 	```
 
-	A refusal comes from the `"TeleportService.TeleportInitFailed"` lookup the same way.
+	What the engine would have said back goes in through the `"TeleportService.TeleportInitFailed"`
+	lookup the same way, `result` and all:
+
+	```lua
+	PlayerMock.writeLookup(mock, "TeleportService.TeleportInitFailed", placeId, {
+		result = Enum.TeleportResult.GameFull,
+		message = "server full",
+	})
+	```
 
 	@class TeleportServiceUtils
 ]=]
 
 local require = require(script.Parent.loader).load(script)
 
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
 local TeleportService = game:GetService("TeleportService")
 
 local Maid = require("Maid")
 local PlayerMock = require("PlayerMock")
 local Promise = require("Promise")
+local PromiseMaidUtils = require("PromiseMaidUtils")
+local PromiseRetryUtils = require("PromiseRetryUtils")
+local TeleportFailedReportUtils = require("TeleportFailedReportUtils")
 
 -- Roblox refuses teleports for transient reasons, so the default is patient.
 local DEFAULT_MAX_ATTEMPTS = 5
 local DEFAULT_RETRY_WAIT = 10
+
+-- Flat by default, matching the fixed wait this retried with before it was built on
+-- PromiseRetryUtils. Retries are rare enough now (only three results reach one) that backing off
+-- further mostly just holds the player at a loading screen.
+local DEFAULT_EXPONENTIAL = 1
 
 local TeleportServiceUtils = {}
 
@@ -43,55 +61,46 @@ export type MockTeleport = {
 }
 
 --[=[
-	How a client teleport retries when the engine refuses it (see
-	[TeleportServiceUtils.promiseTeleportClient]). `maxAttempts = 1` means no retry at all.
+	What a teleport carries and how it retries when the engine refuses it (see
+	[TeleportServiceUtils.promiseTeleport]). `maxAttempts = 1` means no retry at all, and `exponential`
+	is the per-attempt backoff multiplier (1 keeps the wait flat).
 
-	@type TeleportClientConfig { teleportData: { [string]: any }?, maxAttempts: number?, retryWait: number? }
+	`teleportOptions` is the server's extra reach -- reserved servers, a named spawn -- and a server
+	call may pass one on its own instead of a config. A client has only `teleportData`, which is read
+	back out of the options when a call passes those instead.
+
+	@type TeleportConfig { teleportData: { [string]: any }?, teleportOptions: TeleportOptions?, maxAttempts: number?, retryWait: number?, exponential: number?, printWarning: boolean? }
 	@within TeleportServiceUtils
 ]=]
-export type TeleportClientConfig = {
+export type TeleportConfig = {
 	teleportData: { [string]: any }?,
+	teleportOptions: TeleportOptions?,
 	maxAttempts: number?,
 	retryWait: number?,
+	exponential: number?,
+	printWarning: boolean?,
 }
 
-local function recordMockTeleport(player: Player, placeId: number, record: MockTeleport): ()
-	PlayerMock.writeLookup(player, "TeleportService.Teleport", placeId, record)
-end
+--[=[
+	[TeleportConfig] under the name it had while only a client retried.
 
-local function connectTeleportInitFailed(
-	placeId: number,
-	player: Player,
-	onFailed: (message: string) -> ()
-): RBXScriptConnection
-	if PlayerMock.isMock(player) then
-		return PlayerMock.getLookupChangedSignal(player, "TeleportService.TeleportInitFailed", placeId)
-			:Connect(function()
-				local failure = PlayerMock.readLookup(player, "TeleportService.TeleportInitFailed", placeId)
-				if failure == nil then
-					return
-				end
-
-				onFailed(failure.message)
-			end)
-	end
-
-	return TeleportService.TeleportInitFailed:Connect(function(failedPlayer: Player, _result, message: string)
-		if failedPlayer ~= player then
-			return
-		end
-
-		onFailed(message)
-	end)
-end
+	@type TeleportClientConfig TeleportConfig
+	@within TeleportServiceUtils
+]=]
+export type TeleportClientConfig = TeleportConfig
 
 --[=[
-	Mock-aware `TeleportService:Teleport(placeId, player, teleportData)`. On a server prefer
-	[TeleportServiceUtils.teleportAsync]; on a client this is the teleport, since TeleportAsync is
-	server-only.
+	Mock-aware `TeleportService:Teleport(placeId, player, teleportData)`, yielded out of
+	[TeleportServiceUtils.promiseTeleport] -- so it retries like every other teleport now, and answers
+	whether the player is going anywhere rather than only whether the call was made.
 
+	A client teleport that works ends with the player gone, so on the happy path this never returns:
+	there is nothing left to return to. It comes back only when the teleport has failed, which is what
+	makes the answer worth having.
+
+	@client
 	@param placeId number
-	@param player Player -- a real Player or a PlayerMock
+	@param player Player -- the local player, or a PlayerMock standing in for one
 	@param teleportData { [string]: any }?
 	@return boolean -- Whether the teleport was started.
 	@return string? -- Why the engine refused it, when it did.
@@ -101,17 +110,9 @@ function TeleportServiceUtils.teleport(
 	player: Player,
 	teleportData: { [string]: any }?
 ): (boolean, string?)
-	assert(type(placeId) == "number", "Bad placeId")
 	assert(player, "No player")
 
-	if PlayerMock.isMock(player) then
-		recordMockTeleport(player, placeId, { via = "Teleport", teleportData = teleportData or {} })
-		return true
-	end
-
-	local ok, err = pcall(function()
-		TeleportService:Teleport(placeId, player, teleportData)
-	end)
+	local ok, err = TeleportServiceUtils.promiseTeleport(placeId, player, { teleportData = teleportData }):Yield()
 	if not ok then
 		return false, tostring(err)
 	end
@@ -140,7 +141,7 @@ function TeleportServiceUtils.teleportToPlaceInstance(
 	assert(player, "No player")
 
 	if PlayerMock.isMock(player) then
-		recordMockTeleport(player, placeId, {
+		TeleportServiceUtils._recordMockTeleport(player, placeId, {
 			via = "TeleportToPlaceInstance",
 			teleportData = teleportData or {},
 			instanceId = instanceId,
@@ -153,10 +154,12 @@ function TeleportServiceUtils.teleportToPlaceInstance(
 end
 
 --[=[
-	Mock-aware `TeleportService:TeleportAsync(placeId, players, teleportOptions)`. Mock players in the
-	batch are recorded (with the options' teleport data) and dropped from the engine call; a batch of
-	only mocks skips the engine and returns nil. Real players teleport and the TeleportAsyncResult is
-	returned.
+	Mock-aware `TeleportService:TeleportAsync(placeId, players, teleportOptions)`, yielded out of
+	[TeleportServiceUtils.promiseTeleport] -- so it retries like every other teleport now, and throws
+	what the last attempt threw. Mock players in the batch are recorded (with the options' teleport
+	data) and dropped from the engine call; a batch of only mocks skips the engine and returns nil.
+
+	@server
 	@param placeId number
 	@param players { Player }
 	@param teleportOptions TeleportOptions?
@@ -167,29 +170,14 @@ function TeleportServiceUtils.teleportAsync(
 	players: { Player },
 	teleportOptions: TeleportOptions?
 ): TeleportAsyncResult?
-	assert(type(placeId) == "number", "Bad placeId")
 	assert(type(players) == "table", "Bad players")
-	assert(
-		teleportOptions == nil or (typeof(teleportOptions) == "Instance" and teleportOptions:IsA("TeleportOptions")),
-		"Bad teleportOptions"
-	)
 
-	local teleportData: { [string]: any }? = if teleportOptions then teleportOptions:GetTeleportData() :: any else nil
-
-	local realPlayers: { Player } = {}
-	for _, player in players do
-		if PlayerMock.isMock(player) then
-			recordMockTeleport(player, placeId, { via = "TeleportAsync", teleportData = teleportData })
-		else
-			table.insert(realPlayers, player)
-		end
+	local ok, result = TeleportServiceUtils.promiseTeleport(placeId, players, teleportOptions):Yield()
+	if not ok then
+		error(tostring(result), 2)
 	end
 
-	if #realPlayers == 0 then
-		return nil
-	end
-
-	return TeleportService:TeleportAsync(placeId, realPlayers, teleportOptions)
+	return result
 end
 
 --[=[
@@ -214,8 +202,12 @@ function TeleportServiceUtils.promiseReserveServer(placeId: number): Promise.Pro
 end
 
 --[=[
-	Promise wrapper of [TeleportServiceUtils.teleportAsync] -- so it is mock-aware too, recording mock
-	players and resolving without an engine call when the batch is all mocks.
+	One server teleport request, and only ever one: a promise wrapper of `TeleportService:TeleportAsync`
+	-- mock-aware too, recording mock players and resolving without an engine call when the batch is all
+	mocks. Retrying is [TeleportServiceUtils.promiseTeleport]'s job.
+
+	Unlike the client's request this one settles: TeleportAsync yields until the engine has accepted the
+	teleport and throws when it has not, so the promise says which happened.
 
 	@server
 	@param placeId number
@@ -223,7 +215,7 @@ end
 	@param teleportOptions TeleportOptions?
 	@return Promise<TeleportAsyncResult?>
 ]=]
-function TeleportServiceUtils.promiseTeleport(
+function TeleportServiceUtils.promiseTeleportServerOnce(
 	placeId: number,
 	players: { Player },
 	teleportOptions: TeleportOptions?
@@ -238,7 +230,7 @@ function TeleportServiceUtils.promiseTeleport(
 	return Promise.spawn(function(resolve, reject)
 		local teleportAsyncResult
 		local ok, err = pcall(function()
-			teleportAsyncResult = TeleportServiceUtils.teleportAsync(placeId, players, teleportOptions)
+			teleportAsyncResult = TeleportServiceUtils._executeTeleportServer(placeId, players, teleportOptions)
 		end)
 		if not ok then
 			return reject(err)
@@ -249,99 +241,378 @@ function TeleportServiceUtils.promiseTeleport(
 end
 
 --[=[
-	A client teleporting itself through [TeleportServiceUtils.teleport], retried while the engine
-	refuses the hop.
+	One client teleport request, and only ever one. Issues a single `TeleportService:Teleport` and then
+	reports what the engine says about it.
 
-	The promise reports only failure: a teleport that works ends with the player leaving this place, so
-	it stays pending until the client is gone. Destroying it stops the retries and rejects with nothing,
-	so a caller can tell its own teardown from a hop that genuinely failed.
+	Roblox cannot hold more than one outstanding request per player -- a second earns
+	`Enum.TeleportResult.IsTeleporting`, and there is no API to cancel the first -- so this never asks
+	twice. Retrying is [TeleportServiceUtils.promiseTeleportClient]'s job, and it may only ask again
+	once this has rejected, which is the only evidence the request is gone.
+
+	The promise reports failure alone: a teleport that works ends with the player leaving, so success
+	stays pending until the client is gone. It rejects with the whole [TeleportFailedReportUtils.TeleportReport] rather than a
+	message, so a caller can decide on `result`. Destroying it stops listening and rejects with
+	nothing, letting a caller tell its own teardown from a refusal.
 
 	```lua
-	maid._teleport = TeleportServiceUtils.promiseTeleportClient(placeId, Players.LocalPlayer, {
-		teleportData = teleportData,
-	}):Catch(function(err)
-		-- retries spent; the player is going nowhere
-	end)
+	maid._teleport = TeleportServiceUtils.promiseTeleportClientOnce(placeId, Players.LocalPlayer, data)
+		:Catch(function(report)
+			if report then
+				print(report.result, report.message)
+			end
+		end)
 	```
 
 	@client
 	@param placeId number
 	@param player Player -- the local player, or a PlayerMock standing in for one
+	@param teleportData { [string]: any }?
+	@return Promise<()> -- Pending while in flight; rejects with a TeleportFailedReportUtils.TeleportReport when refused.
+]=]
+function TeleportServiceUtils.promiseTeleportClientOnce(
+	placeId: number,
+	player: Player,
+	teleportData: { [string]: any }?
+): Promise.Promise<()>
+	assert(type(placeId) == "number", "Bad placeId")
+	assert(player, "No player")
+	assert(teleportData == nil or type(teleportData) == "table", "Bad teleportData")
+	TeleportServiceUtils._assertIsLocalPlayer(player)
+
+	local promise = Promise.new()
+
+	PromiseMaidUtils.whilePromise(promise, function(maid)
+		-- Listening before asking, so a refusal the engine makes immediately still lands.
+		TeleportServiceUtils._connectTeleportReported(maid, placeId, player, function(report)
+			if not promise:IsPending() then
+				return
+			end
+
+			if TeleportFailedReportUtils.isInFlight(report) then
+				return
+			end
+
+			promise:Reject(report)
+		end)
+
+		-- The raw request, not the public teleport(): that one comes back through promiseTeleport, and
+		-- promiseTeleport is what reaches this.
+		local ok, err = TeleportServiceUtils._executeTeleportClient(placeId, player, teleportData)
+		if not ok then
+			-- The call raised, so no request was made and no report is coming. Said in the same shape a
+			-- refusal arrives in, so every rejection this makes is a TeleportReport.
+			promise:Reject(
+				TeleportFailedReportUtils.new(placeId, Enum.TeleportResult.Failure, err or "Teleport failed")
+			)
+		end
+	end)
+
+	return promise
+end
+
+--[=[
+	A teleport, whichever realm asks for it, retried while a refusal is worth asking about. The realm
+	picks the request: a server batches through [TeleportServiceUtils.promiseTeleportServerOnce], a
+	client sends itself through [TeleportServiceUtils.promiseTeleportClientOnce].
+
+	One request is outstanding at a time: the next only goes out after the last has settled, which on
+	the client is the only evidence Roblox gives that a request is gone. So a refusal the engine will
+	only repeat ([TeleportFailedReportUtils.shouldRetry]) rejects at once rather than spending the
+	budget, and a report that means the hop is still running never starts a second one.
+
+	Where it settles differs because the realms differ, not because the shape does. A server teleport
+	resolves with its `TeleportAsyncResult` -- the server is still here afterwards. A client teleporting
+	itself reports only failure: a teleport that works ends with the player gone, so it stays pending
+	until they are. Destroying it stops the retries and rejects with nothing either way, so a caller can
+	tell its own teardown from a hop that genuinely failed.
+
+	Rejects with the [TeleportFailedReportUtils.TeleportReport] itself when a refusal ends it, and with
+	the retry wrapper's summary once the attempts are spent -- a report renders itself, so either reads
+	as text.
+
+	```lua
+	-- Server: a batch, and the options every call passed before this was unified still work
+	TeleportServiceUtils.promiseTeleport(placeId, { player }, teleportOptions)
+
+	-- Client: itself
+	maid._teleport = TeleportServiceUtils.promiseTeleport(placeId, Players.LocalPlayer, {
+		teleportData = teleportData,
+	})
+	```
+
+	@param placeId number
+	@param players Player | { Player } -- one player or a batch; a client sends only itself
+	@param configOrOptions TeleportConfig | TeleportOptions | nil -- a bare TeleportOptions reads as a config carrying it
+	@return Promise<TeleportAsyncResult?> -- Resolves on a server; on a client, pending until the player is gone.
+]=]
+function TeleportServiceUtils.promiseTeleport(
+	placeId: number,
+	players: Player | { Player },
+	configOrOptions: (TeleportConfig | TeleportOptions)?
+): Promise.Promise<TeleportAsyncResult?>
+	assert(type(placeId) == "number", "Bad placeId")
+	assert(players, "No players")
+
+	local config = TeleportServiceUtils._normalizeTeleportConfig(configOrOptions)
+	local maxAttempts = config.maxAttempts or DEFAULT_MAX_ATTEMPTS
+	local retryWait = config.retryWait or DEFAULT_RETRY_WAIT
+
+	assert(config.teleportData == nil or type(config.teleportData) == "table", "Bad config.teleportData")
+	assert(type(maxAttempts) == "number" and maxAttempts >= 1, "Bad config.maxAttempts")
+	assert(type(retryWait) == "number" and retryWait >= 0, "Bad config.retryWait")
+
+	local maid = Maid.new()
+
+	local promise = PromiseRetryUtils.retry(function()
+		local attempt = TeleportServiceUtils._promiseTeleportOnce(placeId, players, config)
+
+		-- Held so cancelling the retry takes the outstanding request down with it: PromiseRetryUtils
+		-- cancels its own loop, but never touches the promise a callback handed it.
+		maid._attempt = attempt
+
+		return attempt
+	end, {
+		initialWaitTime = retryWait,
+		maxAttempts = maxAttempts,
+		exponential = config.exponential or DEFAULT_EXPONENTIAL,
+		printWarning = if config.printWarning ~= nil then config.printWarning else true,
+		shouldRetry = function(rejection: any): boolean
+			-- A cancelled attempt rejects with nothing -- the empty rejection consumers read as
+			-- teardown -- and there is no refusal there to answer.
+			if rejection == nil then
+				return false
+			end
+
+			if TeleportFailedReportUtils.isReport(rejection) then
+				return TeleportFailedReportUtils.shouldRetry(rejection)
+			end
+
+			-- A server refusal is whatever TeleportAsync threw, with no result to classify by. Nothing
+			-- is outstanding once it has thrown, so asking again is at least safe.
+			return true
+		end,
+	})
+
+	promise:Finally(function()
+		maid:DoCleaning()
+	end)
+
+	return promise
+end
+
+--[=[
+	[TeleportServiceUtils.promiseTeleport] under the name a client used before either realm shared it.
+
+	@client
+	@deprecated 10.3.0 -- Use [TeleportServiceUtils.promiseTeleport], which does this in either realm.
+	@param placeId number
+	@param player Player -- the local player, or a PlayerMock standing in for one
 	@param config TeleportClientConfig?
-	@return Promise<()> -- Pending while in flight; rejects with the reason when the attempts are spent.
+	@return Promise<()> -- Pending while in flight; rejects once the player is going nowhere.
 ]=]
 function TeleportServiceUtils.promiseTeleportClient(
 	placeId: number,
 	player: Player,
 	config: TeleportClientConfig?
 ): Promise.Promise<()>
+	return TeleportServiceUtils.promiseTeleport(placeId, player, config) :: any
+end
+
+--[[
+	Which realm this is running in, behind a seam because a test needs to drive both: --cloud runs
+	server-side, where the client path would otherwise be unreachable.
+]]
+function TeleportServiceUtils._isServer(): boolean
+	return RunService:IsServer()
+end
+
+--[[
+	A client can only send itself. TeleportService:Teleport takes the local player and quietly does
+	nothing useful with anyone else, so refuse it here where the caller can still see why.
+
+	Measured against a designated mock as readily as the real thing, so a simulated client is held to
+	the same rule. Where neither exists there is no local player to be, which is not a client at all --
+	a bare unit test -- and nothing to check.
+]]
+function TeleportServiceUtils._assertIsLocalPlayer(player: Player): ()
+	local localPlayer = Players.LocalPlayer or PlayerMock.getMockedLocalPlayer()
+
+	assert(
+		localPlayer == nil or player == localPlayer,
+		"Cannot teleport a player other than the local player from a client"
+	)
+end
+
+--[[
+	The raw client request. Mock-aware, and the only place TeleportService:Teleport is reached.
+]]
+function TeleportServiceUtils._executeTeleportClient(
+	placeId: number,
+	player: Player,
+	teleportData: { [string]: any }?
+): (boolean, string?)
 	assert(type(placeId) == "number", "Bad placeId")
 	assert(player, "No player")
-	assert(config == nil or type(config) == "table", "Bad config")
 
-	local teleportData = config and config.teleportData
-	local maxAttempts = (config and config.maxAttempts) or DEFAULT_MAX_ATTEMPTS
-	local retryWait = (config and config.retryWait) or DEFAULT_RETRY_WAIT
+	if PlayerMock.isMock(player) then
+		TeleportServiceUtils._recordMockTeleport(
+			player,
+			placeId,
+			{ via = "Teleport", teleportData = teleportData or {} }
+		)
+		return true
+	end
 
-	assert(teleportData == nil or type(teleportData) == "table", "Bad config.teleportData")
-	assert(type(maxAttempts) == "number" and maxAttempts >= 1, "Bad config.maxAttempts")
-	assert(type(retryWait) == "number" and retryWait >= 0, "Bad config.retryWait")
-
-	local promise = Promise.new()
-
-	local maid = Maid.new()
-	promise:Finally(function()
-		maid:DoCleaning()
+	local ok, err = pcall(function()
+		TeleportService:Teleport(placeId, player, teleportData)
 	end)
+	if not ok then
+		return false, tostring(err)
+	end
 
-	local attempt: () -> ()
+	return true
+end
 
-	local attempts = 0
-	local reportedAttempts = 0
+--[[
+	The raw server request. Mock-aware, and the only place TeleportService:TeleportAsync is reached.
+]]
+function TeleportServiceUtils._executeTeleportServer(
+	placeId: number,
+	players: { Player },
+	teleportOptions: TeleportOptions?
+): TeleportAsyncResult?
+	assert(type(placeId) == "number", "Bad placeId")
+	assert(type(players) == "table", "Bad players")
+	assert(
+		teleportOptions == nil or (typeof(teleportOptions) == "Instance" and teleportOptions:IsA("TeleportOptions")),
+		"Bad teleportOptions"
+	)
 
-	local function onFailed(message: string)
-		if not promise:IsPending() then
-			return
+	local teleportData: { [string]: any }? = if teleportOptions then teleportOptions:GetTeleportData() :: any else nil
+
+	local realPlayers: { Player } = {}
+	for _, player in players do
+		if PlayerMock.isMock(player) then
+			TeleportServiceUtils._recordMockTeleport(
+				player,
+				placeId,
+				{ via = "TeleportAsync", teleportData = teleportData }
+			)
+		else
+			table.insert(realPlayers, player)
+		end
+	end
+
+	if #realPlayers == 0 then
+		return nil
+	end
+
+	return TeleportService:TeleportAsync(placeId, realPlayers, teleportOptions)
+end
+
+--[[
+	One shape out of the two callers pass: a bare TeleportOptions -- what every server call passed
+	before the realms shared this -- reads as a config carrying it, with its teleport data lifted out
+	for a client that has no use for the options themselves.
+]]
+function TeleportServiceUtils._normalizeTeleportConfig(
+	configOrOptions: (TeleportConfig | TeleportOptions)?
+): TeleportConfig
+	if configOrOptions == nil then
+		return {}
+	end
+
+	if typeof(configOrOptions) == "Instance" then
+		assert(configOrOptions:IsA("TeleportOptions"), "Bad teleportOptions")
+
+		return {
+			teleportOptions = configOrOptions,
+			teleportData = configOrOptions:GetTeleportData() :: any,
+		}
+	end
+
+	assert(type(configOrOptions) == "table", "Bad config")
+
+	return configOrOptions
+end
+
+--[[
+	The realm's own single request. A server takes the batch as given; a client can only send itself,
+	so a batch means the one player it holds.
+]]
+function TeleportServiceUtils._promiseTeleportOnce(
+	placeId: number,
+	players: Player | { Player },
+	config: TeleportConfig
+): Promise.Promise<TeleportAsyncResult?>
+	if TeleportServiceUtils._isServer() then
+		local batch: { Player } = if type(players) == "table" then players else { players :: Player }
+		local teleportOptions = config.teleportOptions
+
+		if not teleportOptions and config.teleportData then
+			local options = Instance.new("TeleportOptions")
+			options:SetTeleportData(config.teleportData)
+			teleportOptions = options
 		end
 
-		-- A refused hop reports itself twice: the call raises and TeleportInitFailed fires.
-		if reportedAttempts >= attempts then
-			return
-		end
-		reportedAttempts = attempts
+		return TeleportServiceUtils.promiseTeleportServerOnce(placeId, batch, teleportOptions)
+	end
 
-		if attempts >= maxAttempts then
-			promise:Reject(`Teleport to place {placeId} failed after {attempts} attempt(s): {message}`)
-			return
-		end
+	local player: Player = if type(players) == "table" then players[1] else players :: Player
+	assert(player, "No player to teleport")
 
-		-- Cancelling the backoff destroys the promise but cannot unschedule the delay itself.
-		local retry
-		retry = Promise.delay(retryWait, function(resolve)
-			if retry:IsPending() then
-				attempt()
+	return TeleportServiceUtils.promiseTeleportClientOnce(placeId, player, config.teleportData) :: any
+end
+
+--[[
+	A teleport the engine never saw, written where a test reads it back.
+]]
+function TeleportServiceUtils._recordMockTeleport(player: Player, placeId: number, record: MockTeleport): ()
+	PlayerMock.writeLookup(player, "TeleportService.Teleport", placeId, record)
+end
+
+--[[
+	Hands the maid every report the engine makes about THIS player's hop to THIS place, mock and engine
+	alike, in one shape. TeleportInitFailed reports outcomes rather than only failures -- Success and
+	IsTeleporting both arrive through it -- so this only delivers, and the caller classifies.
+]]
+function TeleportServiceUtils._connectTeleportReported(
+	maid: Maid.Maid,
+	placeId: number,
+	player: Player,
+	onReport: (report: TeleportFailedReportUtils.TeleportReport) -> ()
+): ()
+	if PlayerMock.isMock(player) then
+		maid:GiveTask(
+			PlayerMock.getLookupChangedSignal(player, "TeleportService.TeleportInitFailed", placeId):Connect(function()
+				local injected = PlayerMock.readLookup(player, "TeleportService.TeleportInitFailed", placeId)
+				if injected == nil then
+					return
+				end
+
+				onReport(TeleportFailedReportUtils.new(placeId, injected.result, injected.message))
+			end)
+		)
+		return
+	end
+
+	maid:GiveTask(
+		TeleportService.TeleportInitFailed:Connect(
+			function(failedPlayer: Player, result: Enum.TeleportResult, message: string, reportedPlaceId: number?)
+				if failedPlayer ~= player then
+					return
+				end
+
+				-- Keyed by destination like the mock is, so a hop to somewhere else failing never speaks for
+				-- this one. Tolerates the engine omitting the place rather than dropping every report.
+				if reportedPlaceId ~= nil and reportedPlaceId ~= placeId then
+					return
+				end
+
+				onReport(TeleportFailedReportUtils.new(placeId, result, message))
 			end
-
-			resolve()
-		end)
-
-		maid._retry = retry
-	end
-
-	function attempt()
-		attempts += 1
-
-		local ok, err = TeleportServiceUtils.teleport(placeId, player, teleportData)
-		if not ok then
-			onFailed(err or "Teleport failed")
-		end
-	end
-
-	maid:GiveTask(connectTeleportInitFailed(placeId, player, onFailed))
-
-	attempt()
-
-	return promise
+		)
+	)
 end
 
 return TeleportServiceUtils

--- a/src/teleportserviceutils/src/Shared/TeleportServiceUtils.spec.lua
+++ b/src/teleportserviceutils/src/Shared/TeleportServiceUtils.spec.lua
@@ -5,6 +5,8 @@
 
 local require = require(script.Parent.loader).load(script)
 
+local Workspace = game:GetService("Workspace")
+
 local Jest = require("Jest")
 local PlayerMock = require("PlayerMock")
 local PromiseTestUtils = require("PromiseTestUtils")
@@ -12,9 +14,11 @@ local TeleportDataEnvelopeUtils = require("TeleportDataEnvelopeUtils")
 local TeleportServiceUtils = require("TeleportServiceUtils")
 
 local afterEach = Jest.Globals.afterEach
+local beforeEach = Jest.Globals.beforeEach
 local describe = Jest.Globals.describe
 local expect = Jest.Globals.expect
 local it = Jest.Globals.it
+local jest = Jest.Globals.jest
 
 local mocks: { Player } = {}
 
@@ -32,7 +36,21 @@ local function newUnmockedPlayer(): Player
 	return (player :: any) :: Player
 end
 
+-- A cloud run is a server, so the realm seam is what lets the client path be exercised at all.
+--
+-- Spied once and re-implemented between tests rather than restored and re-spied: jest.restoreAllMocks
+-- clears the spy state but not the per-object mock registry, so a second jest.spyOn of the same method
+-- hands back the cached mock WITHOUT reinstalling it, and the spy quietly stops applying.
+local realIsServer = TeleportServiceUtils._isServer
+local isServerSpy = jest.spyOn(TeleportServiceUtils, "_isServer")
+
+local function pretendClient(): ()
+	isServerSpy.mockReturnValue(false)
+end
+
 afterEach(function()
+	isServerSpy.mockImplementation(realIsServer)
+
 	for _, player in mocks do
 		player:Destroy()
 	end
@@ -47,11 +65,35 @@ local function clearHop(player: Player, placeId: number): ()
 	PlayerMock.writeLookup(player, "TeleportService.Teleport", placeId, nil)
 end
 
--- The message must differ from the previous refusal of the same teleport: the backing attribute only
--- reports a change, so a repeat goes unnoticed.
-local function refuse(player: Player, placeId: number, message: string): ()
-	PlayerMock.writeLookup(player, "TeleportService.TeleportInitFailed", placeId, { message = message })
+-- The engine reporting on a teleport. The message must differ from the previous report about the same
+-- teleport: the backing attribute only reports a change, so a repeat goes unnoticed.
+local function report(player: Player, placeId: number, result: Enum.TeleportResult, message: string): ()
+	PlayerMock.writeLookup(
+		player,
+		"TeleportService.TeleportInitFailed",
+		placeId,
+		{ result = result, message = message }
+	)
 end
+
+-- The everyday transient refusal, for tests about retrying rather than about classification.
+local function refuse(player: Player, placeId: number, message: string): ()
+	report(player, placeId, Enum.TeleportResult.GameFull, message)
+end
+
+-- Every result the engine can report, so a test over all of them cannot silently miss one.
+local ALL_RESULTS: { Enum.TeleportResult } = Enum.TeleportResult:GetEnumItems()
+
+local IN_FLIGHT: { Enum.TeleportResult } = {
+	Enum.TeleportResult.Success,
+	Enum.TeleportResult.IsTeleporting,
+}
+
+local TERMINAL: { Enum.TeleportResult } = {
+	Enum.TeleportResult.GameNotFound,
+	Enum.TeleportResult.Unauthorized,
+	Enum.TeleportResult.Flooded,
+}
 
 local function awaitHop(player: Player, placeId: number): any
 	PromiseTestUtils.awaitValue(function()
@@ -61,11 +103,33 @@ local function awaitHop(player: Player, placeId: number): any
 end
 
 describe("TeleportServiceUtils.teleport", function()
+	beforeEach(function()
+		pretendClient()
+	end)
+
+	-- It yields until the teleport is settled, and a teleport that works never settles -- the player
+	-- leaves instead -- so the request is made off-thread and read back through the mock's record.
+	local function requestTeleport(
+		placeId: number,
+		player: Player,
+		teleportData: { [string]: any }?
+	): () -> (boolean?, string?)
+		local ok, err = nil :: boolean?, nil :: string?
+
+		task.spawn(function()
+			ok, err = TeleportServiceUtils.teleport(placeId, player, teleportData)
+		end)
+
+		return function(): (boolean?, string?)
+			return ok, err
+		end
+	end
+
 	it("records the teleport with via=Teleport and its data on a mock", function()
 		local player = newMock(880001)
-		TeleportServiceUtils.teleport(4567, player, { SlotId = "abc", Flag = true })
+		requestTeleport(4567, player, { SlotId = "abc", Flag = true })
 
-		local hop = PlayerMock.readLookup(player, "TeleportService.Teleport", 4567)
+		local hop = awaitHop(player, 4567)
 		expect(hop.via).toEqual("Teleport")
 		expect(hop.teleportData.SlotId).toEqual("abc")
 		expect(hop.teleportData.Flag).toEqual(true)
@@ -73,47 +137,55 @@ describe("TeleportServiceUtils.teleport", function()
 
 	it("records an empty data table when none is passed, so a read still reports the hop", function()
 		local player = newMock(880002)
-		TeleportServiceUtils.teleport(9999, player, nil)
+		requestTeleport(9999, player, nil)
 
-		local hop = PlayerMock.readLookup(player, "TeleportService.Teleport", 9999)
+		local hop = awaitHop(player, 9999)
 		expect(hop).never.toEqual(nil)
 		expect(hop.via).toEqual("Teleport")
 	end)
 
 	it("does not record a hop to a place that was never teleported to", function()
 		local player = newMock(880003)
-		TeleportServiceUtils.teleport(1111, player, {})
+		requestTeleport(1111, player, {})
 
+		awaitHop(player, 1111)
 		expect(PlayerMock.readLookup(player, "TeleportService.Teleport", 2222)).toEqual(nil)
 	end)
 
 	it("overwrites a prior hop to the same place with the latest data", function()
 		local player = newMock(880004)
-		TeleportServiceUtils.teleport(333, player, { SlotId = "first" })
-		TeleportServiceUtils.teleport(333, player, { SlotId = "second" })
+		requestTeleport(333, player, { SlotId = "first" })
+		awaitHop(player, 333)
+		clearHop(player, 333)
+		requestTeleport(333, player, { SlotId = "second" })
 
-		expect(PlayerMock.readLookup(player, "TeleportService.Teleport", 333).teleportData.SlotId).toEqual("second")
+		expect(awaitHop(player, 333).teleportData.SlotId).toEqual("second")
 	end)
 
-	it("returns true when the hop is recorded on a mock", function()
+	it("does not come back while the hop is still in flight", function()
 		local player = newMock(880006)
 
-		local ok, err = TeleportServiceUtils.teleport(444, player, {})
+		local read = requestTeleport(444, player, {})
+		awaitHop(player, 444)
 
-		expect(ok).toEqual(true)
-		expect(err).toEqual(nil)
+		task.wait(0.1)
+		expect(read()).toEqual(nil)
 	end)
 
-	it("reports an engine refusal as false and a reason, instead of throwing", function()
-		local player = newUnmockedPlayer()
+	it("comes back false with the reason once the teleport has failed", function()
+		local player = newMock(880007)
 
-		local ok, err
-		expect(function()
-			ok, err = TeleportServiceUtils.teleport(555, player, {})
-		end).never.toThrow()
+		local read = requestTeleport(555, player, {})
+		awaitHop(player, 555)
+		report(player, 555, Enum.TeleportResult.Unauthorized, "not allowed")
 
+		PromiseTestUtils.awaitValue(function()
+			return read() ~= nil
+		end)
+
+		local ok, err = read()
 		expect(ok).toEqual(false)
-		expect(type(err)).toEqual("string")
+		expect(err).toContain("Unauthorized")
 	end)
 
 	it("errors on a non-number placeId", function()
@@ -186,13 +258,13 @@ describe("TeleportServiceUtils.teleportAsync", function()
 	end)
 end)
 
-describe("TeleportServiceUtils.promiseTeleport", function()
+describe("TeleportServiceUtils.promiseTeleportServerOnce", function()
 	it("is mock-aware: records mocks and resolves nil for an all-mock batch", function()
 		local player = newMock(883001)
 		local options = Instance.new("TeleportOptions")
 		options:SetTeleportData({ SlotId = "z" })
 
-		local result = TeleportServiceUtils.promiseTeleport(700, { player }, options):Wait()
+		local result = TeleportServiceUtils.promiseTeleportServerOnce(700, { player }, options):Wait()
 
 		expect(result).toEqual(nil)
 		local hop = PlayerMock.readLookup(player, "TeleportService.Teleport", 700)
@@ -201,7 +273,240 @@ describe("TeleportServiceUtils.promiseTeleport", function()
 	end)
 end)
 
+describe("TeleportServiceUtils.promiseTeleportClientOnce", function()
+	it("teleports on the spot, carrying the teleport data", function()
+		local player = newMock(886001)
+
+		TeleportServiceUtils.promiseTeleportClientOnce(820, player, { SlotId = "abc" })
+
+		local hop = readHop(player, 820)
+		expect(hop.via).toEqual("Teleport")
+		expect(hop.teleportData.SlotId).toEqual("abc")
+	end)
+
+	it("stays pending, because a teleport that works ends with the player gone", function()
+		local player = newMock(886002)
+
+		local promise = TeleportServiceUtils.promiseTeleportClientOnce(821, player)
+
+		expect(PromiseTestUtils.awaitSettled(promise, 0.2)).toEqual(false)
+
+		promise:Destroy()
+	end)
+
+	it("rejects with the whole report, so a caller decides on the result", function()
+		local player = newMock(886003)
+
+		local promise = TeleportServiceUtils.promiseTeleportClientOnce(822, player)
+		report(player, 822, Enum.TeleportResult.Unauthorized, "not allowed")
+
+		local outcome, rejected = PromiseTestUtils.awaitOutcome(promise)
+		expect(outcome).toEqual("rejected")
+		expect(rejected.result).toEqual(Enum.TeleportResult.Unauthorized)
+		expect(rejected.message).toEqual("not allowed")
+		expect(rejected.placeId).toEqual(822)
+	end)
+
+	it("renders its report as text, for a consumer that only wants a message", function()
+		local player = newMock(886004)
+
+		local promise = TeleportServiceUtils.promiseTeleportClientOnce(823, player)
+		report(player, 823, Enum.TeleportResult.GameFull, "server full")
+
+		local _, rejected = PromiseTestUtils.awaitOutcome(promise)
+		expect(tostring(rejected)).toContain("823")
+		expect(tostring(rejected)).toContain("GameFull")
+		expect(tostring(rejected)).toContain("server full")
+	end)
+
+	it("asks exactly once, whatever the engine reports back", function()
+		for _, result in ALL_RESULTS do
+			local player = newMock(886100 + result.Value)
+
+			local promise = TeleportServiceUtils.promiseTeleportClientOnce(824, player)
+			expect(readHop(player, 824)).never.toEqual(nil)
+
+			clearHop(player, 824)
+			report(player, 824, result, "whatever the engine says")
+
+			-- The request is out and Roblox cannot take it back, so nothing this reports may produce a
+			-- second one. Retrying is the caller's decision, made only after this has rejected.
+			task.wait(0.1)
+			expect({ result = result.Name, secondHop = readHop(player, 824) }).toEqual({
+				result = result.Name,
+				secondHop = nil,
+			})
+
+			promise:Destroy()
+		end
+	end)
+
+	it("stays pending while the engine says the hop is underway", function()
+		for _, result in IN_FLIGHT do
+			local player = newMock(886200 + result.Value)
+
+			local promise = TeleportServiceUtils.promiseTeleportClientOnce(825, player)
+			report(player, 825, result, "still going")
+
+			expect({ result = result.Name, settled = PromiseTestUtils.awaitSettled(promise, 0.2) }).toEqual({
+				result = result.Name,
+				settled = false,
+			})
+
+			promise:Destroy()
+		end
+	end)
+
+	it("reports a raised call as a Failure, so every rejection is a report", function()
+		local player = newUnmockedPlayer()
+
+		local promise = TeleportServiceUtils.promiseTeleportClientOnce(826, player)
+
+		local outcome, rejected = PromiseTestUtils.awaitOutcome(promise)
+		expect(outcome).toEqual("rejected")
+		expect(rejected.result).toEqual(Enum.TeleportResult.Failure)
+		expect(rejected.placeId).toEqual(826)
+	end)
+
+	it("ignores a report aimed at another player's teleport", function()
+		local player = newMock(886005)
+		local other = newMock(886006)
+
+		local promise = TeleportServiceUtils.promiseTeleportClientOnce(827, player)
+		report(other, 827, Enum.TeleportResult.GameFull, "someone else's problem")
+
+		expect(PromiseTestUtils.awaitSettled(promise, 0.2)).toEqual(false)
+
+		promise:Destroy()
+	end)
+
+	it("ignores a report about a hop to a different place", function()
+		local player = newMock(886007)
+
+		local promise = TeleportServiceUtils.promiseTeleportClientOnce(828, player)
+		report(player, 999, Enum.TeleportResult.GameFull, "a different destination")
+
+		expect(PromiseTestUtils.awaitSettled(promise, 0.2)).toEqual(false)
+
+		promise:Destroy()
+	end)
+
+	it("rejects with nothing when cancelled, so a caller can tell teardown from a refusal", function()
+		local player = newMock(886008)
+
+		local outcome, err = "pending", nil :: any
+		local promise = TeleportServiceUtils.promiseTeleportClientOnce(829, player)
+		promise:Then(function()
+			outcome = "resolved"
+		end, function(...)
+			outcome, err = "rejected", ...
+		end)
+
+		promise:Destroy()
+
+		expect(outcome).toEqual("rejected")
+		expect(err).toEqual(nil)
+	end)
+
+	it("stops listening once cancelled, so a later report cannot settle it", function()
+		local player = newMock(886009)
+
+		local promise = TeleportServiceUtils.promiseTeleportClientOnce(830, player)
+		promise:Destroy()
+
+		expect(function()
+			report(player, 830, Enum.TeleportResult.GameFull, "too late")
+			task.wait(0.1)
+		end).never.toThrow()
+	end)
+
+	it("errors on a bad placeId, player, or teleport data", function()
+		local player = newMock(886010)
+
+		expect(function()
+			TeleportServiceUtils.promiseTeleportClientOnce("nope" :: any, player)
+		end).toThrow()
+		expect(function()
+			TeleportServiceUtils.promiseTeleportClientOnce(831, nil :: any)
+		end).toThrow()
+		expect(function()
+			TeleportServiceUtils.promiseTeleportClientOnce(831, player, "nope" :: any)
+		end).toThrow()
+	end)
+
+	it("refuses to teleport anyone but the local player", function()
+		local localPlayer = newMock(886011)
+		local someoneElse = newMock(886012);
+		(localPlayer :: any).Parent = Workspace
+		PlayerMock.setMockedLocalPlayer(localPlayer)
+
+		expect(function()
+			TeleportServiceUtils.promiseTeleportClientOnce(832, someoneElse)
+		end).toThrow()
+
+		-- ...and still sends the one player it may.
+		local promise = TeleportServiceUtils.promiseTeleportClientOnce(832, localPlayer)
+		expect(readHop(localPlayer, 832).via).toEqual("Teleport")
+
+		promise:Destroy()
+		PlayerMock.setMockedLocalPlayer(nil)
+	end)
+end)
+
+describe("TeleportServiceUtils.promiseTeleport (server)", function()
+	it("sends the batch through TeleportAsync, resolving with the engine's result", function()
+		local player = newMock(887001)
+		local options = Instance.new("TeleportOptions")
+		options:SetTeleportData({ SlotId = "batched" })
+
+		local result = TeleportServiceUtils.promiseTeleport(840, { player }, options):Wait()
+
+		expect(result).toEqual(nil)
+		expect(readHop(player, 840).via).toEqual("TeleportAsync")
+		expect(readHop(player, 840).teleportData.SlotId).toEqual("batched")
+	end)
+
+	it("takes a config instead of options, building the options the batch needs", function()
+		local player = newMock(887002)
+
+		TeleportServiceUtils.promiseTeleport(841, { player }, { teleportData = { SlotId = "from-config" } }):Wait()
+
+		expect(readHop(player, 841).via).toEqual("TeleportAsync")
+		expect(readHop(player, 841).teleportData.SlotId).toEqual("from-config")
+	end)
+
+	it("retries a throwing request, then rejects once the attempts are spent", function()
+		local player = newUnmockedPlayer()
+
+		local promise = TeleportServiceUtils.promiseTeleport(842, { player }, {
+			maxAttempts = 3,
+			retryWait = 0,
+			printWarning = false,
+		})
+
+		local outcome, err = PromiseTestUtils.awaitOutcome(promise)
+		expect(outcome).toEqual("rejected")
+		expect(err).toContain("3 times")
+	end)
+end)
+
 describe("TeleportServiceUtils.promiseTeleportClient", function()
+	beforeEach(function()
+		pretendClient()
+	end)
+
+	it("is a transparent shell: promiseTeleport reaches the same client request", function()
+		local player = newMock(887101)
+
+		local promise = TeleportServiceUtils.promiseTeleport(843, player, { teleportData = { SlotId = "direct" } })
+
+		local hop = readHop(player, 843)
+		expect(hop.via).toEqual("Teleport")
+		expect(hop.teleportData.SlotId).toEqual("direct")
+
+		promise:Destroy()
+	end)
+
 	it("teleports on the spot, carrying the config's teleport data", function()
 		local player = newMock(885001)
 
@@ -264,7 +569,7 @@ describe("TeleportServiceUtils.promiseTeleportClient", function()
 		local outcome, err = PromiseTestUtils.awaitOutcome(promise)
 		expect(outcome).toEqual("rejected")
 		expect(err).toContain("refusal 3")
-		expect(err).toContain("3 attempt(s)")
+		expect(err).toContain("3 times")
 		expect(err).toContain("804")
 	end)
 
@@ -382,7 +687,7 @@ describe("TeleportServiceUtils.promiseTeleportClient", function()
 		local outcome, err = PromiseTestUtils.awaitOutcome(promise)
 		expect(outcome).toEqual("rejected")
 		expect(err).toContain("813")
-		expect(err).toContain("1 attempt(s)")
+		expect(err).toContain("1 times")
 	end)
 
 	it("retries a raised refusal like any other, then rejects once the attempts are spent", function()
@@ -392,7 +697,83 @@ describe("TeleportServiceUtils.promiseTeleportClient", function()
 
 		local outcome, err = PromiseTestUtils.awaitOutcome(promise)
 		expect(outcome).toEqual("rejected")
-		expect(err).toContain("3 attempt(s)")
+		expect(err).toContain("3 times")
+	end)
+
+	it("gives up the moment a refusal will only repeat, without spending the budget", function()
+		for _, result in TERMINAL do
+			local player = newMock(886300 + result.Value)
+
+			local promise = TeleportServiceUtils.promiseTeleportClient(815, player, {
+				maxAttempts = 5,
+				retryWait = 0,
+				printWarning = false,
+			})
+
+			clearHop(player, 815)
+			report(player, 815, result, "will not change")
+
+			local outcome, rejected = PromiseTestUtils.awaitOutcome(promise)
+
+			-- Rejected with the report itself rather than the retry wrapper's summary: nothing was
+			-- retried, so there is nothing to summarize, and the caller still has the result.
+			expect({
+				result = result.Name,
+				outcome = outcome,
+				rejectedResult = rejected.result,
+				secondHop = readHop(player, 815),
+			}).toEqual({
+				result = result.Name,
+				outcome = "rejected",
+				rejectedResult = result,
+				secondHop = nil,
+			})
+		end
+	end)
+
+	it("never asks again while the engine says the hop is underway", function()
+		for _, result in IN_FLIGHT do
+			local player = newMock(886400 + result.Value)
+
+			local promise = TeleportServiceUtils.promiseTeleportClient(816, player, { retryWait = 0 })
+
+			clearHop(player, 816)
+			report(player, 816, result, "still going")
+
+			task.wait(0.1)
+			expect({
+				result = result.Name,
+				secondHop = readHop(player, 816),
+				settled = promise:IsPending() == false,
+			}).toEqual({
+				result = result.Name,
+				secondHop = nil,
+				settled = false,
+			})
+
+			promise:Destroy()
+		end
+	end)
+
+	it("holds one request at a time: the next only goes out after the last has rejected", function()
+		local player = newMock(886500)
+
+		local promise = TeleportServiceUtils.promiseTeleportClient(817, player, {
+			maxAttempts = 3,
+			retryWait = 0.3,
+			printWarning = false,
+		})
+
+		clearHop(player, 817)
+		refuse(player, 817, "attempt 1 refused")
+
+		-- The refusal is in and the backoff is running, so for that whole window no request exists.
+		task.wait(0.1)
+		expect(readHop(player, 817)).toEqual(nil)
+
+		expect(awaitHop(player, 817).via).toEqual("Teleport")
+
+		promise:Destroy()
 	end)
 
 	it("errors on a bad placeId, player, or config", function()


### PR DESCRIPTION
TeleportInitFailed reports outcomes rather than only failures, so the client retry loop was reading Success and IsTeleporting as refusals and sending a second Teleport at a player who was already leaving, which Roblox cannot hold and offers no way to cancel. Reports are now classified by TeleportResult in a new TeleportFailedReportUtils, so only a refusal another request could clear is asked again, and only after the last request has rejected.

promiseTeleport now works in either realm over promiseTeleportServerOnce and promiseTeleportClientOnce, retrying through PromiseRetryUtils; existing call sites are unchanged, though a server teleport now retries where it used to fail on the first refusal.

