### PR TITLE
fix(access): unregister a fact, feature or policy when it is destroyed

### DIFF
--- a/src/access/src/Shared/AccessDataService.lua
+++ b/src/access/src/Shared/AccessDataService.lua
@@ -653,7 +653,13 @@ function AccessDataService.RegisterFact(self: AccessDataService, fact: AccessFac
 	end)
 	self:_refreshFactNames()
 
-	return function()
+	local unregistered = false
+	local function unregister()
+		if unregistered then
+			return
+		end
+		unregistered = true
+
 		local current = self._layersByFactName[factName]
 		if not current then
 			return
@@ -670,6 +676,15 @@ function AccessDataService.RegisterFact(self: AccessDataService, fact: AccessFac
 
 		self:_refreshFactNames()
 	end
+
+	-- A destroyed fact must never stay a registered layer. One maid commonly holds both the fact and this
+	-- disposer, and DoCleaning runs its tasks in no particular order -- so relying on the caller to
+	-- unregister first is relying on luck. BaseObject runs the object's own maid *before* nilling its
+	-- metatable, so hooking it here takes the layer out while it is still a usable object; a moment later
+	-- every method call on it would fail instead.
+	fact._maid:GiveTask(unregister)
+
+	return unregister
 end
 
 --[[
@@ -753,8 +768,14 @@ function AccessDataService.RegisterFeature(self: AccessDataService, feature: Acc
 	)
 
 	local remove = self._features:Set(featureName, feature)
+	local unregistered = false
 
-	return function()
+	local function unregister()
+		if unregistered then
+			return
+		end
+		unregistered = true
+
 		-- The removers held here close over *this* feature object. Once it is gone they have nothing to act
 		-- on, and leaving them keyed by name means a feature later registered under the same name is skipped
 		-- as already-pushed and silently gates on the narrower rule.
@@ -762,6 +783,12 @@ function AccessDataService.RegisterFeature(self: AccessDataService, feature: Acc
 
 		remove()
 	end
+
+	-- Same reason as a fact's: a destroyed feature left in the registry is one every reader would call
+	-- methods on. See RegisterFact.
+	feature._maid:GiveTask(unregister)
+
+	return unregister
 end
 
 --[=[

--- a/src/access/src/Shared/AccessFeatureExtension.spec.lua
+++ b/src/access/src/Shared/AccessFeatureExtension.spec.lua
@@ -499,3 +499,87 @@ describe("the registered fact-name list", function()
 		controller:destroy()
 	end)
 end)
+
+describe("a registered object that gets destroyed", function()
+	--[[
+		One maid usually holds both the object and its unregister disposer, and DoCleaning runs tasks in no
+		particular order. Left registered, a destroyed object is one every reader calls methods on -- and
+		BaseObject nils the metatable, so those calls fail rather than returning nothing.
+	]]
+	it("takes its fact layer out of the registry", function()
+		local controller = setup()
+		local fact = AccessFact.new("selfDestructing", {
+			resolve = function()
+				return nil
+			end,
+		})
+		controller.accessDataService:RegisterFact(fact)
+		expect(controller.accessDataService:HasFact("selfDestructing")).toEqual(true)
+
+		fact:Destroy()
+
+		expect(controller.accessDataService:HasFact("selfDestructing")).toEqual(false)
+
+		controller:destroy()
+	end)
+
+	it("leaves a live report readable rather than calling into the wreckage", function()
+		-- The crash this fixes: a merge emission reaches for the layer's override behaviour and finds a
+		-- table with no metatable.
+		local controller = setup()
+		local player = controller.fakePlayer()
+		local fact = AccessFact.new("selfDestructing2", {
+			resolve = function()
+				return true
+			end,
+		})
+		controller.accessDataService:RegisterFact(fact)
+
+		local report = nil
+		controller.maid:GiveTask(
+			controller.accessDataService:ObserveFactReport(player, "selfDestructing2"):Subscribe(function(value)
+				report = value
+			end)
+		)
+		expect((report :: any).value).toEqual(true)
+
+		expect(function()
+			fact:Destroy()
+		end).never.toThrow()
+
+		controller:destroy()
+	end)
+
+	it("takes its feature out of the registry", function()
+		local controller = setup()
+		local feature = AccessFeature.anyOf("selfDestructingFeature", { "ownsGame" })
+		controller.accessDataService:RegisterFeature(feature)
+		expect(controller.accessDataService:GetFeature("selfDestructingFeature")).never.toEqual(nil)
+
+		feature:Destroy()
+
+		expect(controller.accessDataService:GetFeature("selfDestructingFeature")).toEqual(nil)
+
+		controller:destroy()
+	end)
+
+	it("does not mind the disposer being called as well", function()
+		-- The ordinary path still runs it, and both orders have to be fine.
+		local controller = setup()
+		local fact = AccessFact.new("selfDestructing3", {
+			resolve = function()
+				return nil
+			end,
+		})
+		local unregister = controller.accessDataService:RegisterFact(fact)
+
+		unregister()
+
+		expect(function()
+			fact:Destroy()
+			unregister()
+		end).never.toThrow()
+
+		controller:destroy()
+	end)
+end)

--- a/src/access/src/Shared/AccessPolicyService.lua
+++ b/src/access/src/Shared/AccessPolicyService.lua
@@ -141,7 +141,14 @@ function AccessPolicyService.RegisterPolicy(self: AccessPolicyService, policy: A
 		self:SetPolicyEnabled(policyName, true)
 	end
 
-	return function()
+	local unregistered = false
+
+	local function unregister()
+		if unregistered then
+			return
+		end
+		unregistered = true
+
 		-- Teardown order is not ours to control: a maid holding both this and the service bag may already
 		-- have destroyed the registry underneath us. Unregistering a policy from a dead service is a
 		-- no-op, not an error.
@@ -156,6 +163,12 @@ function AccessPolicyService.RegisterPolicy(self: AccessPolicyService, policy: A
 
 		remove()
 	end
+
+	-- A destroyed policy left registered would be applied to the next player who joined. See
+	-- AccessDataService.RegisterFact for why the object's own maid is the right hook.
+	policy._maid:GiveTask(unregister)
+
+	return unregister
 end
 
 --[=[


### PR DESCRIPTION
## What

A destroyed `AccessFact` stayed in the registry, so the merge still called methods on it. `BaseObject.Destroy` nils the metatable, so those calls don't return nothing — they fail:

```
AccessDataService:1097: attempt to call missing method 'GetServerOverrideBehavior' of table
```

Caught in egg-hunt CI, where it produced **10 tracebacks and zero failed assertions** — the harness reads any traceback as a failure, so the job went red with every test passing.

## Why it happens

Fallout from making these objects maid-owned in #759. One maid commonly holds both the object and its unregister disposer, and `Maid.DoCleaning` runs its tasks in no particular order — so relying on the caller to unregister before the object dies was relying on luck.

## The fix

Where the invariant belongs, rather than a nil-guard at the call site: `RegisterFact`, `RegisterFeature` and `RegisterPolicy` hook the object's **own** maid. `BaseObject.Destroy` runs that maid *before* nilling the metatable, so the object leaves the registry while it is still a usable object — a moment later, every method on it would fail instead. The disposers are idempotent, so the ordinary path calling them too is fine, in either order.

## Verification

`nevermore test --cloud` in `src/access` — 285/285. Four new tests: a destroyed fact leaves the registry, a live report survives one being destroyed under it, the same for features, and calling the disposer as well is harmless. luau-lsp 0 errors, stylua and selene clean.

Unblocks egg-hunt PR #315. Its other failure was a `PlayerMock` read in Raven's `owner` package, fixed separately in QuentyStudios/Raven#663.