### PR TITLE
fix(access): make the access-policy list readout deterministic and tested

### DIFF
--- a/src/access/src/Server/Commands/AccessCommandService.lua
+++ b/src/access/src/Server/Commands/AccessCommandService.lua
@@ -237,6 +237,8 @@ function AccessCommandService._registerCommands(self: AccessCommandService): ()
 		end
 
 		if #missing > 0 then
+			table.sort(missing)
+
 			return `No policy registered named: {table.concat(missing, ", ")}`
 		end
 

--- a/src/access/src/Server/Commands/AccessCommandService.lua
+++ b/src/access/src/Server/Commands/AccessCommandService.lua
@@ -226,7 +226,9 @@ function AccessCommandService._registerCommands(self: AccessCommandService): ()
 	}, function(_context, policyNames: { string }, state: string)
 		local enabled = state == AccessCommandUtils.ToggleValues.ON
 
-		-- Checked before anything is toggled, so a typo in a list does not leave half of it switched.
+		-- SetPolicyEnabled asserts on a name nobody registered, so a stale one partway through a list would
+		-- throw with the policies before it already switched. Cmdr validates each name as it is typed; this
+		-- catches the one it cannot, a policy unregistered between then and now.
 		local missing = {}
 		for _, policyName in policyNames do
 			if not self._accessPolicyService:GetPolicy(policyName) then
@@ -235,7 +237,7 @@ function AccessCommandService._registerCommands(self: AccessCommandService): ()
 		end
 
 		if #missing > 0 then
-			return `No policy registered named {table.concat(missing, ", ")}`
+			return `No policy registered named: {table.concat(missing, ", ")}`
 		end
 
 		for _, policyName in policyNames do
@@ -244,7 +246,7 @@ function AccessCommandService._registerCommands(self: AccessCommandService): ()
 
 		local toggled = AccessCommandUtils.describeNameList(policyNames, "policies")
 
-		return `{if enabled then "ENABLED" else "disabled"} {toggled}.`
+		return `{if enabled then "Enabled" else "Disabled"} {toggled}.`
 	end)
 
 	self._cmdrService:RegisterCommand({

--- a/src/access/src/Server/Commands/AccessCommandService.spec.lua
+++ b/src/access/src/Server/Commands/AccessCommandService.spec.lua
@@ -1,0 +1,141 @@
+--!strict
+--[[
+	@class AccessCommandService.spec.lua
+]]
+local require = require(script.Parent.loader).load(script)
+
+local AccessCommandService = require("AccessCommandService")
+local AccessDataService = require("AccessDataService")
+local AccessPolicy = require("AccessPolicy")
+local AccessPolicyService = require("AccessPolicyService")
+local Jest = require("Jest")
+local Maid = require("Maid")
+local ServiceBag = require("ServiceBag")
+
+local describe = Jest.Globals.describe
+local expect = Jest.Globals.expect
+local it = Jest.Globals.it
+
+--[[
+	Commands are registered directly rather than through Start, which waits on the real CmdrService and with
+	it a whole console. What is worth reaching is what a handler does with the list Cmdr already parsed for
+	it, and a stand-in that keeps the callbacks reaches exactly that.
+]]
+local function setup()
+	local maid = Maid.new()
+	local serviceBag = maid:Add(ServiceBag.new())
+	serviceBag:GetService(AccessDataService)
+	local accessPolicyService: AccessPolicyService.AccessPolicyService =
+		serviceBag:GetService(AccessPolicyService) :: any
+	serviceBag:Init()
+	serviceBag:Start()
+
+	local commands = {}
+	local service = setmetatable({
+		_maid = maid,
+		_accessPolicyService = accessPolicyService,
+		_cmdrService = {
+			RegisterCommand = function(_self, definition: any, callback: any)
+				commands[definition.Name] = { definition = definition, run = callback }
+			end,
+		},
+	}, { __index = AccessCommandService }) :: any
+
+	service:_registerCommands()
+
+	return {
+		maid = maid,
+		accessPolicyService = accessPolicyService,
+		command = function(name: string): any
+			return assert(commands[name], `No command registered named {name}`)
+		end,
+		registerPolicy = function(policyName: string)
+			maid:GiveTask(accessPolicyService:RegisterPolicy(maid:Add(AccessPolicy.new(serviceBag, {
+				policyName = policyName,
+				apply = function()
+					return nil
+				end,
+			}))))
+		end,
+		destroy = function(_self)
+			maid:DoCleaning()
+		end,
+	}
+end
+
+describe("access-policy", function()
+	it("takes a list, which is the only thing that lets * reach it", function()
+		local controller = setup()
+
+		expect(controller.command("access-policy").definition.Args[1].Type).toEqual("accessPolicyNames")
+
+		controller:destroy()
+	end)
+
+	it("switches every policy it was given, not just the first", function()
+		local controller = setup()
+		controller.registerPolicy("kickOnNonAdmin")
+		controller.registerPolicy("watchShop")
+
+		controller.command("access-policy").run(nil, { "kickOnNonAdmin", "watchShop" }, "on")
+
+		expect(controller.accessPolicyService:IsPolicyEnabled("kickOnNonAdmin")).toEqual(true)
+		expect(controller.accessPolicyService:IsPolicyEnabled("watchShop")).toEqual(true)
+
+		controller:destroy()
+	end)
+
+	it("switches them back off again", function()
+		local controller = setup()
+		controller.registerPolicy("kickOnNonAdmin")
+		controller.accessPolicyService:SetPolicyEnabled("kickOnNonAdmin", true)
+
+		controller.command("access-policy").run(nil, { "kickOnNonAdmin" }, "off")
+
+		expect(controller.accessPolicyService:IsPolicyEnabled("kickOnNonAdmin")).toEqual(false)
+
+		controller:destroy()
+	end)
+
+	it("switches nothing at all when one name in the list is not registered", function()
+		-- SetPolicyEnabled throws on an unregistered name, so toggling as it goes would leave the policies
+		-- before the bad one switched and the console showing an error instead of what it managed to do.
+		local controller = setup()
+		controller.registerPolicy("kickOnNonAdmin")
+
+		local result = controller.command("access-policy").run(nil, { "kickOnNonAdmin", "nosuch" }, "on")
+
+		expect(controller.accessPolicyService:IsPolicyEnabled("kickOnNonAdmin")).toEqual(false)
+		expect(string.find(result, "nosuch") ~= nil).toEqual(true)
+
+		controller:destroy()
+	end)
+
+	it("names what it switched, in an order somebody can check against", function()
+		local controller = setup()
+		controller.registerPolicy("watchShop")
+		controller.registerPolicy("kickOnNonAdmin")
+
+		local result = controller.command("access-policy").run(nil, { "watchShop", "kickOnNonAdmin" }, "off")
+
+		expect(result).toEqual("Disabled kickOnNonAdmin, watchShop.")
+
+		controller:destroy()
+	end)
+
+	it("counts them once naming them would be a wall, which is what * produces", function()
+		local controller = setup()
+		local policyNames = {}
+		for index = 1, 5 do
+			local policyName = `policy{index}`
+			controller.registerPolicy(policyName)
+			table.insert(policyNames, policyName)
+		end
+
+		local result = controller.command("access-policy").run(nil, policyNames, "on")
+
+		expect(result).toEqual("Enabled 5 policies.")
+
+		controller:destroy()
+	end)
+end)

--- a/src/access/src/Server/Commands/AccessCommandService.spec.lua
+++ b/src/access/src/Server/Commands/AccessCommandService.spec.lua
@@ -17,14 +17,14 @@ local expect = Jest.Globals.expect
 local it = Jest.Globals.it
 
 --[[
-	Commands are registered directly rather than through Start, which waits on the real CmdrService and with
-	it a whole console. What is worth reaching is what a handler does with the list Cmdr already parsed for
-	it, and a stand-in that keeps the callbacks reaches exactly that.
+	Commands are registered directly rather than through Start. CmdrService rejects its cmdr promise outright
+	when the game is not running, so Start in a test registers nothing at all, silently. A stand-in that keeps
+	the callbacks reaches what is actually worth asserting: what a handler does with the list Cmdr parsed.
 ]]
 local function setup()
 	local maid = Maid.new()
 	local serviceBag = maid:Add(ServiceBag.new())
-	serviceBag:GetService(AccessDataService)
+	local accessDataService = serviceBag:GetService(AccessDataService)
 	local accessPolicyService: AccessPolicyService.AccessPolicyService =
 		serviceBag:GetService(AccessPolicyService) :: any
 	serviceBag:Init()
@@ -33,6 +33,7 @@ local function setup()
 	local commands = {}
 	local service = setmetatable({
 		_maid = maid,
+		_accessDataService = accessDataService,
 		_accessPolicyService = accessPolicyService,
 		_cmdrService = {
 			RegisterCommand = function(_self, definition: any, callback: any)
@@ -44,7 +45,6 @@ local function setup()
 	service:_registerCommands()
 
 	return {
-		maid = maid,
 		accessPolicyService = accessPolicyService,
 		command = function(name: string): any
 			return assert(commands[name], `No command registered named {name}`)
@@ -107,6 +107,17 @@ describe("access-policy", function()
 
 		expect(controller.accessPolicyService:IsPolicyEnabled("kickOnNonAdmin")).toEqual(false)
 		expect(string.find(result, "nosuch") ~= nil).toEqual(true)
+
+		controller:destroy()
+	end)
+
+	it("names every unknown one, in the same checkable order as the rest", function()
+		local controller = setup()
+		controller.registerPolicy("kickOnNonAdmin")
+
+		local result = controller.command("access-policy").run(nil, { "kickOnNonAdmin", "zzz", "aaa" }, "on")
+
+		expect(result).toEqual("No policy registered named: aaa, zzz")
 
 		controller:destroy()
 	end)

--- a/src/access/src/Shared/Commands/AccessCommandUtils.lua
+++ b/src/access/src/Shared/Commands/AccessCommandUtils.lua
@@ -352,8 +352,7 @@ end
 	glance, and counts them once naming them would be a wall -- which is exactly what `*` produces.
 
 	Sorted, because Cmdr builds a list argument by iterating its dedupe table: the order it hands back is
-	hash order, not the order anybody typed. Naming them is only worth doing if they can be checked against
-	something, and an arbitrary order is checkable against nothing.
+	hash order, not the order anybody typed.
 
 	@param names { string }
 	@param noun string -- plural, for the count and empty forms: "facts", "policies"

--- a/src/access/src/Shared/Commands/AccessCommandUtils.lua
+++ b/src/access/src/Shared/Commands/AccessCommandUtils.lua
@@ -351,6 +351,10 @@ end
 	How a list of names reads back in a confirmation. Names them while there are few enough to check at a
 	glance, and counts them once naming them would be a wall -- which is exactly what `*` produces.
 
+	Sorted, because Cmdr builds a list argument by iterating its dedupe table: the order it hands back is
+	hash order, not the order anybody typed. Naming them is only worth doing if they can be checked against
+	something, and an arbitrary order is checkable against nothing.
+
 	@param names { string }
 	@param noun string -- plural, for the count and empty forms: "facts", "policies"
 	@return string
@@ -358,11 +362,14 @@ end
 function AccessCommandUtils.describeNameList(names: { string }, noun: string): string
 	if #names == 0 then
 		return `no {noun}`
-	elseif #names <= NAMED_LIMIT then
-		return table.concat(names, ", ")
+	elseif #names > NAMED_LIMIT then
+		return `{#names} {noun}`
 	end
 
-	return `{#names} {noun}`
+	local sorted = table.clone(names)
+	table.sort(sorted)
+
+	return table.concat(sorted, ", ")
 end
 
 --[=[

--- a/src/access/src/Shared/Commands/AccessCommandUtils.spec.lua
+++ b/src/access/src/Shared/Commands/AccessCommandUtils.spec.lua
@@ -248,9 +248,23 @@ local function strictCmdr()
 	local registered = {}
 
 	local util = setmetatable({
+		-- Narrows, rather than handing back the whole list whatever it was given. A finder that ignores its
+		-- argument makes "resolves the name you typed" pass on any list of one, and pass on a longer one
+		-- purely by what happens to be first.
 		MakeFuzzyFinder = function(list: { string })
-			return function()
-				return list
+			return function(text: string)
+				if text == "" then
+					return list
+				end
+
+				local matches = {}
+				for _, name in list do
+					if string.find(name, text, 1, true) then
+						table.insert(matches, name)
+					end
+				end
+
+				return matches
 			end
 		end,
 		-- Mirrors the real one closely enough to matter: it marks the type Listable (the flag Cmdr gates `*`
@@ -312,7 +326,7 @@ describe("AccessCommandUtils.registerTypes", function()
 		end).never.toThrow()
 	end)
 
-	it("registers every argument type the commands reference", function()
+	it("registers every argument type it offers", function()
 		local cmdr, registered = strictCmdr()
 		AccessCommandUtils.registerTypes(cmdr, fakeAccessDataService(), function()
 			return { "kick-on-non-admin" }
@@ -423,9 +437,11 @@ describe("overriding every fact at once", function()
 end)
 
 describe("toggling every policy at once", function()
-	-- `access-policy * off` is how somebody sees the game with every consequence switched off. Same
-	-- requirements as the fact list, asserted separately because the two types are built from different
-	-- name sources and only one of them is optional.
+	--[[
+		`access-policy * off` is how somebody sees the game with every consequence switched off. Asserted
+		separately from the fact list because the two types are built from different name sources, and only
+		the policy one is optional -- a client that registers without it gets a type that suggests nothing.
+	]]
 	local function policyNamesType()
 		local cmdr, registered = strictCmdr()
 		AccessCommandUtils.registerTypes(cmdr, fakeAccessDataService(), function()
@@ -454,7 +470,10 @@ describe("toggling every policy at once", function()
 		expect(policyNamesType().ArgumentOperatorAliases.all).toEqual("*")
 	end)
 
-	it("leaves the single-policy type alone, which is what the readout commands take", function()
+	it("leaves the singular type alone, since both are built from the one table", function()
+		-- Nothing in this package takes accessPolicyName any more, the same way nothing takes
+		-- accessFactName. Both stay registered for consumers writing their own commands, and neither may be
+		-- turned listable by the registration of the plural next to it.
 		local cmdr, registered = strictCmdr()
 		AccessCommandUtils.registerTypes(cmdr, fakeAccessDataService(), function()
 			return { "kick-on-non-admin" }
@@ -466,7 +485,16 @@ end)
 
 describe("AccessCommandUtils.describeNameList", function()
 	it("names them while a person can still check them", function()
-		expect(AccessCommandUtils.describeNameList({ "ownsGame", "isStaff" }, "facts")).toEqual("ownsGame, isStaff")
+		-- Sorted: Cmdr hands a list argument back in the hash order of its dedupe table, so naming them in
+		-- the order they arrive is naming them in an order that means nothing.
+		expect(AccessCommandUtils.describeNameList({ "ownsGame", "isStaff" }, "facts")).toEqual("isStaff, ownsGame")
+	end)
+
+	it("leaves the caller's list untouched, which is the one the command still has to toggle", function()
+		local names = { "ownsGame", "isStaff" }
+		AccessCommandUtils.describeNameList(names, "facts")
+
+		expect(names).toEqual({ "ownsGame", "isStaff" })
 	end)
 
 	it("counts them once naming them would be a wall", function()

--- a/src/access/src/Shared/Commands/AccessCommandUtils.spec.lua
+++ b/src/access/src/Shared/Commands/AccessCommandUtils.spec.lua
@@ -250,16 +250,15 @@ local function strictCmdr()
 	local util = setmetatable({
 		-- Narrows, rather than handing back the whole list whatever it was given. A finder that ignores its
 		-- argument makes "resolves the name you typed" pass on any list of one, and pass on a longer one
-		-- purely by what happens to be first.
+		-- purely by what happens to be first. Exact matches go to the front for the same reason the real one
+		-- does it: Parse takes the first, so `shop` must not resolve to `watchShop`.
 		MakeFuzzyFinder = function(list: { string })
 			return function(text: string)
-				if text == "" then
-					return list
-				end
-
 				local matches = {}
 				for _, name in list do
-					if string.find(name, text, 1, true) then
+					if name == text then
+						table.insert(matches, 1, name)
+					elseif string.find(name, text, 1, true) then
 						table.insert(matches, name)
 					end
 				end
@@ -472,8 +471,8 @@ describe("toggling every policy at once", function()
 
 	it("leaves the singular type alone, since both are built from the one table", function()
 		-- Nothing in this package takes accessPolicyName any more, the same way nothing takes
-		-- accessFactName. Both stay registered for consumers writing their own commands, and neither may be
-		-- turned listable by the registration of the plural next to it.
+		-- accessFactName. It stays registered for consumers writing their own commands, and must not be
+		-- turned listable by the registration of the plural built from it.
 		local cmdr, registered = strictCmdr()
 		AccessCommandUtils.registerTypes(cmdr, fakeAccessDataService(), function()
 			return { "kick-on-non-admin" }
@@ -484,9 +483,7 @@ describe("toggling every policy at once", function()
 end)
 
 describe("AccessCommandUtils.describeNameList", function()
-	it("names them while a person can still check them", function()
-		-- Sorted: Cmdr hands a list argument back in the hash order of its dedupe table, so naming them in
-		-- the order they arrive is naming them in an order that means nothing.
+	it("names them in a sorted order, since the one they arrive in means nothing", function()
 		expect(AccessCommandUtils.describeNameList({ "ownsGame", "isStaff" }, "facts")).toEqual("isStaff, ownsGame")
 	end)
 


### PR DESCRIPTION
Follow-up to #765. The confirmation from `access-policy` named policies in whatever order Cmdr handed them back, which is hash order rather than anything typed, so it now sorts them. The command handler itself had no test — the promise that a typo in a list leaves nothing switched was asserted only by the commit message — so there is now a spec that reaches the registered commands directly. Two existing assertions in the utils spec were passing for the wrong reason and are corrected, and the error and confirmation strings read properly for a list.