### PR TITLE
fix(access): make client-realm policies actually run, and give them an off switch

### DIFF
--- a/src/access/src/Shared/AccessPolicyService.lua
+++ b/src/access/src/Shared/AccessPolicyService.lua
@@ -129,26 +129,20 @@ function AccessPolicyService.Start(self: AccessPolicyService): ()
 end
 
 --[[
-	Publishes which policies are switched on, so a console session on the server reaches the realm the
-	policy actually runs in.
+	Publishes which policies are switched on, so a server-side console reaches the realm a policy runs in.
 
-	This is the half that was missing. `AccessPolicyServiceInterface` is query-only on purpose -- letting
-	anything that merely found an interface start a kick would make "can see the registry" and "can
-	enforce" the same permission -- but that left a client-realm policy with no off switch at all: the
-	command is server-side, the consequence is client-side, and nothing joined them. So enablement
-	replicates one way, server to client, as state rather than as a callable.
+	State rather than a tie method: [AccessPolicyServiceInterface] stays query-only, so finding the
+	registry is not permission to start enforcing.
 
-	The whole effective map is published rather than the changes to it, and includes the policies that are
-	*off*: a client whose own `isEnabledByDefault` switched something on has to hear that the server says
-	otherwise, and "absent from the payload" cannot carry that.
+	The whole effective map is published, including the policies that are *off* -- a client whose own
+	`isEnabledByDefault` switched something on has to hear that the server says otherwise, and
+	absent-from-the-payload cannot carry that.
 ]]
 function AccessPolicyService._replicatePolicyEnabled(self: AccessPolicyService): ()
 	local replicated: any = JSONAttributeValue.new(ReplicatedStorage, REPLICATED_ENABLED_ATTRIBUTE, {})
 	local lastPublished: string? = nil
 
-	-- Cleared when this service goes, but only if what is there is still ours -- another live service may
-	-- have published since, and clearing unconditionally would switch off policies somebody is relying on.
-	-- Same reasoning as AccessDataService's feature-fact publication.
+	-- Only if what is there is still ours: another live service may have published since.
 	self._maid:GiveTask(function()
 		if lastPublished ~= nil and ReplicatedStorage:GetAttribute(REPLICATED_ENABLED_ATTRIBUTE) == lastPublished then
 			replicated.Value = nil
@@ -165,9 +159,8 @@ function AccessPolicyService._replicatePolicyEnabled(self: AccessPolicyService):
 		lastPublished = ReplicatedStorage:GetAttribute(REPLICATED_ENABLED_ATTRIBUTE)
 	end
 
-	-- Both, because either can change what the map should say: a registration adds a name, and a toggle
-	-- changes a value. `_enabled` only ever holds `true` -- SetPolicyEnabled removes the key rather than
-	-- storing false -- so watching its key list catches every toggle.
+	-- `_enabled` only ever holds `true` (SetPolicyEnabled removes the key rather than storing false), so
+	-- its key list catches every toggle.
 	self._maid:GiveTask(self._policies:ObserveKeyList():Subscribe(publish))
 	self._maid:GiveTask(self._enabled:ObserveKeyList():Subscribe(publish))
 end
@@ -179,7 +172,7 @@ function AccessPolicyService._consumeReplicatedPolicyEnabled(self: AccessPolicyS
 		self:SetReplicatedPolicyEnabled(payload or {})
 	end))
 
-	-- A policy registered after the payload landed still picks it up. Neither order is ours to control.
+	-- A policy registered after the payload landed still picks it up.
 	self._maid:GiveTask(self._policies:ObserveKeyList():Subscribe(function()
 		self:_reconcileReplicatedPolicyEnabled()
 	end))
@@ -189,8 +182,7 @@ end
 	Applies what the server says each policy's switch is set to. The entry point the client's replication
 	arrives through, and the seam a test drives directly.
 
-	The server wins where it has spoken. A policy it has never heard of -- one registered only in this
-	realm -- is left entirely alone.
+	A policy the server never registered is left alone.
 
 	@param payload { [string]: boolean }
 ]=]
@@ -428,16 +420,10 @@ function AccessPolicyService.IsPolicyActiveForPlayer(
 end
 
 --[[
-	The realm this **bag** was told it is, not the one RunService reports.
+	The realm this bag was told it is, not the one RunService reports. The two come apart wherever a bag
+	is told its realm, and reading RunService there means a client-realm policy silently never runs.
 
-	The two come apart wherever a bag is told its realm -- a test booting both halves in one DataModel is
-	the whole reason [TieRealmService] exists -- and reading RunService there means a client-realm policy
-	never runs however the bag is configured. That failure is silent: the policy is registered, listed,
-	enabled, and simply does nothing. Every other realm branch in this package already reads the tie
-	realm; this one was the odd one out.
-
-	Anything not explicitly the client counts as the server, matching how [AccessDataService] branches, so
-	a shared bag still runs server-realm enforcement.
+	Anything not explicitly the client counts as the server, matching how [AccessDataService] branches.
 ]]
 function AccessPolicyService._runsHere(self: AccessPolicyService, policy: AccessPolicy.AccessPolicy): boolean
 	return policy:RunsInRealm(self._tieRealmService:GetTieRealm() ~= TieRealms.CLIENT)

--- a/src/access/src/Shared/AccessPolicyService.lua
+++ b/src/access/src/Shared/AccessPolicyService.lua
@@ -22,7 +22,6 @@ local require = require(script.Parent.loader).load(script)
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local RunService = game:GetService("RunService")
 
 local AccessDataService = require("AccessDataService")
 local AccessFactNames = require("AccessFactNames")
@@ -39,6 +38,7 @@ local Promise = require("Promise")
 local Rx = require("Rx")
 local ServiceBag = require("ServiceBag")
 local TieRealmService = require("TieRealmService")
+local TieRealms = require("TieRealms")
 
 local AccessPolicyService = {}
 AccessPolicyService.ServiceName = "AccessPolicyService"
@@ -328,8 +328,24 @@ function AccessPolicyService.IsPolicyActiveForPlayer(
 
 	return policy ~= nil
 		and self:IsPolicyEnabled(policyName)
-		and policy:RunsInRealm(RunService:IsServer())
+		and self:_runsHere(policy)
 		and self._playerMaids[player] ~= nil
+end
+
+--[[
+	The realm this **bag** was told it is, not the one RunService reports.
+
+	The two come apart wherever a bag is told its realm -- a test booting both halves in one DataModel is
+	the whole reason [TieRealmService] exists -- and reading RunService there means a client-realm policy
+	never runs however the bag is configured. That failure is silent: the policy is registered, listed,
+	enabled, and simply does nothing. Every other realm branch in this package already reads the tie
+	realm; this one was the odd one out.
+
+	Anything not explicitly the client counts as the server, matching how [AccessDataService] branches, so
+	a shared bag still runs server-realm enforcement.
+]]
+function AccessPolicyService._runsHere(self: AccessPolicyService, policy: AccessPolicy.AccessPolicy): boolean
+	return policy:RunsInRealm(self._tieRealmService:GetTieRealm() ~= TieRealms.CLIENT)
 end
 
 --[=[
@@ -444,7 +460,7 @@ function AccessPolicyService._applyPolicy(self: AccessPolicyService, policyName:
 
 	-- Registered here, but not ours to run. Enabling a server policy from the client's registry must not
 	-- half-enforce it locally.
-	if not policy:RunsInRealm(RunService:IsServer()) then
+	if not self:_runsHere(policy) then
 		return nil
 	end
 

--- a/src/access/src/Shared/AccessPolicyService.lua
+++ b/src/access/src/Shared/AccessPolicyService.lua
@@ -31,6 +31,7 @@ local AccessPolicy = require("AccessPolicy")
 local AccessPolicyContextUtils = require("AccessPolicyContextUtils")
 local AccessPolicyNames = require("AccessPolicyNames")
 local AccessPolicyServiceInterface = require("AccessPolicyServiceInterface")
+local JSONAttributeValue = require("JSONAttributeValue")
 local Maid = require("Maid")
 local Observable = require("Observable")
 local ObservableMap = require("ObservableMap")
@@ -39,6 +40,8 @@ local Rx = require("Rx")
 local ServiceBag = require("ServiceBag")
 local TieRealmService = require("TieRealmService")
 local TieRealms = require("TieRealms")
+
+local REPLICATED_ENABLED_ATTRIBUTE = "AccessPolicyEnabled"
 
 local AccessPolicyService = {}
 AccessPolicyService.ServiceName = "AccessPolicyService"
@@ -54,6 +57,9 @@ export type AccessPolicyService = typeof(setmetatable(
 		-- One maid per player, holding one task per enabled policy, keyed by policy name so a policy can be
 		-- switched off for everyone without disturbing the others.
 		_playerMaids: { [any]: any },
+		-- What the server says each policy's switch is set to. Empty on the server itself, which holds the
+		-- real thing in _enabled.
+		_replicatedEnabled: { [string]: boolean },
 		_alive: boolean,
 	},
 	{} :: typeof({ __index = AccessPolicyService })
@@ -74,6 +80,7 @@ function AccessPolicyService.Init(self: AccessPolicyService, serviceBag: Service
 	self._enabled = enabled :: any
 	self._maid:GiveTask(enabled)
 	self._playerMaids = {}
+	self._replicatedEnabled = {}
 	self._alive = true
 
 	self:_registerBuiltInPolicies()
@@ -107,11 +114,99 @@ function AccessPolicyService.Start(self: AccessPolicyService): ()
 		self:RemovePlayer(player)
 	end))
 
+	-- Branching on the tie realm rather than RunService, for the same reason _runsHere does.
+	if self._tieRealmService:GetTieRealm() == TieRealms.CLIENT then
+		self:_consumeReplicatedPolicyEnabled()
+	else
+		self:_replicatePolicyEnabled()
+	end
+
 	-- Same adornee as AccessDataServiceInterface: this is a singleton, and ReplicatedStorage is the one
 	-- instance both realms already agree on.
 	self._maid:GiveTask(
 		AccessPolicyServiceInterface:Implement(ReplicatedStorage, self :: any, self._tieRealmService:GetTieRealm())
 	)
+end
+
+--[[
+	Publishes which policies are switched on, so a console session on the server reaches the realm the
+	policy actually runs in.
+
+	This is the half that was missing. `AccessPolicyServiceInterface` is query-only on purpose -- letting
+	anything that merely found an interface start a kick would make "can see the registry" and "can
+	enforce" the same permission -- but that left a client-realm policy with no off switch at all: the
+	command is server-side, the consequence is client-side, and nothing joined them. So enablement
+	replicates one way, server to client, as state rather than as a callable.
+
+	The whole effective map is published rather than the changes to it, and includes the policies that are
+	*off*: a client whose own `isEnabledByDefault` switched something on has to hear that the server says
+	otherwise, and "absent from the payload" cannot carry that.
+]]
+function AccessPolicyService._replicatePolicyEnabled(self: AccessPolicyService): ()
+	local replicated: any = JSONAttributeValue.new(ReplicatedStorage, REPLICATED_ENABLED_ATTRIBUTE, {})
+	local lastPublished: string? = nil
+
+	-- Cleared when this service goes, but only if what is there is still ours -- another live service may
+	-- have published since, and clearing unconditionally would switch off policies somebody is relying on.
+	-- Same reasoning as AccessDataService's feature-fact publication.
+	self._maid:GiveTask(function()
+		if lastPublished ~= nil and ReplicatedStorage:GetAttribute(REPLICATED_ENABLED_ATTRIBUTE) == lastPublished then
+			replicated.Value = nil
+		end
+	end)
+
+	local function publish()
+		local payload = {}
+		for _, policyName in self:GetPolicyNames() do
+			payload[policyName] = self:IsPolicyEnabled(policyName)
+		end
+
+		replicated.Value = payload
+		lastPublished = ReplicatedStorage:GetAttribute(REPLICATED_ENABLED_ATTRIBUTE)
+	end
+
+	-- Both, because either can change what the map should say: a registration adds a name, and a toggle
+	-- changes a value. `_enabled` only ever holds `true` -- SetPolicyEnabled removes the key rather than
+	-- storing false -- so watching its key list catches every toggle.
+	self._maid:GiveTask(self._policies:ObserveKeyList():Subscribe(publish))
+	self._maid:GiveTask(self._enabled:ObserveKeyList():Subscribe(publish))
+end
+
+function AccessPolicyService._consumeReplicatedPolicyEnabled(self: AccessPolicyService): ()
+	local replicated: any = JSONAttributeValue.new(ReplicatedStorage, REPLICATED_ENABLED_ATTRIBUTE, {})
+
+	self._maid:GiveTask(replicated:Observe():Subscribe(function(payload: any)
+		self:SetReplicatedPolicyEnabled(payload or {})
+	end))
+
+	-- A policy registered after the payload landed still picks it up. Neither order is ours to control.
+	self._maid:GiveTask(self._policies:ObserveKeyList():Subscribe(function()
+		self:_reconcileReplicatedPolicyEnabled()
+	end))
+end
+
+--[=[
+	Applies what the server says each policy's switch is set to. The entry point the client's replication
+	arrives through, and the seam a test drives directly.
+
+	The server wins where it has spoken. A policy it has never heard of -- one registered only in this
+	realm -- is left entirely alone.
+
+	@param payload { [string]: boolean }
+]=]
+function AccessPolicyService.SetReplicatedPolicyEnabled(self: AccessPolicyService, payload: { [string]: boolean }): ()
+	assert(type(payload) == "table", "Bad payload")
+
+	self._replicatedEnabled = payload
+	self:_reconcileReplicatedPolicyEnabled()
+end
+
+function AccessPolicyService._reconcileReplicatedPolicyEnabled(self: AccessPolicyService): ()
+	for policyName, enabled in self._replicatedEnabled do
+		if self._policies:ContainsKey(policyName) and self:IsPolicyEnabled(policyName) ~= enabled then
+			self:SetPolicyEnabled(policyName, enabled)
+		end
+	end
 end
 
 --[=[

--- a/src/access/src/Shared/AccessPolicyService.spec.lua
+++ b/src/access/src/Shared/AccessPolicyService.spec.lua
@@ -26,9 +26,8 @@ local describe = Jest.Globals.describe
 local expect = Jest.Globals.expect
 local it = Jest.Globals.it
 
--- `tieRealm` is what the bag is *told* it is, which is not always what RunService reports -- a test
--- booting both halves in one DataModel is the whole reason that distinction exists. Passing it is how a
--- client-realm policy can be exercised at all from a runner that is technically a server.
+-- `tieRealm` is what the bag is told it is, which is how a client-realm policy can be exercised from a
+-- runner that is technically a server.
 local function setup(tieRealm: string?)
 	local maid = Maid.new()
 	local serviceBag = maid:Add(ServiceBag.new())
@@ -660,8 +659,7 @@ describe("AccessPolicyService.IsPolicyActiveForPlayer", function()
 		controller:destroy()
 	end)
 
-	-- The realm has to come from the bag, not from RunService. Read from RunService, a client-realm policy
-	-- in a bag told it is a client never runs: registered, listed, enabled, and silently doing nothing.
+	-- Read from RunService, this policy is registered, listed, enabled -- and silently does nothing.
 	it("runs a client-realm policy in a bag that was told it is a client", function()
 		local controller = setup(TieRealms.CLIENT)
 		local applied = { n = 0 }

--- a/src/access/src/Shared/AccessPolicyService.spec.lua
+++ b/src/access/src/Shared/AccessPolicyService.spec.lua
@@ -19,14 +19,24 @@ local Maid = require("Maid")
 local PlayerMock = require("PlayerMock")
 local PromiseTestUtils = require("PromiseTestUtils")
 local ServiceBag = require("ServiceBag")
+local TieRealmService = require("TieRealmService")
+local TieRealms = require("TieRealms")
 
 local describe = Jest.Globals.describe
 local expect = Jest.Globals.expect
 local it = Jest.Globals.it
 
-local function setup()
+-- `tieRealm` is what the bag is *told* it is, which is not always what RunService reports -- a test
+-- booting both halves in one DataModel is the whole reason that distinction exists. Passing it is how a
+-- client-realm policy can be exercised at all from a runner that is technically a server.
+local function setup(tieRealm: string?)
 	local maid = Maid.new()
 	local serviceBag = maid:Add(ServiceBag.new())
+	if tieRealm then
+		-- Before Init, which only infers a realm when it has not been given one.
+		local tieRealmService: any = serviceBag:GetService(TieRealmService)
+		tieRealmService:SetTieRealm(tieRealm)
+	end
 	local accessDataService: AccessDataService.AccessDataService = serviceBag:GetService(AccessDataService) :: any
 	local accessPolicyService: AccessPolicyService.AccessPolicyService =
 		serviceBag:GetService(AccessPolicyService) :: any
@@ -646,6 +656,60 @@ describe("AccessPolicyService.IsPolicyActiveForPlayer", function()
 		controller.accessPolicyService:AddPlayer(player)
 
 		expect(controller.accessPolicyService:IsPolicyActiveForPlayer(player, "clientOnly")).toEqual(false)
+
+		controller:destroy()
+	end)
+
+	-- The realm has to come from the bag, not from RunService. Read from RunService, a client-realm policy
+	-- in a bag told it is a client never runs: registered, listed, enabled, and silently doing nothing.
+	it("runs a client-realm policy in a bag that was told it is a client", function()
+		local controller = setup(TieRealms.CLIENT)
+		local applied = { n = 0 }
+		controller.maid:GiveTask(
+			controller.accessPolicyService:RegisterPolicy(controller.maid:Add(AccessPolicy.new(controller.serviceBag, {
+				policyName = "clientOnly",
+				realm = AccessPolicyRealm.CLIENT,
+				isEnabledByDefault = true,
+				apply = function()
+					applied.n += 1
+
+					return function()
+						applied.n -= 1
+					end
+				end,
+			})))
+		)
+
+		local player = controller.fakePlayer()
+		controller.accessPolicyService:AddPlayer(player)
+
+		expect(applied.n).toEqual(1)
+		expect(controller.accessPolicyService:IsPolicyActiveForPlayer(player, "clientOnly")).toEqual(true)
+
+		controller:destroy()
+	end)
+
+	it("still refuses a server-realm policy in a bag that was told it is a client", function()
+		local controller = setup(TieRealms.CLIENT)
+		local applied = { n = 0 }
+		controller.maid:GiveTask(
+			controller.accessPolicyService:RegisterPolicy(controller.maid:Add(AccessPolicy.new(controller.serviceBag, {
+				policyName = "serverOnly",
+				realm = AccessPolicyRealm.SERVER,
+				isEnabledByDefault = true,
+				apply = function()
+					applied.n += 1
+
+					return nil
+				end,
+			})))
+		)
+
+		local player = controller.fakePlayer()
+		controller.accessPolicyService:AddPlayer(player)
+
+		expect(applied.n).toEqual(0)
+		expect(controller.accessPolicyService:IsPolicyActiveForPlayer(player, "serverOnly")).toEqual(false)
 
 		controller:destroy()
 	end)

--- a/src/access/src/Shared/AccessRealmReplication.spec.lua
+++ b/src/access/src/Shared/AccessRealmReplication.spec.lua
@@ -430,8 +430,7 @@ end)
 
 local policyCounter = 0
 
--- Returns as soon as the client agrees, and returns whatever it has if it never does -- so a failure
--- prints the real state rather than a timeout.
+-- Returns whatever the client has if the realms never agree, so a failure prints the real state.
 local function waitForPolicyEnabled(accessPolicyService: any, policyName: string, expected: boolean): boolean
 	for _ = 1, CONVERGE_FRAMES do
 		if accessPolicyService:IsPolicyEnabled(policyName) == expected then
@@ -471,8 +470,7 @@ local function setupPolicies()
 		register = function(self, realmBag: any, isEnabledByDefault: boolean)
 			local policy = maid:Add(AccessPolicy.new(realmBag.serviceBag, {
 				policyName = self.policyName,
-				-- Client realm throughout: a server-realm policy would be togglable from the console
-				-- already, and the gap this closes is the one where the consequence is on the other side.
+				-- Client realm: a server-realm policy was already togglable from the console.
 				realm = AccessPolicyRealm.CLIENT,
 				isEnabledByDefault = isEnabledByDefault,
 				apply = function()
@@ -491,8 +489,7 @@ end
 
 describe("policy enablement across realms", function()
 	it("carries a policy switched off on the server to the client", function()
-		-- The gap this closes: the console command is server-side and a client-realm consequence is not,
-		-- so before this there was no way to switch off the policy you were trying to test around.
+		-- The console command is server-side and this consequence is not.
 		local controller = setupPolicies()
 		controller:register(controller.server, true)
 		controller:register(controller.client, true)
@@ -517,8 +514,7 @@ describe("policy enablement across realms", function()
 	end)
 
 	it("leaves a policy the server never registered alone", function()
-		-- Replication widens what the client knows; it does not own the client's registry. A policy that
-		-- exists only in this realm keeps whatever it was built with.
+		-- Replication widens what the client knows; it does not own the client's registry.
 		local controller = setupPolicies()
 		controller:register(controller.client, true)
 

--- a/src/access/src/Shared/AccessRealmReplication.spec.lua
+++ b/src/access/src/Shared/AccessRealmReplication.spec.lua
@@ -23,6 +23,9 @@ local AccessDataService = require("AccessDataService")
 local AccessFact = require("AccessFact")
 local AccessFactServerOverrideBehavior = require("AccessFactServerOverrideBehavior")
 local AccessFeature = require("AccessFeature")
+local AccessPolicy = require("AccessPolicy")
+local AccessPolicyRealm = require("AccessPolicyRealm")
+local AccessPolicyService = require("AccessPolicyService")
 local AccessService = require("AccessService")
 local AccessServiceClient = require("AccessServiceClient")
 local AccessStateUtils = require("AccessStateUtils")
@@ -422,5 +425,109 @@ describe("the published composition and the service that wrote it", function()
 		controller:destroy()
 
 		expect(ReplicatedStorage:GetAttribute("AccessFeatureFactNames")).toEqual(nil)
+	end)
+end)
+
+local policyCounter = 0
+
+-- Returns as soon as the client agrees, and returns whatever it has if it never does -- so a failure
+-- prints the real state rather than a timeout.
+local function waitForPolicyEnabled(accessPolicyService: any, policyName: string, expected: boolean): boolean
+	for _ = 1, CONVERGE_FRAMES do
+		if accessPolicyService:IsPolicyEnabled(policyName) == expected then
+			return expected
+		end
+
+		task.wait()
+	end
+
+	return accessPolicyService:IsPolicyEnabled(policyName)
+end
+
+local function setupPolicies()
+	local maid = Maid.new()
+
+	local function bag(tieRealm: string)
+		local serviceBag = maid:Add(ServiceBag.new());
+		(serviceBag:GetService(TieRealmService) :: any):SetTieRealm(tieRealm)
+		local accessPolicyService = serviceBag:GetService(AccessPolicyService) :: any
+		serviceBag:Init()
+		serviceBag:Start()
+
+		return { serviceBag = serviceBag, accessPolicyService = accessPolicyService }
+	end
+
+	local server = bag(TieRealms.SERVER)
+	local client = bag(TieRealms.CLIENT)
+
+	policyCounter += 1
+
+	return {
+		maid = maid,
+		server = server,
+		client = client,
+		-- Unique per test: the registries are per-bag, but the attribute they meet on is not.
+		policyName = `chapterPaywall{policyCounter}`,
+		register = function(self, realmBag: any, isEnabledByDefault: boolean)
+			local policy = maid:Add(AccessPolicy.new(realmBag.serviceBag, {
+				policyName = self.policyName,
+				-- Client realm throughout: a server-realm policy would be togglable from the console
+				-- already, and the gap this closes is the one where the consequence is on the other side.
+				realm = AccessPolicyRealm.CLIENT,
+				isEnabledByDefault = isEnabledByDefault,
+				apply = function()
+					return nil
+				end,
+			}))
+			maid:GiveTask(realmBag.accessPolicyService:RegisterPolicy(policy))
+
+			return policy
+		end,
+		destroy = function(_self)
+			maid:DoCleaning()
+		end,
+	}
+end
+
+describe("policy enablement across realms", function()
+	it("carries a policy switched off on the server to the client", function()
+		-- The gap this closes: the console command is server-side and a client-realm consequence is not,
+		-- so before this there was no way to switch off the policy you were trying to test around.
+		local controller = setupPolicies()
+		controller:register(controller.server, true)
+		controller:register(controller.client, true)
+
+		controller.server.accessPolicyService:SetPolicyEnabled(controller.policyName, false)
+
+		expect(waitForPolicyEnabled(controller.client.accessPolicyService, controller.policyName, false)).toEqual(false)
+
+		controller:destroy()
+	end)
+
+	it("carries a policy switched on on the server to the client", function()
+		local controller = setupPolicies()
+		controller:register(controller.server, false)
+		controller:register(controller.client, false)
+
+		controller.server.accessPolicyService:SetPolicyEnabled(controller.policyName, true)
+
+		expect(waitForPolicyEnabled(controller.client.accessPolicyService, controller.policyName, true)).toEqual(true)
+
+		controller:destroy()
+	end)
+
+	it("leaves a policy the server never registered alone", function()
+		-- Replication widens what the client knows; it does not own the client's registry. A policy that
+		-- exists only in this realm keeps whatever it was built with.
+		local controller = setupPolicies()
+		controller:register(controller.client, true)
+
+		for _ = 1, 20 do
+			task.wait()
+		end
+
+		expect(controller.client.accessPolicyService:IsPolicyEnabled(controller.policyName)).toEqual(true)
+
+		controller:destroy()
 	end)
 end)


### PR DESCRIPTION
Two changes to `AccessPolicyService`, both about the same thing: a policy whose consequence runs on the client was unusable.

## 1. `fix`: run policies against the bag's tie realm, not RunService

`AccessPolicyService` decided where a policy runs by asking `RunService:IsServer()`. Every other realm branch in this package reads `TieRealmService`, and `AccessDataService` says why in as many words:

> Branching on the tie realm rather than on RunService, for the same reason the tie itself does: it is the one realm answer a service bag can be told, which is what lets both halves be booted together and actually exercised against each other.

The two come apart wherever a bag is *told* its realm — a test booting both halves in one DataModel is the whole reason `TieRealmService` exists. In that setup a `CLIENT`-realm policy never ran.

The failure was silent rather than loud: the policy is registered, appears in `GetPolicyNames`, reports `true` from `IsPolicyEnabled`, shows up in `GetDebugState` — and does nothing. `IsPolicyActiveForPlayer` is the one method that would have contradicted that, and it read `RunService` too, so the readout agreed with the bug.

Both call sites now go through one `_runsHere`. Anything not explicitly `TieRealms.CLIENT` counts as the server, matching how `AccessDataService` branches, so a shared bag still runs server-realm enforcement. No behaviour change in a real client or a real server, where the two agree.

## 2. `feat`: replicate policy enablement from server to client

Once a client-realm policy runs, it still has no off switch. `access-policy <name> off` is a server-side command (`AccessCommandService` is `@server`), `AccessPolicyServiceInterface` is query-only on purpose, and nothing joined the two — so switching off a client-realm policy did nothing, silently, with both realms' readouts agreeing it was off.

That matters most for what policies are *for*: taking one layer of enforcement out of the way to prove the layer beneath it catches what the first one missed. A layer you cannot disable cannot be tested around.

Enablement now replicates one way, server → client, as state on `ReplicatedStorage` — deliberately **not** a new tie method, so the interface's rule holds: finding the registry is still not permission to start enforcing.

Two details worth reviewing:

- **The whole effective map is published, including the policies that are off.** A client whose own `isEnabledByDefault` switched something on has to hear that the server says otherwise, and "absent from the payload" cannot carry that.
- **A policy the server never registered is left alone.** Replication widens what the client knows; it does not own the client's registry. Same rule as `_reconcileReplicatedFeatureFacts`.

`SetReplicatedPolicyEnabled` is exposed as the seam a test drives directly, matching `AccessDataService.SetReplicatedFactOverrides`.

## Tests

`nevermore test --cloud`: **292/292** (was 287).

`AccessPolicyService.spec` — an optional `tieRealm` argument on `setup()` so a client bag can be built at all:
- a client-realm policy **runs** in a bag told it is a client, and `IsPolicyActiveForPlayer` agrees
- a server-realm policy in that same bag still does **not** run

`AccessRealmReplication.spec` — both halves booted, exercised through the real transport:
- a policy switched **off** on the server reaches the client
- a policy switched **on** on the server reaches the client
- a policy the server never registered keeps what it was built with

## Found by

Building the enforcement layer for a game: a client-realm "hold the paywall up while this player may not play here" policy. It could not be exercised from the test runner (1), and could not be switched off to test the server-side layer beneath it (2).

