### PR TITLE
feat(saveslot): let save-slot commands address ephemeral slots and persist them

### DIFF
--- a/src/saveslot/src/Server/Binders/HasSaveSlots.lua
+++ b/src/saveslot/src/Server/Binders/HasSaveSlots.lua
@@ -40,13 +40,6 @@ export type SummaryProvider = (Player, DataStoreStage.DataStoreStage) -> Observa
 -- identity, so it never collides with a real value (even an empty table) a provider might emit.
 local NONE = {}
 
--- An ephemeral slot carries no meaningful index -- a real slot's index positions it in the save list and
--- routes its store, neither of which applies to a throwaway slot. The authoritative "is ephemeral"
--- discriminator is the slot's own IsEphemeral property (see _isEphemeral), and every index-accounting path
--- skips ephemeral slots, so this value never routes anything and any number of ephemeral slots can coexist.
--- 0 is used because a real index is always >= 1 (DEFAULT_SLOT_INDEX is 1, PromiseCreateSlot rejects < 1).
-local EPHEMERAL_SLOT_INDEX = 0
-
 -- The caller-supplied fields for a new slot. SlotId and SlotIndex are assigned by PromiseCreateSlot
 -- itself (from a fresh GUID and the slotIndex argument), so they are never taken from here.
 export type SaveSlotCreateMetadata = {
@@ -458,7 +451,7 @@ function HasSaveSlots.PromiseSelectTransferableEphemeralSlot(
 			local slotId = HttpService:GenerateGUID(false)
 			self:_buildSlot(slotId, {
 				SlotId = slotId,
-				SlotIndex = EPHEMERAL_SLOT_INDEX,
+				SlotIndex = SaveSlotConstants.EPHEMERAL_SLOT_INDEX,
 				SlotName = export.slotName or "Transfer",
 				CreatedTime = os.time(),
 				Summary = export.summary,
@@ -638,6 +631,12 @@ end
 	copying its saved data. Resolves to the new slot's id. The copy is not selected,
 	its metadata (playtime, timestamps) starts fresh, and its name is suffixed with
 	" (Copy)". Rejects when the source slot is missing or every index is in use.
+
+	An ephemeral slot may be duplicated: the copy is a real, persisted slot seeded with the ephemeral
+	slot's live in-memory data, which is how a throwaway session is turned into a save. It keeps the
+	source's name unsuffixed (the copy is the first real slot for that session, not a second copy of an
+	existing save) and, like any duplicate, is not selected -- see
+	[HasSaveSlots.PromisePersistEphemeralSlot] for the version that continues play on the new slot.
 ]=]
 function HasSaveSlots.PromiseDuplicateSlot(
 	self: HasSaveSlots,
@@ -649,9 +648,7 @@ function HasSaveSlots.PromiseDuplicateSlot(
 			return (Promise :: any).rejected(`Slot \{{slotId}\} not found`)
 		end
 
-		if self:_isEphemeral(slotId) then
-			return (Promise :: any).rejected("Cannot duplicate an ephemeral slot")
-		end
+		local sourceIsEphemeral = self:_isEphemeral(slotId)
 
 		-- Lowest free positive index, filling gaps left by deletions (mirrors PromiseSelectNewSaveSlot).
 		local usedIndices = {}
@@ -677,34 +674,89 @@ function HasSaveSlots.PromiseDuplicateSlot(
 			local slotData = if type(sourceData) == "table" then table.clone(sourceData) else {}
 			slotData[SaveSlotConstants.SYSTEM_STORE_KEY] = nil
 
-			return self:PromiseCreateSlot(freeIndex, {
-				SlotName = `{sourceMetadata.SlotName} (Copy)`,
-				Summary = sourceMetadata.Summary,
-			}):Then(function(newSlotId: SaveSlotData.SlotId)
-				local destStore = self:_getSlotStore(newSlotId)
+			return self
+				:PromiseCreateSlot(freeIndex, {
+					SlotName = if sourceIsEphemeral
+						then sourceMetadata.SlotName
+						else `{sourceMetadata.SlotName} (Copy)`,
+					Summary = sourceMetadata.Summary,
+				})
+				:Then(function(newSlotId: SaveSlotData.SlotId)
+					local destStore = self:_getSlotStore(newSlotId)
 
-				if destStore == self._dataStore then
-					-- The copy is the default slot, whose store is the shared root. Merge so the SaveSlots
-					-- system store living alongside it survives (a plain Overwrite would wipe it).
-					destStore:OverwriteMerge(slotData)
-				else
-					destStore:Overwrite(slotData)
-				end
+					if destStore == self._dataStore then
+						-- The copy is the default slot, whose store is the shared root. Merge so the SaveSlots
+						-- system store living alongside it survives (a plain Overwrite would wipe it).
+						destStore:OverwriteMerge(slotData)
+					else
+						destStore:Overwrite(slotData)
+					end
 
-				-- Flush so the duplicated data survives a crash before the next autosave.
-				return self._dataStore:Save():Then(function()
-					return newSlotId
+					-- Flush so the duplicated data survives a crash before the next autosave.
+					return self._dataStore:Save():Then(function()
+						return newSlotId
+					end)
 				end)
+		end)
+	end)
+end
+
+--[=[
+	Turns an ephemeral slot into a real save: duplicates it into a fresh persisted slot at the lowest free
+	index (see [HasSaveSlots.PromiseDuplicateSlot]) and selects that slot, so play continues on data that
+	is now being written. Defaults to the active slot, which in practice is the only ephemeral slot there
+	is -- one stops existing the moment it stops being active. Resolves to the new slot's id.
+
+	The copy is taken from the ephemeral slot's live in-memory data at the moment this runs, and selecting
+	the new slot retires the ephemeral one, so anything written to the old store between the copy and the
+	selection is dropped. Rejects when no slot is active, the slot is missing, the slot is not ephemeral,
+	or every index is in use.
+
+	@param slotId SlotId? -- defaults to the active slot
+	@return Promise<SlotId>
+]=]
+function HasSaveSlots.PromisePersistEphemeralSlot(
+	self: HasSaveSlots,
+	slotId: SaveSlotData.SlotId?
+): Promise.Promise<SaveSlotData.SlotId>
+	return (self._loadPromise :: any):Then(function()
+		local targetSlotId = slotId or self.ActiveSlotId.Value
+		if not targetSlotId then
+			return (Promise :: any).rejected("No slot to persist")
+		end
+
+		if not self._slotMap[targetSlotId] then
+			return (Promise :: any).rejected(`Slot \{{targetSlotId}\} not found`)
+		end
+
+		if not self:_isEphemeral(targetSlotId) then
+			return (Promise :: any).rejected(`Slot \{{targetSlotId}\} is already persisted`)
+		end
+
+		return self:PromiseDuplicateSlot(targetSlotId):Then(function(newSlotId: SaveSlotData.SlotId)
+			return self:PromiseSelectSlot(newSlotId):Then(function()
+				return newSlotId
 			end)
 		end)
 	end)
 end
 
 --[=[
-	Deletes the slot with the given ID
+	Deletes the slot with the given ID. Deleting an ephemeral slot ends that session -- it is deselected
+	and retired along with its in-memory store -- rather than being refused for being the active slot.
 ]=]
 function HasSaveSlots.PromiseDeleteSlot(self: HasSaveSlots, slotId: SaveSlotData.SlotId): Promise.Promise<any>
 	return (self._loadPromise :: any):Then(function()
+		-- An ephemeral slot only exists while it is active, so deleting one is retiring it. Nothing was
+		-- ever persisted, so there is no stored data to wipe afterwards -- hence the early return.
+		if self:_isEphemeral(slotId) then
+			if slotId == self.ActiveSlotId.Value then
+				return self:PromiseDeselectSlot()
+			end
+			self:_destroyEphemeralSlot(slotId)
+			return (Promise :: any).resolved()
+		end
+
 		if slotId == self.ActiveSlotId.Value then
 			return (Promise :: any).rejected("Cannot delete active slot")
 		end
@@ -1003,7 +1055,7 @@ function HasSaveSlots.PromiseSelectEphemeralSlot(
 		local slotId = HttpService:GenerateGUID(false)
 		local data = {
 			SlotId = slotId,
-			SlotIndex = EPHEMERAL_SLOT_INDEX,
+			SlotIndex = SaveSlotConstants.EPHEMERAL_SLOT_INDEX,
 			SlotName = (metadata and metadata.SlotName) or "Ephemeral",
 			CreatedTime = os.time(),
 			Summary = metadata and metadata.Summary,

--- a/src/saveslot/src/Server/Binders/HasSaveSlots.spec.lua
+++ b/src/saveslot/src/Server/Binders/HasSaveSlots.spec.lua
@@ -1717,7 +1717,7 @@ describe("HasSaveSlots ephemeral slots", function()
 		context.destroy()
 	end)
 
-	it("refuses to reset or duplicate an ephemeral slot", function()
+	it("refuses to reset an ephemeral slot", function()
 		local context = setup()
 
 		local ephemeralId = selectEphemeral(context)
@@ -1726,9 +1726,78 @@ describe("HasSaveSlots ephemeral slots", function()
 		expect(PromiseTestUtils.awaitSettled(resetPromise, 10)).toEqual(true)
 		expect((resetPromise:Yield())).toEqual(false)
 
-		local duplicatePromise = context.hasSaveSlots:PromiseDuplicateSlot(ephemeralId)
-		expect(PromiseTestUtils.awaitSettled(duplicatePromise, 10)).toEqual(true)
-		expect((duplicatePromise:Yield())).toEqual(false)
+		context.destroy()
+	end)
+
+	it("duplicates an ephemeral slot into a real slot carrying its live data", function()
+		local context = setup()
+
+		createAndSelectReal(context, 1)
+		local ephemeralId = selectEphemeral(context, { SlotName = "Lobby run" })
+		resolve(context.hasSaveSlots:PromiseActiveSlotStore()):Store("Coins", 12)
+
+		local newSlotId = resolve(context.hasSaveSlots:PromiseDuplicateSlot(ephemeralId))
+
+		local metadata = resolve(context.hasSaveSlots:PromiseGetSlotMetadata(newSlotId))
+		expect(metadata.IsEphemeral).never.toEqual(true)
+		expect(metadata.SlotName).toEqual("Lobby run")
+
+		local export = resolve(context.hasSaveSlots:PromiseExportSlot(newSlotId))
+		expect(export.data.Coins).toEqual(12)
+
+		-- Duplicating leaves the session running on the ephemeral slot, like any other duplicate.
+		expect(context.hasSaveSlots.ActiveSlotId.Value).toEqual(ephemeralId)
+
+		context.destroy()
+	end)
+
+	it("persists the ephemeral slot and continues play on the new real slot", function()
+		local context = setup()
+
+		local ephemeralId = selectEphemeral(context, { SlotName = "Lobby run" })
+		resolve(context.hasSaveSlots:PromiseActiveSlotStore()):Store("Coins", 12)
+
+		local newSlotId = resolve(context.hasSaveSlots:PromisePersistEphemeralSlot())
+
+		expect(context.hasSaveSlots.ActiveSlotId.Value).toEqual(newSlotId)
+		expect(resolve(context.hasSaveSlots:PromiseHasSlot(ephemeralId))).toEqual(false)
+
+		local listedIds = {}
+		for _, metadata in (SaveSlotDataService :: any):GetSlotList(context.fakePlayer) do
+			listedIds[metadata.SlotId] = true
+		end
+		expect(listedIds[newSlotId]).toEqual(true)
+
+		-- The copy landed on the default index, whose store is the player's root: the session's data is
+		-- there and the SaveSlots system data alongside it survived the merge.
+		local data = resolve(resolve(context.hasSaveSlots:PromiseActiveSlotStore()):LoadAll({}))
+		expect(data.Coins).toEqual(12)
+		expect(data.SaveSlots).never.toBeNil()
+
+		context.destroy()
+	end)
+
+	it("refuses to persist when the active slot is a real one", function()
+		local context = setup()
+
+		createAndSelectReal(context, 1)
+
+		local persistPromise = context.hasSaveSlots:PromisePersistEphemeralSlot()
+		expect(PromiseTestUtils.awaitSettled(persistPromise, 10)).toEqual(true)
+		expect((persistPromise:Yield())).toEqual(false)
+
+		context.destroy()
+	end)
+
+	it("ends the session when the ephemeral slot is deleted", function()
+		local context = setup()
+
+		local ephemeralId = selectEphemeral(context)
+		resolve(context.hasSaveSlots:PromiseDeleteSlot(ephemeralId))
+
+		expect(context.hasSaveSlots.ActiveSlotId.Value).toEqual(nil)
+		expect(resolve(context.hasSaveSlots:PromiseHasSlot(ephemeralId))).toEqual(false)
+		expect(slotContainerHasChild(context, ephemeralId)).toEqual(false)
 
 		context.destroy()
 	end)

--- a/src/saveslot/src/Server/Cmdr/SaveSlotCmdrService.lua
+++ b/src/saveslot/src/Server/Cmdr/SaveSlotCmdrService.lua
@@ -10,6 +10,7 @@ local HasSaveSlots = require("HasSaveSlots")
 local Maid = require("Maid")
 local Promise = require("Promise")
 local SaveSlotCmdrUtils = require("SaveSlotCmdrUtils")
+local SaveSlotConstants = require("SaveSlotConstants")
 local SaveSlotDataService = require("SaveSlotDataService")
 local ServiceBag = require("ServiceBag")
 
@@ -78,6 +79,14 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 				local isActive = (slot.SlotId == activeSlotId)
 				listString ..= `\n"{slot.SlotName}" ({slot.SlotIndex}){isActive and " — Active" or ""}\n{slot.Summary}\n`
 			end
+
+			-- An ephemeral session is not a save, so it is absent from the slot list above -- but it is what
+			-- the player is playing right now and the thing persist-save-slot acts on, so list it under the
+			-- reserved index the other commands address it by.
+			if self._saveSlotDataService:IsActiveSlotEphemeral(player) then
+				local metadata = self._saveSlotDataService:GetActiveSlotMetadata(player)
+				listString ..= `\n"{metadata.SlotName}" ({metadata.SlotIndex}) — Active, ephemeral\n{metadata.Summary}\n`
+			end
 		end
 
 		return listString
@@ -128,7 +137,7 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 		},
 	}, function(_context, players: { Player }, slotIndex: number)
 		local lines = self:_promisePlayerLines(players, function(hasSaveSlots, player)
-			local slotId = self._saveSlotDataService:GetSlotIdFromIndex(player, slotIndex)
+			local slotId = self:_getSlotIdFromIndex(player, slotIndex)
 			if not slotId then
 				return `{player.Name} has no slot with index {slotIndex}.`
 			end
@@ -268,29 +277,34 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 			return "No matching slots to delete."
 		end
 
-		local lines = self:_promiseSlotLines(targets, function(hasSaveSlots, entry, player)
-			-- The active slot can't be deleted while selected, so deselect it first (flushing its
-			-- progress) when reached. Read live rather than up front, since an earlier deletion in
-			-- this batch may have already deselected it.
-			local deselect = if entry.slotId == self._saveSlotDataService:GetActiveSlotId(player)
-				then hasSaveSlots:PromiseDeselectSlot()
-				else Promise.resolved()
+		local lines = self
+			:_promiseSlotLines(targets, function(hasSaveSlots, entry, player)
+				-- The active slot can't be deleted while selected, so deselect it first (flushing its
+				-- progress) when reached. Read live rather than up front, since an earlier deletion in
+				-- this batch may have already deselected it. An ephemeral session is left alone:
+				-- PromiseDeleteSlot retires it itself, and deselecting first would retire it early,
+				-- leaving nothing behind to delete.
+				local isActive = (entry.slotId == self._saveSlotDataService:GetActiveSlotId(player))
+				local deselect = if isActive and not self._saveSlotDataService:IsActiveSlotEphemeral(player)
+					then hasSaveSlots:PromiseDeselectSlot()
+					else Promise.resolved()
 
-			return deselect
-				:Then(function()
-					return hasSaveSlots:PromiseDeleteSlot(entry.slotId)
-				end)
-				:Then(function()
-					return `{player.Name} deleted slot {entry.slotIndex}.`
-				end)
-		end):Wait()
+				return deselect
+					:Then(function()
+						return hasSaveSlots:PromiseDeleteSlot(entry.slotId)
+					end)
+					:Then(function()
+						return `{player.Name} deleted slot {entry.slotIndex}.`
+					end)
+			end)
+			:Wait()
 
 		return `Deleted:\n{table.concat(lines, "\n")}`
 	end)
 
 	self._cmdrService:RegisterCommand({
 		Name = "duplicate-save-slot",
-		Description = "Duplicates save slots into new slots at the lowest free indices.",
+		Description = "Duplicates save slots into new slots at the lowest free indices. Duplicating an ephemeral session saves it without switching onto the copy -- see persist-save-slot.",
 		Group = "SaveSlots",
 		Args = {
 			{
@@ -321,6 +335,36 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 			:Wait()
 
 		return `Duplicated:\n{table.concat(lines, "\n")}`
+	end)
+
+	self._cmdrService:RegisterCommand({
+		Name = "persist-save-slot",
+		Description = "Turns an ephemeral session into a real save slot and switches onto it.",
+		Group = "SaveSlots",
+		Args = {
+			{
+				Name = "Players",
+				Type = "players",
+				Description = "Players to persist the session of (e.g. . for yourself, or * for everyone).",
+			},
+		},
+	}, function(_context, players: { Player })
+		-- Takes no slot argument: an ephemeral slot exists only while it is active, so the active slot is
+		-- the only one there is to persist.
+		local lines = self
+			:_promisePlayerLines(players, function(hasSaveSlots, player)
+				if not self._saveSlotDataService:IsActiveSlotEphemeral(player) then
+					return `{player.Name} has no ephemeral session active.`
+				end
+
+				return hasSaveSlots:PromisePersistEphemeralSlot():Then(function(newSlotId)
+					local metadata = self._saveSlotDataService:GetSlotMetadata(player, newSlotId)
+					return `{player.Name} persisted their session to slot {metadata.SlotIndex} ("{metadata.SlotName}").`
+				end)
+			end)
+			:Wait()
+
+		return table.concat(lines, "\n")
 	end)
 
 	self._cmdrService:RegisterCommand({
@@ -489,6 +533,20 @@ function SaveSlotCmdrService._registerCommands(self: SaveSlotCmdrService): ()
 	end)
 end
 
+-- Resolves a slot index to the player's slot id, including the reserved ephemeral index (see
+-- [SaveSlotCmdrUtils]). The data service's index lookup only walks the save list, which an ephemeral slot
+-- is excluded from, so that one index resolves against the active slot instead.
+function SaveSlotCmdrService._getSlotIdFromIndex(self: SaveSlotCmdrService, player: Player, slotIndex: number): string?
+	if slotIndex == SaveSlotConstants.EPHEMERAL_SLOT_INDEX then
+		if self._saveSlotDataService:IsActiveSlotEphemeral(player) then
+			return self._saveSlotDataService:GetActiveSlotId(player)
+		end
+		return nil
+	end
+
+	return self._saveSlotDataService:GetSlotIdFromIndex(player, slotIndex)
+end
+
 -- Resolves a slotIndices argument (or nil = the active slot) into de-duplicated { slotIndex, slotId }
 -- entries for the player. An empty result means nothing matched, and the caller reports it.
 function SaveSlotCmdrService._resolveSlotEntries(
@@ -507,7 +565,7 @@ function SaveSlotCmdrService._resolveSlotEntries(
 	else
 		local seen = {}
 		for _, slotIndex in slotIndices do
-			local slotId = self._saveSlotDataService:GetSlotIdFromIndex(player, slotIndex)
+			local slotId = self:_getSlotIdFromIndex(player, slotIndex)
 			if slotId and not seen[slotId] then
 				seen[slotId] = true
 				table.insert(entries, { slotIndex = slotIndex, slotId = slotId })

--- a/src/saveslot/src/Server/SaveSlotService.lua
+++ b/src/saveslot/src/Server/SaveSlotService.lua
@@ -461,6 +461,20 @@ function SaveSlotService.PromiseResetActiveSlot(self: SaveSlotService, player: P
 end
 
 --[=[
+	Turns the player's ephemeral session into a real save slot and continues play on it, resolving to the
+	new slot id. See [HasSaveSlots.PromisePersistEphemeralSlot].
+]=]
+function SaveSlotService.PromisePersistEphemeralSlot(
+	self: SaveSlotService,
+	player: Player,
+	slotId: SaveSlotData.SlotId?
+): Promise.Promise<SaveSlotData.SlotId>
+	return self._hasSaveSlotsBinder:Promise(player):Then(function(hasSaveSlots)
+		return hasSaveSlots:PromisePersistEphemeralSlot(slotId)
+	end)
+end
+
+--[=[
 	Exports the player's non-main slot into a serializable table. See [HasSaveSlots.PromiseExportSlot].
 ]=]
 function SaveSlotService.PromiseExportSlot(

--- a/src/saveslot/src/Shared/Cmdr/SaveSlotCmdrUtils.lua
+++ b/src/saveslot/src/Shared/Cmdr/SaveSlotCmdrUtils.lua
@@ -3,6 +3,10 @@
 	@class SaveSlotCmdrUtils
 ]=]
 
+local require = require(script.Parent.loader).load(script)
+
+local SaveSlotConstants = require("SaveSlotConstants")
+
 local SaveSlotCmdrUtils = {}
 
 function SaveSlotCmdrUtils.registerSlotIndexType(cmdr, saveSlotDataService)
@@ -13,10 +17,36 @@ function SaveSlotCmdrUtils.registerSlotIndexType(cmdr, saveSlotDataService)
 			for _, metadata in slots do
 				table.insert(slotIndices, tostring(metadata.SlotIndex))
 			end
-			return cmdr.Util.MakeFuzzyFinder(slotIndices)(text)
+
+			-- The active ephemeral slot is deliberately absent from the slot list -- it is a throwaway
+			-- session, not a save -- but it is still the slot the player is actually in, and admin tooling
+			-- has to be able to name it (to persist it, export it, or end it). It answers to the reserved
+			-- ephemeral index, which no real slot can hold, so it never shadows one. Offering it here is
+			-- also what makes "." resolve while a session is active, since Default hands its index back
+			-- through this finder.
+			if saveSlotDataService:IsActiveSlotEphemeral(player) then
+				table.insert(slotIndices, tostring(SaveSlotConstants.EPHEMERAL_SLOT_INDEX))
+			end
+
+			local matches = cmdr.Util.MakeFuzzyFinder(slotIndices)(text)
+			if #matches > 0 then
+				return matches
+			end
+
+			-- Autocomplete can only ever offer the executor's own slots -- Cmdr resolves types against the
+			-- executor -- but these commands target other players, whose slots the executor cannot see. So
+			-- any literal index typed out is accepted even when the executor has no such slot, which is what
+			-- makes `export-save-slot SomeoneElse 3` possible. A target without that slot is reported by the
+			-- command itself, which resolves the index per player.
+			local literalIndex = tonumber(text)
+			if literalIndex and (literalIndex >= 0) and (literalIndex % 1 == 0) then
+				return { tostring(literalIndex) }
+			end
+
+			return matches
 		end,
 		Validate = function(keys)
-			return #keys > 0, "No matching slot."
+			return #keys > 0, "Not a slot index."
 		end,
 		Autocomplete = function(keys)
 			return keys

--- a/src/saveslot/src/Shared/Cmdr/SaveSlotCmdrUtils.spec.lua
+++ b/src/saveslot/src/Shared/Cmdr/SaveSlotCmdrUtils.spec.lua
@@ -13,7 +13,9 @@ local it = Jest.Globals.it
 
 local FAKE_PLAYER = newproxy(false)
 
-local function newFakeDataService(state)
+local function newFakeDataService(state: any)
+	-- Mirrors the real service: an ephemeral slot is excluded from the slot list but still resolvable as
+	-- metadata, which is exactly the split the type has to bridge.
 	return {
 		GetSlotList = function(_self, _player)
 			return state.slots
@@ -21,7 +23,13 @@ local function newFakeDataService(state)
 		GetLastActiveSlotId = function(_self, _player)
 			return state.lastActiveSlotId
 		end,
+		IsActiveSlotEphemeral = function(_self, _player)
+			return state.ephemeralSlot ~= nil
+		end,
 		GetSlotMetadata = function(_self, _player, slotId)
+			if state.ephemeralSlot and state.ephemeralSlot.SlotId == slotId then
+				return state.ephemeralSlot
+			end
 			for _, slot in state.slots do
 				if slot.SlotId == slotId then
 					return slot
@@ -67,7 +75,7 @@ local function newFakeCmdr()
 	return cmdr, registered
 end
 
-local function registerSlotIndex(state)
+local function registerSlotIndex(state: any)
 	local cmdr, registered = newFakeCmdr()
 	SaveSlotCmdrUtils.registerSlotIndexType(cmdr :: any, newFakeDataService(state))
 	return registered.slotIndex, registered.slotIndices
@@ -116,6 +124,56 @@ describe("SaveSlotCmdrUtils.registerSlotIndexType", function()
 		})
 
 		expect(slotIndex.Parse(slotIndex.Transform("2", FAKE_PLAYER))).toBe(2)
+	end)
+
+	it("suggests the reserved ephemeral index while an ephemeral session is active", function()
+		local slotIndex = registerSlotIndex({
+			lastActiveSlotId = "id-ephemeral",
+			ephemeralSlot = { SlotId = "id-ephemeral", SlotIndex = 0, IsEphemeral = true },
+			slots = {
+				{ SlotId = "id-1", SlotIndex = 1 },
+			},
+		})
+
+		-- Transform("") is what "*" and autocomplete expand against.
+		expect(slotIndex.Transform("", FAKE_PLAYER)).toEqual({ "1", "0" })
+		expect(slotIndex.Default(FAKE_PLAYER)).toBe("0")
+		expect(slotIndex.Parse(slotIndex.Transform("0", FAKE_PLAYER))).toBe(0)
+	end)
+
+	it("leaves the ephemeral index out of the suggestions when no session is active", function()
+		local slotIndex = registerSlotIndex({
+			lastActiveSlotId = "id-1",
+			slots = {
+				{ SlotId = "id-1", SlotIndex = 1 },
+			},
+		})
+
+		expect(slotIndex.Transform("", FAKE_PLAYER)).toEqual({ "1" })
+	end)
+
+	it("accepts a literal index the executor has no slot for, so other players can be targeted", function()
+		local slotIndex = registerSlotIndex({
+			lastActiveSlotId = "id-1",
+			slots = {
+				{ SlotId = "id-1", SlotIndex = 1 },
+			},
+		})
+
+		expect((slotIndex.Validate(slotIndex.Transform("3", FAKE_PLAYER)))).toBe(true)
+		expect(slotIndex.Parse(slotIndex.Transform("3", FAKE_PLAYER))).toBe(3)
+	end)
+
+	it("rejects text that is not a slot index at all", function()
+		local slotIndex = registerSlotIndex({
+			lastActiveSlotId = "id-1",
+			slots = {
+				{ SlotId = "id-1", SlotIndex = 1 },
+			},
+		})
+
+		expect((slotIndex.Validate(slotIndex.Transform("nope", FAKE_PLAYER)))).toBe(false)
+		expect((slotIndex.Validate(slotIndex.Transform("-2", FAKE_PLAYER)))).toBe(false)
 	end)
 
 	it('exposes Default on the listable type too, so "." works for delete-save-slot', function()

--- a/src/saveslot/src/Shared/HasSaveSlotsInterface.lua
+++ b/src/saveslot/src/Shared/HasSaveSlotsInterface.lua
@@ -36,6 +36,7 @@ return TieDefinition.new("HasSaveSlots", {
 		PromiseSelectLastSaveSlot = TieDefinition.Types.METHOD,
 		PromiseSelectNewSaveSlot = TieDefinition.Types.METHOD,
 		PromiseSelectEphemeralSlot = TieDefinition.Types.METHOD,
+		PromisePersistEphemeralSlot = TieDefinition.Types.METHOD,
 		PromiseDeleteAllSlots = TieDefinition.Types.METHOD,
 
 		-- Export/import operate on the server's datastore-backed slots and are refused on the main

--- a/src/saveslot/src/Shared/SaveSlotConstants.lua
+++ b/src/saveslot/src/Shared/SaveSlotConstants.lua
@@ -16,4 +16,12 @@ return Table.readonly({
 	-- Carries the shared-store key of a transferable ephemeral slot across a teleport (trusted band).
 	TELEPORT_DATA_EPHEMERAL_KEY = "IncomingEphemeralSaveSlotKey",
 	DEFAULT_SLOT_INDEX = 1,
+	-- An ephemeral slot carries no meaningful index -- a real slot's index positions it in the save list and
+	-- routes its store, neither of which applies to a throwaway slot. The authoritative "is ephemeral"
+	-- discriminator is the slot's own IsEphemeral property (see HasSaveSlots._isEphemeral), and every
+	-- index-accounting path skips ephemeral slots, so this value never routes anything and any number of
+	-- ephemeral slots can coexist. 0 is used because a real index is always >= 1 (DEFAULT_SLOT_INDEX is 1,
+	-- PromiseCreateSlot rejects < 1), which also makes it a free address for tooling that has to name the
+	-- active ephemeral slot (see SaveSlotCmdrUtils).
+	EPHEMERAL_SLOT_INDEX = 0,
 })


### PR DESCRIPTION
The save-slot Cmdr commands could not name an ephemeral slot, since ephemeral slots are kept out of the slot list, so a throwaway session could not be exported, ended, or turned into a save. The slot-index type now offers the reserved ephemeral index while a session is active and the commands resolve it against the active slot, so "." and an explicit 0 both reach it.

Duplicating an ephemeral slot is now allowed and copies its live in-memory data into a real slot, and the new persist-save-slot command does that and switches onto the copy so play continues on data that actually saves. Deleting an ephemeral slot ends the session instead of being refused for being the active slot, and list-save-slots shows the active session.

The slot-index type also accepts any literal index the executor has no slot for, so you can act on another player's slot that your own autocomplete cannot see.

All 188 saveslot tests pass on cloud.