### PR TITLE
feat(saveslot): save slot commands take a players argument

### DIFF
--- a/src/saveslot/src/Server/Binders/HasSaveSlots.ExportImport.spec.lua
+++ b/src/saveslot/src/Server/Binders/HasSaveSlots.ExportImport.spec.lua
@@ -158,6 +158,39 @@ describe("HasSaveSlots.PromiseExportSlot / PromiseImportSlot", function()
 		end)
 	end)
 
+	it("exports the main slot when allowMainSlot is set", function()
+		runWithContext(function(context)
+			local hasSaveSlots = context.hasSaveSlots
+
+			local mainSlotId = createSelectAndWrite(hasSaveSlots, SaveSlotConstants.DEFAULT_SLOT_INDEX)
+
+			local export = awaitValueOf(hasSaveSlots:PromiseExportSlot(mainSlotId, true))
+			expect(export.data.Coins).toEqual(7)
+			expect(export.data.World_2.Eggs).toEqual(3)
+		end)
+	end)
+
+	it("strips the SaveSlots system data from a main slot export", function()
+		runWithContext(function(context)
+			local hasSaveSlots = context.hasSaveSlots
+
+			local mainSlotId = createSelectAndWrite(hasSaveSlots, SaveSlotConstants.DEFAULT_SLOT_INDEX)
+			createSelectAndWrite(hasSaveSlots, 2)
+
+			local export = awaitValueOf(hasSaveSlots:PromiseExportSlot(mainSlotId, true))
+			expect(export.data[SaveSlotConstants.SYSTEM_STORE_KEY]).toBeNil()
+		end)
+	end)
+
+	it("still refuses the main slot when allowMainSlot is false", function()
+		runWithContext(function(context)
+			local hasSaveSlots = context.hasSaveSlots
+
+			local mainSlotId = awaitValueOf(hasSaveSlots:PromiseCreateSlot(SaveSlotConstants.DEFAULT_SLOT_INDEX))
+			expect(awaitResolved(hasSaveSlots:PromiseExportSlot(mainSlotId, false))).toEqual(false)
+		end)
+	end)
+
 	it("refuses to export a missing slot", function()
 		runWithContext(function(context)
 			local hasSaveSlots = context.hasSaveSlots

--- a/src/saveslot/src/Server/Binders/HasSaveSlots.lua
+++ b/src/saveslot/src/Server/Binders/HasSaveSlots.lua
@@ -273,16 +273,24 @@ end
 
 --[=[
 	Exports a slot's saved data into a plain, serializable [SaveSlotExportUtils.SaveSlotExport].
-	Rejects the main/default slot: its store is the player's shared root datastore, so exporting it
-	would leak the SaveSlots system data and universe-scoped global data living alongside it. Only
-	isolated non-main slot substores are exportable.
+	Rejects the main/default slot by default: its store is the player's shared root datastore, so
+	exporting it would leak the SaveSlots system data and universe-scoped global data living
+	alongside it. Only isolated non-main slot substores are exportable.
+
+	`allowMainSlot` opts out of that refusal for trusted admin tooling (see [SaveSlotCmdrService]).
+	The SaveSlots system data is always stripped from the result, so the export never carries the
+	slot roster or the other slots' saved data. Universe-scoped global data sharing the root store
+	is indistinguishable from the main slot's own data and is still carried, which is why this is
+	not exposed through [SaveSlotService].
 
 	@param slotId SlotId
+	@param allowMainSlot boolean? -- defaults to false
 	@return Promise<SaveSlotExportUtils.SaveSlotExport>
 ]=]
 function HasSaveSlots.PromiseExportSlot(
 	self: HasSaveSlots,
-	slotId: SaveSlotData.SlotId
+	slotId: SaveSlotData.SlotId,
+	allowMainSlot: boolean?
 ): Promise.Promise<SaveSlotExportUtils.SaveSlotExport>
 	return (self._loadPromise :: any):Then(function()
 		local slot = self._slotMap[slotId]
@@ -290,13 +298,23 @@ function HasSaveSlots.PromiseExportSlot(
 			return (Promise :: any).rejected(`Slot \{{slotId}\} not found`)
 		end
 
-		if SaveSlotExportUtils.isMainSlotIndex(SaveSlotData.SlotIndex:Get(slot)) then
+		local isMainSlot = SaveSlotExportUtils.isMainSlotIndex(SaveSlotData.SlotIndex:Get(slot))
+		if isMainSlot and not allowMainSlot then
 			return (Promise :: any).rejected("Cannot export the main slot")
 		end
 
 		local metadata = SaveSlotData:Get(slot)
 		return self:_getSlotStore(slotId):LoadAll({}):Then(function(sourceData)
 			local data = if type(sourceData) == "table" then table.clone(sourceData) else {}
+
+			if isMainSlot then
+				-- The main slot's store is the player's shared root, so LoadAll pulls the SaveSlots system
+				-- data with it -- the slot roster and every non-main slot's saved data. Drop it so the
+				-- export is only this slot, and so importing it can't nest a whole roster inside a slot
+				-- (mirrors PromiseDuplicateSlot, which strips the same key for the same reason).
+				data[SaveSlotConstants.SYSTEM_STORE_KEY] = nil
+			end
+
 			return SaveSlotExportUtils.create(data, metadata.SlotName, metadata.Summary)
 		end)
 	end)
@@ -358,14 +376,16 @@ end
 
 	@param slotId SlotId
 	@param key string
+	@param allowMainSlot boolean? -- defaults to false, see [HasSaveSlots.PromiseExportSlot]
 	@return Promise<boolean>
 ]=]
 function HasSaveSlots.PromiseSaveSlotToSharedDataStore(
 	self: HasSaveSlots,
 	slotId: SaveSlotData.SlotId,
-	key: string
+	key: string,
+	allowMainSlot: boolean?
 ): Promise.Promise<boolean>
-	return self:PromiseExportSlot(slotId):Then(function(export)
+	return self:PromiseExportSlot(slotId, allowMainSlot):Then(function(export)
 		return self._sharedSaveSlotDataStoreService:PromiseWrite(key, export)
 	end)
 end
@@ -523,15 +543,18 @@ end
 --[=[
 	Exports a slot to the shared store under a fresh generated code and resolves to that code. The code
 	is a shareable handle other sessions load with [HasSaveSlots.PromiseImportEphemeralSaveSlotFromCode].
-	Defaults to the active slot. Refuses the main slot (see [HasSaveSlots.PromiseExportSlot]). The code
-	format comes from the configured generator (see [HasSaveSlots.SetCodeGenerator]).
+	Defaults to the active slot. Refuses the main slot unless `allowMainSlot` is set (see
+	[HasSaveSlots.PromiseExportSlot]). The code format comes from the configured generator (see
+	[HasSaveSlots.SetCodeGenerator]).
 
 	@param slotId SlotId? -- defaults to the active slot
+	@param allowMainSlot boolean? -- defaults to false, see [HasSaveSlots.PromiseExportSlot]
 	@return Promise<string>
 ]=]
 function HasSaveSlots.PromiseExportSaveSlotToCode(
 	self: HasSaveSlots,
-	slotId: SaveSlotData.SlotId?
+	slotId: SaveSlotData.SlotId?,
+	allowMainSlot: boolean?
 ): Promise.Promise<string>
 	return (self._loadPromise :: any):Then(function()
 		local targetSlotId = slotId or self.ActiveSlotId.Value
@@ -540,7 +563,7 @@ function HasSaveSlots.PromiseExportSaveSlotToCode(
 		end
 
 		local code = self:_generateCode(targetSlotId)
-		return self:PromiseSaveSlotToSharedDataStore(targetSlotId, code):Then(function()
+		return self:PromiseSaveSlotToSharedDataStore(targetSlotId, code, allowMainSlot):Then(function()
 			return code
 		end)
 	end)
@@ -562,14 +585,17 @@ end
 
 --[=[
 	Exports a slot as a raw JSON string (no shared store), for direct inspection or attaching to a bug
-	report. Defaults to the active slot. Refuses the main slot (see [HasSaveSlots.PromiseExportSlot]).
+	report. Defaults to the active slot. Refuses the main slot unless `allowMainSlot` is set (see
+	[HasSaveSlots.PromiseExportSlot]).
 
 	@param slotId SlotId? -- defaults to the active slot
+	@param allowMainSlot boolean? -- defaults to false, see [HasSaveSlots.PromiseExportSlot]
 	@return Promise<string>
 ]=]
 function HasSaveSlots.PromiseExportSaveSlotToJson(
 	self: HasSaveSlots,
-	slotId: SaveSlotData.SlotId?
+	slotId: SaveSlotData.SlotId?,
+	allowMainSlot: boolean?
 ): Promise.Promise<string>
 	return (self._loadPromise :: any):Then(function()
 		local targetSlotId = slotId or self.ActiveSlotId.Value
@@ -577,7 +603,7 @@ function HasSaveSlots.PromiseExportSaveSlotToJson(
 			return (Promise :: any).rejected("No slot to export")
 		end
 
-		return self:PromiseExportSlot(targetSlotId):Then(function(export)
+		return self:PromiseExportSlot(targetSlotId, allowMainSlot):Then(function(export)
 			return HttpService:JSONEncode(export)
 		end)
 	end)

--- a/src/saveslot/src/Server/Cmdr/SaveSlotCmdrService.lua
+++ b/src/saveslot/src/Server/Cmdr/SaveSlotCmdrService.lua
@@ -55,15 +55,29 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 		Name = "list-save-slots",
 		Description = "Lists all save slots.",
 		Group = "SaveSlots",
-		Args = {},
-	}, function(context)
-		local activeSlotId = self._saveSlotDataService:GetActiveSlotId(context.Executor)
-		local slotList = self._saveSlotDataService:GetSlotList(context.Executor)
+		Args = {
+			{
+				Name = "Players",
+				Type = "players",
+				Description = "Players to list slots for (e.g. . for yourself, or * for everyone).",
+			},
+		},
+	}, function(_context, players: { Player })
 		local listString = ""
 
-		for _, slot in slotList do
-			local isActive = (slot.SlotId == activeSlotId)
-			listString ..= `\n"{slot.SlotName}" ({slot.SlotIndex}){isActive and " — Active" or ""}\n{slot.Summary}\n`
+		for _, player in players do
+			local activeSlotId = self._saveSlotDataService:GetActiveSlotId(player)
+			local slotList = self._saveSlotDataService:GetSlotList(player)
+
+			listString ..= `\n{player.Name}:\n`
+			if #slotList == 0 then
+				listString ..= "No slots.\n"
+			end
+
+			for _, slot in slotList do
+				local isActive = (slot.SlotId == activeSlotId)
+				listString ..= `\n"{slot.SlotName}" ({slot.SlotIndex}){isActive and " — Active" or ""}\n{slot.Summary}\n`
+			end
 		end
 
 		return listString
@@ -73,16 +87,27 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 		Name = "get-active-save-slot",
 		Description = "Returns the active save slot.",
 		Group = "SaveSlots",
-		Args = {},
-	}, function(context)
-		local activeSlotId = self._saveSlotDataService:GetActiveSlotId(context.Executor)
-		if not activeSlotId then
-			return "No active slot."
+		Args = {
+			{
+				Name = "Players",
+				Type = "players",
+				Description = "Players to query (e.g. . for yourself, or * for everyone).",
+			},
+		},
+	}, function(_context, players: { Player })
+		local lines = {}
+
+		for _, player in players do
+			local activeSlotId = self._saveSlotDataService:GetActiveSlotId(player)
+			if activeSlotId then
+				local slotData = self._saveSlotDataService:GetSlotMetadata(player, activeSlotId)
+				table.insert(lines, `{player.Name} is using slot {slotData.SlotIndex} ("{slotData.SlotName}").`)
+			else
+				table.insert(lines, `{player.Name} has no active slot.`)
+			end
 		end
 
-		local slotData = self._saveSlotDataService:GetSlotMetadata(context.Executor, activeSlotId)
-
-		return `Currently using slot {slotData.SlotIndex} ("{slotData.SlotName}").`
+		return table.concat(lines, "\n")
 	end)
 
 	self._cmdrService:RegisterCommand({
@@ -91,49 +116,58 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 		Group = "SaveSlots",
 		Args = {
 			{
+				Name = "Players",
+				Type = "players",
+				Description = "Players to switch (e.g. . for yourself, or * for everyone).",
+			},
+			{
 				Name = "Slot",
 				Type = "slotIndex",
 				Description = "Slot index to switch to, or . for your current slot.",
 			},
 		},
-	}, function(context, slotIndex: number)
-		local slotId = self._saveSlotDataService:GetSlotIdFromIndex(context.Executor, slotIndex)
-		if not slotId then
-			return `No slot with index {slotIndex}.`
-		end
+	}, function(_context, players: { Player }, slotIndex: number)
+		local lines = self:_promisePlayerLines(players, function(hasSaveSlots, player)
+			local slotId = self._saveSlotDataService:GetSlotIdFromIndex(player, slotIndex)
+			if not slotId then
+				return `{player.Name} has no slot with index {slotIndex}.`
+			end
 
-		if slotId == self._saveSlotDataService:GetActiveSlotId(context.Executor) then
-			return "Slot is already active."
-		end
+			if slotId == self._saveSlotDataService:GetActiveSlotId(player) then
+				return `{player.Name} already has slot {slotIndex} active.`
+			end
 
-		self._maid
-			:GivePromise(self._hasSaveSlotsBinder:Promise(context.Executor))
-			:Then(function(hasSaveSlots)
-				return hasSaveSlots:PromiseSelectSlot(slotId)
+			return hasSaveSlots:PromiseSelectSlot(slotId):Then(function()
+				return `{player.Name} switched to slot {slotIndex}.`
 			end)
-			:Wait()
+		end):Wait()
 
-		return `Switched to slot {slotIndex}.`
+		return table.concat(lines, "\n")
 	end)
 
 	self._cmdrService:RegisterCommand({
 		Name = "deselect-save-slot",
 		Description = "Clears the active save slot, returning to a no-slot state.",
 		Group = "SaveSlots",
-		Args = {},
-	}, function(context)
-		if not self._saveSlotDataService:GetActiveSlotId(context.Executor) then
-			return "No active slot."
-		end
+		Args = {
+			{
+				Name = "Players",
+				Type = "players",
+				Description = "Players to deselect (e.g. . for yourself, or * for everyone).",
+			},
+		},
+	}, function(_context, players: { Player })
+		local lines = self:_promisePlayerLines(players, function(hasSaveSlots, player)
+			if not self._saveSlotDataService:GetActiveSlotId(player) then
+				return `{player.Name} has no active slot.`
+			end
 
-		self._maid
-			:GivePromise(self._hasSaveSlotsBinder:Promise(context.Executor))
-			:Then(function(hasSaveSlots)
-				return hasSaveSlots:PromiseDeselectSlot()
+			return hasSaveSlots:PromiseDeselectSlot():Then(function()
+				return `{player.Name} deselected active slot.`
 			end)
-			:Wait()
+		end):Wait()
 
-		return "Deselected active slot."
+		return table.concat(lines, "\n")
 	end)
 
 	self._cmdrService:RegisterCommand({
@@ -142,66 +176,74 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 		Group = "SaveSlots",
 		Args = {
 			{
+				Name = "Players",
+				Type = "players",
+				Description = "Players to create slots for (e.g. . for yourself, or * for everyone).",
+			},
+			{
 				Name = "Slots",
 				Type = "numbers",
 				Description = "Slot indices to create (e.g. 1,2). Omit to use the lowest free index.",
 				Optional = true,
 			},
 		},
-	}, function(context, slotIndices: { number }?)
-		local maxSlotCount = context.Executor:GetAttribute("MaxSlotCount")
+	}, function(_context, players: { Player }, slotIndices: { number }?)
+		local lines = self:_promisePlayerLines(players, function(hasSaveSlots, player)
+			-- The cap is per-player, so it has to come off each target rather than the executor, whose
+			-- cap may be larger. Read from the binder rather than the mirrored attribute, since that is
+			-- what PromiseCreateSlot itself validates against.
+			local maxSlotCount = hasSaveSlots.MaxSlotCount.Value
 
-		-- Track indices already taken so a batch fills gaps and never collides within itself.
-		local used = {}
-		for _, metadata in self._saveSlotDataService:GetSlotList(context.Executor) do
-			used[metadata.SlotIndex] = true
-		end
-
-		local toCreate = {}
-		if slotIndices == nil then
-			-- Default to the lowest free index, filling gaps left by deletions.
-			local freeIndex = 1
-			while used[freeIndex] do
-				freeIndex += 1
+			-- Track indices already taken so a batch fills gaps and never collides within itself.
+			local used = {}
+			for _, metadata in self._saveSlotDataService:GetSlotList(player) do
+				used[metadata.SlotIndex] = true
 			end
 
-			if freeIndex > maxSlotCount then
-				return "All slots are already in use."
+			local toCreate = {}
+			if slotIndices == nil then
+				-- Default to the lowest free index, filling gaps left by deletions.
+				local freeIndex = 1
+				while used[freeIndex] do
+					freeIndex += 1
+				end
+
+				if freeIndex > maxSlotCount then
+					return `{player.Name}: all slots are already in use.`
+				end
+
+				table.insert(toCreate, freeIndex)
+			else
+				-- Validate the whole batch up front so nothing is created when any index is bad.
+				local seen = {}
+				for _, slotIndex in slotIndices do
+					if (slotIndex < 1) or (slotIndex > maxSlotCount) then
+						return `{player.Name}: index must be in range [1, {maxSlotCount}].`
+					end
+					if used[slotIndex] then
+						return `{player.Name}: slot {slotIndex} already exists.`
+					end
+					if not seen[slotIndex] then
+						seen[slotIndex] = true
+						table.insert(toCreate, slotIndex)
+					end
+				end
 			end
 
-			table.insert(toCreate, freeIndex)
-		else
-			-- Validate the whole batch up front so nothing is created when any index is bad.
-			local seen = {}
-			for _, slotIndex in slotIndices do
-				if (slotIndex < 1) or (slotIndex > maxSlotCount) then
-					return `Index must be in range [1, {maxSlotCount}].`
-				end
-				if used[slotIndex] then
-					return `Slot {slotIndex} already exists.`
-				end
-				if not seen[slotIndex] then
-					seen[slotIndex] = true
-					table.insert(toCreate, slotIndex)
-				end
+			-- Create sequentially to avoid concurrent datastore saves.
+			local promise = Promise.resolved()
+			for _, slotIndex in toCreate do
+				promise = promise:Then(function()
+					return hasSaveSlots:PromiseCreateSlot(slotIndex)
+				end)
 			end
-		end
 
-		self._maid
-			:GivePromise(self._hasSaveSlotsBinder:Promise(context.Executor))
-			:Then(function(hasSaveSlots)
-				-- Create sequentially to avoid concurrent datastore saves.
-				local promise = Promise.resolved()
-				for _, slotIndex in toCreate do
-					promise = promise:Then(function()
-						return hasSaveSlots:PromiseCreateSlot(slotIndex)
-					end)
-				end
-				return promise
+			return promise:Then(function()
+				return `{player.Name} created slot(s) {table.concat(toCreate, ", ")}.`
 			end)
-			:Wait()
+		end):Wait()
 
-		return `Created slot(s) {table.concat(toCreate, ", ")}.`
+		return table.concat(lines, "\n")
 	end)
 
 	self._cmdrService:RegisterCommand({
@@ -210,56 +252,40 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 		Group = "SaveSlots",
 		Args = {
 			{
+				Name = "Players",
+				Type = "players",
+				Description = "Players to delete slots for (e.g. . for yourself, or * for everyone).",
+			},
+			{
 				Name = "Slots",
 				Type = "slotIndices",
 				Description = "Slot indices to delete (e.g. 1,2, . for your current slot, or * for all).",
 			},
 		},
-	}, function(context, slotIndices: { number })
-		local activeSlotId = self._saveSlotDataService:GetActiveSlotId(context.Executor)
-
-		-- Resolve indices to ids up front; `*` can include the active slot and duplicates.
-		local seen = {}
-		local toDelete = {}
-		for _, slotIndex in slotIndices do
-			local slotId = self._saveSlotDataService:GetSlotIdFromIndex(context.Executor, slotIndex)
-			if slotId and not seen[slotId] then
-				seen[slotId] = true
-				table.insert(toDelete, { slotIndex = slotIndex, slotId = slotId })
-			end
-		end
-
-		if #toDelete == 0 then
+	}, function(_context, players: { Player }, slotIndices: { number })
+		local targets = self:_resolveTargets(players, slotIndices)
+		if #targets == 0 then
 			return "No matching slots to delete."
 		end
 
-		self._maid
-			:GivePromise(self._hasSaveSlotsBinder:Promise(context.Executor))
-			:Then(function(hasSaveSlots)
-				-- Delete sequentially to avoid concurrent datastore saves. The active slot can't be
-				-- deleted while selected, so deselect it first (flushing its progress) when reached.
-				local promise = Promise.resolved()
-				for _, entry in toDelete do
-					promise = promise:Then(function()
-						if entry.slotId == activeSlotId then
-							return hasSaveSlots:PromiseDeselectSlot():Then(function()
-								return hasSaveSlots:PromiseDeleteSlot(entry.slotId)
-							end)
-						end
+		local lines = self:_promiseSlotLines(targets, function(hasSaveSlots, entry, player)
+			-- The active slot can't be deleted while selected, so deselect it first (flushing its
+			-- progress) when reached. Read live rather than up front, since an earlier deletion in
+			-- this batch may have already deselected it.
+			local deselect = if entry.slotId == self._saveSlotDataService:GetActiveSlotId(player)
+				then hasSaveSlots:PromiseDeselectSlot()
+				else Promise.resolved()
 
-						return hasSaveSlots:PromiseDeleteSlot(entry.slotId)
-					end)
-				end
-				return promise
-			end)
-			:Wait()
+			return deselect
+				:Then(function()
+					return hasSaveSlots:PromiseDeleteSlot(entry.slotId)
+				end)
+				:Then(function()
+					return `{player.Name} deleted slot {entry.slotIndex}.`
+				end)
+		end):Wait()
 
-		local deletedIndices = {}
-		for _, entry in toDelete do
-			table.insert(deletedIndices, entry.slotIndex)
-		end
-
-		return `Deleted slot(s) {table.concat(deletedIndices, ", ")}.`
+		return `Deleted:\n{table.concat(lines, "\n")}`
 	end)
 
 	self._cmdrService:RegisterCommand({
@@ -303,60 +329,32 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 		Group = "SaveSlots",
 		Args = {
 			{
+				Name = "Players",
+				Type = "players",
+				Description = "Players to reset slots for (e.g. . for yourself, or * for everyone).",
+			},
+			{
+				-- Required rather than defaulting to the active slot: with Players ahead of it, an
+				-- optional Slots would leave `reset-save-slot *` as valid syntax that wipes the active
+				-- slot of every player in the server.
 				Name = "Slots",
 				Type = "slotIndices",
-				Description = "Slot indices to reset (e.g. 1,2, . for your current slot, or * for all). Omit to reset the active slot.",
-				Optional = true,
+				Description = "Slot indices to reset (e.g. 1,2, . for your current slot, or * for all).",
 			},
 		},
-	}, function(context, slotIndices: { number }?)
-		local toReset = {}
-		if slotIndices == nil then
-			-- No indices given: reset the active slot.
-			local activeSlotId = self._saveSlotDataService:GetActiveSlotId(context.Executor)
-			if not activeSlotId then
-				return "No active slot."
-			end
-
-			local metadata = self._saveSlotDataService:GetSlotMetadata(context.Executor, activeSlotId)
-			table.insert(toReset, { slotIndex = metadata.SlotIndex, slotId = activeSlotId })
-		else
-			-- Resolve indices to ids up front; `*`/`.` can include duplicates.
-			local seen = {}
-			for _, slotIndex in slotIndices do
-				local slotId = self._saveSlotDataService:GetSlotIdFromIndex(context.Executor, slotIndex)
-				if slotId and not seen[slotId] then
-					seen[slotId] = true
-					table.insert(toReset, { slotIndex = slotIndex, slotId = slotId })
-				end
-			end
-
-			if #toReset == 0 then
-				return "No matching slots to reset."
-			end
+	}, function(_context, players: { Player }, slotIndices: { number })
+		local targets = self:_resolveTargets(players, slotIndices)
+		if #targets == 0 then
+			return "No matching slots to reset."
 		end
 
-		local resetIndices = self._maid
-			:GivePromise(self._hasSaveSlotsBinder:Promise(context.Executor))
-			:Then(function(hasSaveSlots)
-				-- Reset sequentially to avoid concurrent datastore saves.
-				local promise = Promise.resolved()
-				local done = {}
-				for _, entry in toReset do
-					promise = promise:Then(function()
-						return hasSaveSlots:PromiseResetSlot(entry.slotId):Then(function()
-							table.insert(done, entry.slotIndex)
-						end)
-					end)
-				end
-				return promise:Then(function()
-					return done
-				end)
+		local lines = self:_promiseSlotLines(targets, function(hasSaveSlots, entry, player)
+			return hasSaveSlots:PromiseResetSlot(entry.slotId):Then(function()
+				return `{player.Name} reset slot {entry.slotIndex}.`
 			end)
-			:Wait()
+		end):Wait()
 
-		table.sort(resetIndices)
-		return `Reset slot(s) {table.concat(resetIndices, ", ")}.`
+		return `Reset:\n{table.concat(lines, "\n")}`
 	end)
 
 	self._cmdrService:RegisterCommand({
@@ -531,6 +529,38 @@ function SaveSlotCmdrService._resolveTargets(
 		end
 	end
 	return targets
+end
+
+-- Runs handlePlayer once per player, sequentially, to avoid concurrent datastore writes. For the
+-- commands that act on a player as a whole rather than on a resolved slot list. handlePlayer may
+-- return a line directly to report without doing any work.
+function SaveSlotCmdrService._promisePlayerLines(
+	self: SaveSlotCmdrService,
+	players: { Player },
+	handlePlayer: (any, Player) -> any
+): any
+	local promise = Promise.resolved()
+	local results: { string } = {}
+
+	for _, player in players do
+		promise = promise:Then(function()
+			return self._maid
+				:GivePromise(self._hasSaveSlotsBinder:Promise(player))
+				:Then(function(hasSaveSlots)
+					return handlePlayer(hasSaveSlots, player)
+				end)
+				:Then(function(line)
+					table.insert(results, line)
+				end)
+				:Catch(function(err)
+					table.insert(results, `{player.Name}: {tostring(err)}`)
+				end)
+		end)
+	end
+
+	return promise:Then(function()
+		return results
+	end)
 end
 
 -- Runs handleSlot over every resolved slot of every target, sequentially, to avoid concurrent

--- a/src/saveslot/src/Server/Cmdr/SaveSlotCmdrService.lua
+++ b/src/saveslot/src/Server/Cmdr/SaveSlotCmdrService.lua
@@ -268,53 +268,28 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 		Group = "SaveSlots",
 		Args = {
 			{
+				Name = "Players",
+				Type = "players",
+				Description = "Players to duplicate slots for (e.g. . for yourself, or * for everyone).",
+			},
+			{
 				Name = "Slots",
 				Type = "slotIndices",
 				Description = "Slot indices to duplicate (e.g. 1,2, . for your current slot, or * for all).",
 			},
 		},
-	}, function(context, slotIndices: { number })
-		-- Resolve indices to ids up front; `*`/`.` can include duplicates.
-		local seen = {}
-		local toDuplicate = {}
-		for _, slotIndex in slotIndices do
-			local slotId = self._saveSlotDataService:GetSlotIdFromIndex(context.Executor, slotIndex)
-			if slotId and not seen[slotId] then
-				seen[slotId] = true
-				table.insert(toDuplicate, { slotIndex = slotIndex, slotId = slotId })
-			end
-		end
-
-		if #toDuplicate == 0 then
+	}, function(_context, players: { Player }, slotIndices: { number })
+		local targets = self:_resolveTargets(players, slotIndices)
+		if #targets == 0 then
 			return "No matching slots to duplicate."
 		end
 
-		local lines = self._maid
-			:GivePromise(self._hasSaveSlotsBinder:Promise(context.Executor))
-			:Then(function(hasSaveSlots)
-				-- Duplicate sequentially: each copy consumes a free index the next one must see. Report
-				-- per-slot so a mid-batch failure (e.g. the roster filling up) still surfaces the successes.
-				local promise = Promise.resolved()
-				local results = {}
-				for _, entry in toDuplicate do
-					promise = promise:Then(function()
-						return hasSaveSlots
-							:PromiseDuplicateSlot(entry.slotId)
-							:Then(function(newSlotId)
-								local newMetadata =
-									self._saveSlotDataService:GetSlotMetadata(context.Executor, newSlotId)
-								table.insert(
-									results,
-									`slot {entry.slotIndex} → slot {newMetadata.SlotIndex} ("{newMetadata.SlotName}")`
-								)
-							end)
-							:Catch(function(err)
-								table.insert(results, `slot {entry.slotIndex}: {tostring(err)}`)
-							end)
-					end)
-				end
-				return promise:Then(function()
-					return results
+		-- Each copy consumes a free index the next one must see, which the sequential walk guarantees.
+		local lines = self
+			:_promiseSlotLines(targets, function(hasSaveSlots, entry, player)
+				return hasSaveSlots:PromiseDuplicateSlot(entry.slotId):Then(function(newSlotId)
+					local newMetadata = self._saveSlotDataService:GetSlotMetadata(player, newSlotId)
+					return `{player.Name} slot {entry.slotIndex} → slot {newMetadata.SlotIndex} ("{newMetadata.SlotName}")`
 				end)
 			end)
 			:Wait()
@@ -402,12 +377,12 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 			},
 		},
 	}, function(_context, players: { Player }, slotIndices: { number }?)
-		local targets = self:_resolveExportTargets(players, slotIndices)
+		local targets = self:_resolveTargets(players, slotIndices)
 		if #targets == 0 then
 			return "No matching slots to export."
 		end
 
-		local lines = self:_promiseExportLines(targets, function(hasSaveSlots, entry, player)
+		local lines = self:_promiseSlotLines(targets, function(hasSaveSlots, entry, player)
 			return hasSaveSlots:PromiseExportSaveSlotToCode(entry.slotId):Then(function(code)
 				return `{player.Name} slot {entry.slotIndex} → {code}`
 			end)
@@ -434,12 +409,12 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 			},
 		},
 	}, function(_context, players: { Player }, slotIndices: { number }?)
-		local targets = self:_resolveExportTargets(players, slotIndices)
+		local targets = self:_resolveTargets(players, slotIndices)
 		if #targets == 0 then
 			return "No matching slots to export."
 		end
 
-		local blocks = self:_promiseExportLines(targets, function(hasSaveSlots, entry, player)
+		local blocks = self:_promiseSlotLines(targets, function(hasSaveSlots, entry, player)
 			return hasSaveSlots:PromiseExportSaveSlotToJson(entry.slotId):Then(function(json)
 				return `-- {player.Name} slot {entry.slotIndex}\n{json}`
 			end)
@@ -530,10 +505,10 @@ function SaveSlotCmdrService._resolveSlotEntries(
 	return entries
 end
 
--- Pairs each player with their resolved slots, dropping players with nothing to export. Note that
+-- Pairs each player with their resolved slots, dropping players with nothing to act on. Note that
 -- Cmdr resolves the "." and "*" slot operators against the executor's slot list, since types only
 -- see the executor, so indices given that way come from the executor's slots.
-function SaveSlotCmdrService._resolveExportTargets(
+function SaveSlotCmdrService._resolveTargets(
 	self: SaveSlotCmdrService,
 	players: { Player },
 	slotIndices: { number }?
@@ -548,13 +523,13 @@ function SaveSlotCmdrService._resolveExportTargets(
 	return targets
 end
 
--- Exports every resolved slot of every target, sequentially, to avoid concurrent datastore writes.
--- Reports per-slot so a mid-batch failure (e.g. the main slot, which export refuses) still surfaces
--- the successes.
-function SaveSlotCmdrService._promiseExportLines(
+-- Runs handleSlot over every resolved slot of every target, sequentially, to avoid concurrent
+-- datastore writes. Reports per-slot so a mid-batch failure (e.g. the main slot, which export
+-- refuses) still surfaces the successes.
+function SaveSlotCmdrService._promiseSlotLines(
 	self: SaveSlotCmdrService,
 	targets: { { player: Player, entries: SlotEntries } },
-	exportSlot: (any, SlotEntry, Player) -> any
+	handleSlot: (any, SlotEntry, Player) -> any
 ): any
 	local promise = Promise.resolved()
 	local results: { string } = {}
@@ -565,7 +540,7 @@ function SaveSlotCmdrService._promiseExportLines(
 				local slotPromise = Promise.resolved()
 				for _, entry in target.entries do
 					slotPromise = slotPromise:Then(function()
-						return exportSlot(hasSaveSlots, entry, target.player)
+						return handleSlot(hasSaveSlots, entry, target.player)
 							:Then(function(line)
 								table.insert(results, line)
 							end)

--- a/src/saveslot/src/Server/Cmdr/SaveSlotCmdrService.lua
+++ b/src/saveslot/src/Server/Cmdr/SaveSlotCmdrService.lua
@@ -380,8 +380,10 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 			return "No matching slots to export."
 		end
 
+		-- Admin tooling exports the main slot too, which the normal path refuses. See
+		-- HasSaveSlots.PromiseExportSlot for what that carries.
 		local lines = self:_promiseSlotLines(targets, function(hasSaveSlots, entry, player)
-			return hasSaveSlots:PromiseExportSaveSlotToCode(entry.slotId):Then(function(code)
+			return hasSaveSlots:PromiseExportSaveSlotToCode(entry.slotId, true):Then(function(code)
 				return `{player.Name} slot {entry.slotIndex} → {code}`
 			end)
 		end):Wait()
@@ -412,8 +414,10 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 			return "No matching slots to export."
 		end
 
+		-- Admin tooling exports the main slot too, which the normal path refuses. See
+		-- HasSaveSlots.PromiseExportSlot for what that carries.
 		local blocks = self:_promiseSlotLines(targets, function(hasSaveSlots, entry, player)
-			return hasSaveSlots:PromiseExportSaveSlotToJson(entry.slotId):Then(function(json)
+			return hasSaveSlots:PromiseExportSaveSlotToJson(entry.slotId, true):Then(function(json)
 				return `-- {player.Name} slot {entry.slotIndex}\n{json}`
 			end)
 		end):Wait()
@@ -564,8 +568,8 @@ function SaveSlotCmdrService._promisePlayerLines(
 end
 
 -- Runs handleSlot over every resolved slot of every target, sequentially, to avoid concurrent
--- datastore writes. Reports per-slot so a mid-batch failure (e.g. the main slot, which export
--- refuses) still surfaces the successes.
+-- datastore writes. Reports per-slot so a mid-batch failure (e.g. one player's slot failing to
+-- load) still surfaces the successes.
 function SaveSlotCmdrService._promiseSlotLines(
 	self: SaveSlotCmdrService,
 	targets: { { player: Player, entries: SlotEntries } },

--- a/src/saveslot/src/Server/Cmdr/SaveSlotCmdrService.lua
+++ b/src/saveslot/src/Server/Cmdr/SaveSlotCmdrService.lua
@@ -429,20 +429,25 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 		Group = "SaveSlots",
 		Args = {
 			{
+				Name = "Player",
+				Type = "player",
+				Description = "Player to import into (e.g. . for yourself).",
+			},
+			{
 				Name = "Code",
 				Type = "string",
 				Description = "The code to import.",
 			},
 		},
-	}, function(context, code: string)
+	}, function(_context, player: Player, code: string)
 		return self._maid
-			:GivePromise(self._hasSaveSlotsBinder:Promise(context.Executor))
+			:GivePromise(self._hasSaveSlotsBinder:Promise(player))
 			:Then(function(hasSaveSlots)
 				return hasSaveSlots:PromiseImportSlotFromSharedDataStore(code)
 			end)
 			:Then(function(newSlotId)
-				local metadata = self._saveSlotDataService:GetSlotMetadata(context.Executor, newSlotId)
-				return `Imported save slot from code into slot {metadata.SlotIndex} ("{metadata.SlotName}").`
+				local metadata = self._saveSlotDataService:GetSlotMetadata(player, newSlotId)
+				return `Imported save slot from code into {player.Name} slot {metadata.SlotIndex} ("{metadata.SlotName}").`
 			end)
 			:Catch(function(err)
 				return `Import failed: {tostring(err)}`
@@ -456,19 +461,24 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 		Group = "SaveSlots",
 		Args = {
 			{
+				Name = "Player",
+				Type = "player",
+				Description = "Player to import into (e.g. . for yourself).",
+			},
+			{
 				Name = "Code",
 				Type = "string",
 				Description = "The code to load.",
 			},
 		},
-	}, function(context, code: string)
+	}, function(_context, player: Player, code: string)
 		return self._maid
-			:GivePromise(self._hasSaveSlotsBinder:Promise(context.Executor))
+			:GivePromise(self._hasSaveSlotsBinder:Promise(player))
 			:Then(function(hasSaveSlots)
 				return hasSaveSlots:PromiseImportEphemeralSaveSlotFromCode(code)
 			end)
 			:Then(function()
-				return `Imported ephemeral save slot from code: {code}`
+				return `Imported ephemeral save slot into {player.Name} from code: {code}`
 			end)
 			:Catch(function(err)
 				return `Load failed: {tostring(err)}`


### PR DESCRIPTION
Every Cmdr command in the save slot package now takes a player argument ahead of its existing arguments, the same shape export-save-slot already had, so an admin can act on other players instead of only themselves. Previously only the two export commands could. Each command reports its result per player.

The two import commands take a single Player, since applying one code across everyone is disruptive enough to be worth spelling out per player, and the ephemeral import also selects the slot it creates. The rest take Players.

The export commands can now also export a player's main slot, which the normal path refuses. That refusal exists because the main slot's store is the player's shared root datastore, so reading it pulls the SaveSlots system data alongside the slot's own data, meaning the roster and every other slot. A main slot export now strips that key the same way slot duplication already did, so the export carries only the slot itself and importing it cannot nest a roster inside a slot. Universe-scoped global data sharing the root store cannot be told apart from the main slot's own data and is still carried, so the opt-in is deliberately not available through SaveSlotService, only to code holding the binder directly. The export methods were already server realm only, so there is no client path to this.

Two commands changed beyond gaining the argument. reset-save-slot's Slots argument becomes required, because with Players ahead of it an optional Slots would leave `reset-save-slot *` as valid syntax meaning "wipe the active slot of every player in the server", where it used to mean "reset all of my slots". And create-save-slot was reading the MaxSlotCount cap off the executor, which would have validated every target against the executor's cap once it took players, so it now reads each player's own cap from the binder.

Note that the slot `.` and `*` operators still resolve against the executor's slot list, since Cmdr types only ever see the executor. For the commands taking both players and slot indices, that means "each player's slots at the indices I have", not "each player's own slots". That was already true of the export commands.

https://claude.ai/code/session_014vxqfL1jx7niZx3xKUaCTG