### PR TITLE
fix(access): keep a destroyed layer out of a merge already in flight

### DIFF
--- a/src/access/src/Shared/AccessDataService.lua
+++ b/src/access/src/Shared/AccessDataService.lua
@@ -660,17 +660,20 @@ function AccessDataService.RegisterFact(self: AccessDataService, fact: AccessFac
 		end
 		unregistered = true
 
-		local current = self._layersByFactName[factName]
-		if not current then
-			return
-		end
-
-		local index = table.find(current, fact)
+		-- The array this fact was inserted into, not whatever the registry currently points at. Destroy
+		-- clears the registry table, but a live report closure still holds the array -- so going through
+		-- the registry would find nothing, leave the fact in that array, and let the next emission call a
+		-- method on an object whose metatable is about to be nil.
+		-- The array this fact was inserted into, not whatever the registry currently points at. The two come
+		-- apart in two ways: Destroy clears the registry table, and re-registering the same name after the
+		-- last layer left builds a fresh array. Either way a report already subscribed still holds the old
+		-- one, and going through the registry would leave the dead fact sitting in it.
+		local index = table.find(layers, fact)
 		if index then
-			table.remove(current, index)
+			table.remove(layers, index)
 		end
 
-		if #current == 0 then
+		if #layers == 0 and self._layersByFactName[factName] == layers then
 			self._layersByFactName[factName] = nil
 		end
 
@@ -1121,7 +1124,16 @@ function AccessDataService.ObserveFactReport(
 		Rx.map(function(latest: { [string]: any }): AccessFactReport
 			local overrides = (latest.overrides or EMPTY_OVERRIDE_STATE) :: OverrideState
 			local replicatedOverrides = (latest.replicatedOverrides or EMPTY_OVERRIDE_STATE) :: OverrideState
-			local behavior = if layers[1] then layers[1]:GetServerOverrideBehavior() else nil
+			-- Only a live layer is asked anything. Unregistering on destroy keeps dead ones out of here in
+			-- the first place, but teardown order is not ours to control and a merge already in flight must
+			-- not be taken down by a layer that went while it was running -- a destroyed BaseObject has no
+			-- metatable, so every method on it is missing rather than merely unhelpful.
+			-- Only a live layer is asked anything. Unregistering on destroy should keep dead ones out of
+			-- here, and this is the belt: teardown order is not ours to control, and a merge already in
+			-- flight must not be taken down by a layer that went while it was running. A destroyed
+			-- BaseObject has no metatable, so every method on it is missing rather than merely unhelpful.
+			local first = if AccessFact.isAccessFact(layers[1]) then layers[1] else nil
+			local behavior = if first then first:GetServerOverrideBehavior() else nil
 
 			-- An override set in this realm shadows one the server sent, so a local investigation is not
 			-- fighting a console session somebody left running elsewhere.
@@ -1156,6 +1168,10 @@ function AccessDataService.ObserveFactReport(
 			end
 
 			for index, layer in layers do
+				if not AccessFact.isAccessFact(layer) then
+					continue
+				end
+
 				table.insert(
 					contributions,
 					{
@@ -1642,6 +1658,12 @@ function AccessDataService.Destroy(self: AccessDataService): ()
 		overrides:Destroy()
 	end
 	table.clear(self._overridesByPlayer :: any)
+
+	-- Emptied, not just dropped: a report already subscribed holds the array itself, and clearing only the
+	-- keys would leave it pointing at layers about to lose their metatables.
+	for _, layers in self._layersByFactName do
+		table.clear(layers)
+	end
 	table.clear(self._layersByFactName :: any)
 
 	self._maid:DoCleaning()

--- a/src/access/src/Shared/AccessFeatureExtension.spec.lua
+++ b/src/access/src/Shared/AccessFeatureExtension.spec.lua
@@ -583,3 +583,88 @@ describe("a registered object that gets destroyed", function()
 		controller:destroy()
 	end)
 end)
+
+describe("a layer destroyed under a live report", function()
+	it("stops contributing instead of taking the next merge down with it", function()
+		-- The crash this guards is not the destroy itself, it is the *next* emission: a report already
+		-- subscribed holds the layer array, and a destroyed BaseObject has no metatable, so every method on
+		-- it is missing rather than merely unhelpful. Something always emits afterwards -- an override, a
+		-- player leaving, another layer registering.
+		local maid = Maid.new()
+		local serviceBag = maid:Add(ServiceBag.new())
+		local accessDataService: any = serviceBag:GetService(AccessDataService)
+		serviceBag:Init()
+		serviceBag:Start()
+
+		local player = maid:Add(PlayerMock.new()) :: any
+		maid:GiveTask(accessDataService:RegisterFact(maid:Add(AccessFact.new("layered", {
+			resolve = function()
+				return false
+			end,
+		}))))
+
+		-- A second layer, so destroying the first leaves the fact registered and the report alive.
+		local elevated = AccessFact.new("layered", {
+			resolve = function()
+				return true
+			end,
+			priority = AccessFactPriority.ELEVATED,
+			source = "allowlist",
+		})
+		accessDataService:RegisterFact(elevated)
+
+		local report = nil
+		maid:GiveTask(accessDataService:ObserveFactReport(player, "layered"):Subscribe(function(value)
+			report = value
+		end))
+		expect((report :: any).value).toEqual(true)
+
+		elevated:Destroy()
+
+		-- Forces the merge to run again over the array that layer was in.
+		expect(function()
+			maid:GiveTask(accessDataService:SetFactOverride(player, "layered", true))
+		end).never.toThrow()
+
+		expect((report :: any).value).toEqual(true)
+
+		maid:DoCleaning()
+	end)
+
+	it("takes the destroyed layer out of the readout rather than leaving a dead row", function()
+		local maid = Maid.new()
+		local serviceBag = maid:Add(ServiceBag.new())
+		local accessDataService: any = serviceBag:GetService(AccessDataService)
+		serviceBag:Init()
+		serviceBag:Start()
+
+		local player = maid:Add(PlayerMock.new()) :: any
+		maid:GiveTask(accessDataService:RegisterFact(maid:Add(AccessFact.new("layered2", {
+			resolve = function()
+				return false
+			end,
+		}))))
+
+		local elevated = AccessFact.new("layered2", {
+			resolve = function()
+				return true
+			end,
+			priority = AccessFactPriority.ELEVATED,
+			source = "allowlist",
+		})
+		accessDataService:RegisterFact(elevated)
+
+		local report = nil
+		maid:GiveTask(accessDataService:ObserveFactReport(player, "layered2"):Subscribe(function(value)
+			report = value
+		end))
+
+		local before = #(report :: any).layers
+		elevated:Destroy()
+		maid:GiveTask(accessDataService:SetFactOverride(player, "layered2", nil))
+
+		expect(#(report :: any).layers).toEqual(before - 1)
+
+		maid:DoCleaning()
+	end)
+end)


### PR DESCRIPTION
Follow-up to #761, which fixed the common case but not the one still failing in egg-hunt CI. That run went from 45 tracebacks to 9 — the Raven half cleared, this one did not:

```
AccessDataService:1124: attempt to call missing method 'GetServerOverrideBehavior' of table
```

## What was still wrong

**The disposer looked the fact up through the registry.** The registry and the array a subscribed report holds come apart in two ways: `Destroy` clears the registry table, and re-registering a name after its last layer left builds a fresh array. Either way `self._layersByFactName[factName]` no longer points at the array the report closure captured — so the lookup finds nothing, returns early, and the dead fact sits in that array until the next emission calls a method on it. By then `BaseObject.Destroy` has nilled its metatable, so the method is *missing* rather than merely unhelpful. It now removes from the array it inserted into.

**The merge now reads only live layers.** `AccessFact.isAccessFact` is false for a destroyed fact, so a dead one stops contributing instead of taking the merge down. That's the belt, not the braces — teardown order isn't ours to control, and a merge in flight shouldn't be takeable down by a layer that went while it was running.

## What is and isn't proven

`nevermore test --cloud` — 287/287, luau-lsp 0 errors, stylua and selene clean. Two new tests cover a layer destroyed under a live report: the merge keeps working, and the readout drops the row rather than showing a dead one.

**Being straight about the limit:** I could not reproduce the exact CI sequence in a unit test. I wrote three attempts that passed with the fix fully reverted, so I threw them away rather than ship green-looking cover. The tests here assert real behaviour but would not have caught this specific bug. The proof will be egg-hunt #315 going from 9 tracebacks to 0 — if it doesn't, this diagnosis is wrong and I'd rather find that out from CI than from a test I talked myself into.