### PR TITLE
feat(access): toggle several policies at once with access-policy

### DIFF
--- a/src/access/README.md
+++ b/src/access/README.md
@@ -194,7 +194,7 @@ what a policy reads shows up in a readout like everything else.
 | `access-feature <players> <feature> [subject]` | one verdict and the facts it was reached from |
 | `access-override <players> <facts> <true\|false\|unresolved>` | force facts — `*` or `all` for every one |
 | `access-policies` | every policy and whether it is running |
-| `access-policy <policy> <on\|off>` | turn a consequence on or off |
+| `access-policy <policies> <on\|off>` | turn consequences on or off — `*` or `all` for every one |
 
 Every command is admin-gated by `CmdrService`. Overrides appear as their own layer with the real answer
 still visible underneath, so nobody mistakes one left on after a QA session for a genuine entitlement.

--- a/src/access/src/Server/Commands/AccessCommandService.lua
+++ b/src/access/src/Server/Commands/AccessCommandService.lua
@@ -209,13 +209,13 @@ function AccessCommandService._registerCommands(self: AccessCommandService): ()
 
 	self._cmdrService:RegisterCommand({
 		Name = "access-policy",
-		Description = "Turns an access policy on or off for everybody.",
+		Description = "Turns access policies on or off for everybody.",
 		Group = "Access",
 		Args = {
 			{
-				Name = "Policy",
-				Type = "accessPolicyName",
-				Description = "The policy to toggle.",
+				Name = "Policies",
+				Type = "accessPolicyNames",
+				Description = "The policies to toggle. Comma-separated, or * for every registered policy.",
 			},
 			{
 				Name = "State",
@@ -223,15 +223,28 @@ function AccessCommandService._registerCommands(self: AccessCommandService): ()
 				Description = "on or off.",
 			},
 		},
-	}, function(_context, policyName: string, state: string)
+	}, function(_context, policyNames: { string }, state: string)
 		local enabled = state == AccessCommandUtils.ToggleValues.ON
-		if not self._accessPolicyService:GetPolicy(policyName) then
-			return `No policy registered named {policyName}`
+
+		-- Checked before anything is toggled, so a typo in a list does not leave half of it switched.
+		local missing = {}
+		for _, policyName in policyNames do
+			if not self._accessPolicyService:GetPolicy(policyName) then
+				table.insert(missing, policyName)
+			end
 		end
 
-		self._accessPolicyService:SetPolicyEnabled(policyName, enabled)
+		if #missing > 0 then
+			return `No policy registered named {table.concat(missing, ", ")}`
+		end
 
-		return `{policyName} is now {if enabled then "ENABLED" else "disabled"}.`
+		for _, policyName in policyNames do
+			self._accessPolicyService:SetPolicyEnabled(policyName, enabled)
+		end
+
+		local toggled = AccessCommandUtils.describeNameList(policyNames, "policies")
+
+		return `{if enabled then "ENABLED" else "disabled"} {toggled}.`
 	end)
 
 	self._cmdrService:RegisterCommand({
@@ -264,7 +277,7 @@ function AccessCommandService._registerCommands(self: AccessCommandService): ()
 			end
 		end
 
-		return `Set {AccessCommandUtils.describeFactList(factNames)} to {value} for {#players} player(s). `
+		return `Set {AccessCommandUtils.describeNameList(factNames, "facts")} to {value} for {#players} player(s). `
 			.. `Each shows as its own layer in access-facts, so the real answer stays visible underneath.`
 	end)
 

--- a/src/access/src/Shared/Commands/AccessCommandUtils.lua
+++ b/src/access/src/Shared/Commands/AccessCommandUtils.lua
@@ -45,7 +45,7 @@ AccessCommandUtils.OverrideValues = {
 
 local DECIDED_MARKER = " <-- decided"
 local SOURCE_WIDTH = 16
-local NAMED_FACT_LIMIT = 4
+local NAMED_LIMIT = 4
 
 --[[
 	GOTCHA: keeps the LAST emission, not the first. A fact opens on unresolved before anything is looked
@@ -348,20 +348,21 @@ function AccessCommandUtils.formatPlayerState(
 end
 
 --[=[
-	How a list of facts reads back in a confirmation. Names them while there are few enough to check at a
+	How a list of names reads back in a confirmation. Names them while there are few enough to check at a
 	glance, and counts them once naming them would be a wall -- which is exactly what `*` produces.
 
-	@param factNames { string }
+	@param names { string }
+	@param noun string -- plural, for the count and empty forms: "facts", "policies"
 	@return string
 ]=]
-function AccessCommandUtils.describeFactList(factNames: { string }): string
-	if #factNames == 0 then
-		return "no facts"
-	elseif #factNames <= NAMED_FACT_LIMIT then
-		return table.concat(factNames, ", ")
+function AccessCommandUtils.describeNameList(names: { string }, noun: string): string
+	if #names == 0 then
+		return `no {noun}`
+	elseif #names <= NAMED_LIMIT then
+		return table.concat(names, ", ")
 	end
 
-	return `{#factNames} facts`
+	return `{#names} {noun}`
 end
 
 --[=[
@@ -516,6 +517,21 @@ function AccessCommandUtils.registerTypes(cmdr: any, accessDataService: any, get
 		end,
 	}
 
+	local policyName = {
+		Transform = function(text: string)
+			return cmdr.Util.MakeFuzzyFinder(if getPolicyNames then getPolicyNames() else { text })(text)
+		end,
+		Validate = function(keys)
+			return #keys > 0, "No policy registered by that name."
+		end,
+		Autocomplete = function(keys)
+			return keys
+		end,
+		Parse = function(keys)
+			return keys[1]
+		end,
+	}
+
 	cmdr.Registry:RegisterType("accessFactName", factName)
 	-- Listable, which is what buys `access-override . * false`: Cmdr only expands `*` and `**` for a type
 	-- that says it takes a list. `all` is the spelled-out alias, the same one the built-in players type
@@ -529,20 +545,17 @@ function AccessCommandUtils.registerTypes(cmdr: any, accessDataService: any, get
 		})
 	)
 	cmdr.Registry:RegisterType("accessFeatureName", featureName)
-	cmdr.Registry:RegisterType("accessPolicyName", {
-		Transform = function(text: string)
-			return cmdr.Util.MakeFuzzyFinder(if getPolicyNames then getPolicyNames() else { text })(text)
-		end,
-		Validate = function(keys)
-			return #keys > 0, "No policy registered by that name."
-		end,
-		Autocomplete = function(keys)
-			return keys
-		end,
-		Parse = function(keys)
-			return keys[1]
-		end,
-	})
+	cmdr.Registry:RegisterType("accessPolicyName", policyName)
+	-- Same as the facts, and for the same reason: `access-policy * off` is how somebody switches every
+	-- consequence off to see the game without them.
+	cmdr.Registry:RegisterType(
+		"accessPolicyNames",
+		cmdr.Util.MakeListableType(policyName, {
+			ArgumentOperatorAliases = {
+				all = "*",
+			},
+		})
+	)
 	cmdr.Registry:RegisterType(
 		"accessToggle",
 		cmdr.Util.MakeEnumType("accessToggle", {

--- a/src/access/src/Shared/Commands/AccessCommandUtils.spec.lua
+++ b/src/access/src/Shared/Commands/AccessCommandUtils.spec.lua
@@ -324,6 +324,7 @@ describe("AccessCommandUtils.registerTypes", function()
 				"accessFactNames",
 				"accessFeatureName",
 				"accessPolicyName",
+				"accessPolicyNames",
 				"accessOverrideValue",
 				"accessRealm",
 				"accessToggle",
@@ -421,18 +422,65 @@ describe("overriding every fact at once", function()
 	end)
 end)
 
-describe("AccessCommandUtils.describeFactList", function()
+describe("toggling every policy at once", function()
+	-- `access-policy * off` is how somebody sees the game with every consequence switched off. Same
+	-- requirements as the fact list, asserted separately because the two types are built from different
+	-- name sources and only one of them is optional.
+	local function policyNamesType()
+		local cmdr, registered = strictCmdr()
+		AccessCommandUtils.registerTypes(cmdr, fakeAccessDataService(), function()
+			return { "kick-on-non-admin", "watch-shop" }
+		end)
+		return registered.accessPolicyNames
+	end
+
+	it("is listable, which is the only reason * expands at all", function()
+		expect(policyNamesType().Listable).toEqual(true)
+	end)
+
+	it("matches every policy on an empty segment, which is what * expands to", function()
+		local policyType = policyNamesType()
+
+		expect(policyType.Autocomplete(policyType.Transform(""))).toEqual({ "kick-on-non-admin", "watch-shop" })
+	end)
+
+	it("still resolves one typed name", function()
+		local policyType = policyNamesType()
+
+		expect(policyType.Parse(policyType.Transform("kick-on-non-admin"))).toEqual({ "kick-on-non-admin" })
+	end)
+
+	it("offers `all` as the spelled-out wildcard", function()
+		expect(policyNamesType().ArgumentOperatorAliases.all).toEqual("*")
+	end)
+
+	it("leaves the single-policy type alone, which is what the readout commands take", function()
+		local cmdr, registered = strictCmdr()
+		AccessCommandUtils.registerTypes(cmdr, fakeAccessDataService(), function()
+			return { "kick-on-non-admin" }
+		end)
+
+		expect(registered.accessPolicyName.Listable).toEqual(nil)
+	end)
+end)
+
+describe("AccessCommandUtils.describeNameList", function()
 	it("names them while a person can still check them", function()
-		expect(AccessCommandUtils.describeFactList({ "ownsGame", "isStaff" })).toEqual("ownsGame, isStaff")
+		expect(AccessCommandUtils.describeNameList({ "ownsGame", "isStaff" }, "facts")).toEqual("ownsGame, isStaff")
 	end)
 
 	it("counts them once naming them would be a wall", function()
 		-- Which is exactly what * produces.
-		expect(AccessCommandUtils.describeFactList({ "a", "b", "c", "d", "e" })).toEqual("5 facts")
+		expect(AccessCommandUtils.describeNameList({ "a", "b", "c", "d", "e" }, "facts")).toEqual("5 facts")
 	end)
 
 	it("says something rather than nothing for an empty list", function()
-		expect(AccessCommandUtils.describeFactList({})).toEqual("no facts")
+		expect(AccessCommandUtils.describeNameList({}, "facts")).toEqual("no facts")
+	end)
+
+	it("names whatever it was given, so a policy list does not read as facts", function()
+		expect(AccessCommandUtils.describeNameList({ "a", "b", "c", "d", "e" }, "policies")).toEqual("5 policies")
+		expect(AccessCommandUtils.describeNameList({}, "policies")).toEqual("no policies")
 	end)
 end)
 


### PR DESCRIPTION
The access-policy console command now takes a list of policies instead of a single one, so `access-policy * off` (or `all`, or a comma-separated list) switches every registered consequence off in one go, matching what access-override already did for facts. Names that aren't registered are reported before anything is toggled, so a typo in the middle of a list doesn't leave half of it switched.
