### PR TITLE
fix(access): run client-realm policies for the local player

### DIFF
--- a/src/access/src/Client/AccessServiceClient.lua
+++ b/src/access/src/Client/AccessServiceClient.lua
@@ -17,11 +17,14 @@
 
 local require = require(script.Parent.loader).load(script)
 
+local Players = game:GetService("Players")
+
 local AccessCommandServiceClient = require("AccessCommandServiceClient")
 local AccessDataService = require("AccessDataService")
 local AccessPlayerClient = require("AccessPlayerClient")
 local AccessPolicyService = require("AccessPolicyService")
 local Maid = require("Maid")
+local PlayerMock = require("PlayerMock")
 local ServiceBag = require("ServiceBag")
 
 local AccessServiceClient = {}
@@ -44,14 +47,30 @@ function AccessServiceClient.Init(self: AccessServiceClient, serviceBag: Service
 	self._maid = Maid.new()
 
 	self._accessDataService = self._serviceBag:GetService(AccessDataService) :: any
-	-- Registered here purely so the console knows every policy name. Server-realm policies never run
-	-- client-side; the service skips them.
 	self._accessPolicyService = self._serviceBag:GetService(AccessPolicyService) :: any
 	self._serviceBag:GetService(AccessCommandServiceClient)
 	self._serviceBag:GetService(AccessPlayerClient)
 end
 
-function AccessServiceClient.Start(_self: AccessServiceClient): () end
+--[[
+	The client half of what [AccessService] does on join: without this a client-realm policy is registered,
+	enabled, listed by `access-policies` -- and never applied to anybody, because a policy only runs against
+	a player somebody added.
+
+	The local player and nobody else. Player instances replicate, so this realm can answer questions about
+	everyone here, but a client-realm consequence is presentation *for the person at this client* -- adding
+	the rest would raise this client's paywall on a stranger's verdict.
+
+	Read once, matching production: `Players.LocalPlayer` exists before any LocalScript runs, and a headless
+	test designates its [PlayerMock] before booting bags for the same reason. A realm with neither simply
+	runs no client policies, which is what a bag with no client to speak for should do.
+]]
+function AccessServiceClient.Start(self: AccessServiceClient): ()
+	local localPlayer = Players.LocalPlayer or PlayerMock.getMockedLocalPlayer()
+	if localPlayer then
+		self._maid:GiveTask(self._accessPolicyService:AddPlayer(localPlayer))
+	end
+end
 
 --[=[
 	The shared registry, for a game registering its facts and features.

--- a/src/access/src/Client/AccessServiceClient.spec.lua
+++ b/src/access/src/Client/AccessServiceClient.spec.lua
@@ -1,0 +1,152 @@
+--!strict
+--[[
+	Boots the client entry point the way a game does, which is the only place the question below can be
+	asked: a client-realm policy that nobody added a player to is registered, enabled, listed by
+	`access-policies` -- and silent. Every seam test around it passes, because they all call
+	[AccessPolicyService.AddPlayer] themselves.
+
+	@class AccessServiceClient.spec.lua
+]]
+local require = require(script.Parent.loader).load(script)
+
+local Workspace = game:GetService("Workspace")
+
+local AccessPolicy = require("AccessPolicy")
+local AccessPolicyRealm = require("AccessPolicyRealm")
+local AccessPolicyService = require("AccessPolicyService")
+local AccessServiceClient = require("AccessServiceClient")
+local Jest = require("Jest")
+local Maid = require("Maid")
+local PlayerMock = require("PlayerMock")
+local ServiceBag = require("ServiceBag")
+local TieRealmService = require("TieRealmService")
+local TieRealms = require("TieRealms")
+
+local describe = Jest.Globals.describe
+local expect = Jest.Globals.expect
+local afterEach = Jest.Globals.afterEach
+local it = Jest.Globals.it
+
+local policyCounter = 0
+
+-- Torn down here rather than at the end of each test: a failing test never reaches its last line, and the
+-- local-player designation is ambient, so one leaked mock would be the local player for every test after it.
+local live: any = nil
+afterEach(function()
+	if live then
+		live:destroy()
+		live = nil
+	end
+end)
+
+type SetupOptions = {
+	designateLocalPlayer: boolean?,
+	realm: string?,
+}
+
+local function setup(options: SetupOptions?)
+	local opts: SetupOptions = options or {}
+	local maid = Maid.new()
+
+	-- Parented before designating: the designation is carried as a tag, and an unparented mock reads back
+	-- as nil.
+	local localPlayer = maid:Add(PlayerMock.new()) :: any
+	localPlayer.Parent = Workspace
+
+	if opts.designateLocalPlayer ~= false then
+		PlayerMock.setMockedLocalPlayer(localPlayer)
+		maid:GiveTask(function()
+			if PlayerMock.getMockedLocalPlayer() == localPlayer then
+				PlayerMock.setMockedLocalPlayer(nil)
+			end
+		end)
+	end
+
+	local otherPlayer = maid:Add(PlayerMock.new()) :: any
+	otherPlayer.Parent = Workspace
+
+	local serviceBag = maid:Add(ServiceBag.new())
+	-- Before Init, which only infers a realm when it has not been given one. This runner is a server, so
+	-- without it every client-realm policy here would be skipped for the wrong reason.
+	local tieRealmService: any = serviceBag:GetService(TieRealmService)
+	tieRealmService:SetTieRealm(TieRealms.CLIENT)
+
+	local accessPolicyService: any = serviceBag:GetService(AccessPolicyService)
+	serviceBag:GetService(AccessServiceClient)
+	serviceBag:Init()
+
+	policyCounter += 1
+	local appliedFor: { Player } = {}
+
+	-- Registered between Init and Start, because Start is where the entry point adds the player: a policy
+	-- registered after it would have missed the only application this realm ever makes.
+	maid:GiveTask(accessPolicyService:RegisterPolicy(maid:Add(AccessPolicy.new(serviceBag, {
+		policyName = `recordApplied{policyCounter}`,
+		realm = opts.realm or AccessPolicyRealm.CLIENT,
+		isEnabledByDefault = true,
+		apply = function(context)
+			table.insert(appliedFor, context.player)
+			return nil
+		end,
+	}))))
+
+	serviceBag:Start()
+
+	local controller
+	controller = {
+		maid = maid,
+		serviceBag = serviceBag,
+		accessPolicyService = accessPolicyService,
+		localPlayer = localPlayer,
+		otherPlayer = otherPlayer,
+		appliedFor = appliedFor,
+		destroy = function(_self)
+			maid:DoCleaning()
+		end,
+	}
+
+	live = controller
+	return controller
+end
+
+describe("AccessServiceClient", function()
+	it("initializes and starts, command service and all", function()
+		expect(function()
+			setup()
+		end).never.toThrow()
+	end)
+
+	--[[
+		The regression: nothing else on the client ever adds a player, so an enabled client-realm policy --
+		a paywall screen, a locked banner -- simply never ran in a real game.
+	]]
+	it("runs a client-realm policy for the local player, with nobody having added them", function()
+		local controller = setup()
+
+		expect(controller.appliedFor).toEqual({ controller.localPlayer })
+	end)
+
+	--[[
+		Player instances replicate, so this realm can answer questions about everybody here. Applying to them
+		would raise this client's screen on somebody else's verdict.
+	]]
+	it("adds only the local player, not everybody the client can see", function()
+		local controller = setup()
+
+		expect(table.find(controller.appliedFor, controller.otherPlayer)).toBeNil()
+	end)
+
+	it("leaves a server-realm policy to the server", function()
+		local controller = setup({ realm = AccessPolicyRealm.SERVER })
+
+		expect(controller.appliedFor).toEqual({})
+	end)
+
+	-- Asserted against the undesignated mock rather than against an empty list: the designation is ambient,
+	-- so a mock another spec left designated would be adopted here and is not this test's business.
+	it("starts without a local player rather than erroring", function()
+		local controller = setup({ designateLocalPlayer = false })
+
+		expect(table.find(controller.appliedFor, controller.localPlayer)).toBeNil()
+	end)
+end)


### PR DESCRIPTION
## The bug

`AccessPolicyService` only applies policies to players handed to `AddPlayer`, and the only caller was the server's `AccessService` (`Players.PlayerAdded` → `AddPlayer`). `AccessServiceClient` — its mirror — never added anybody, so `_playerMaids` stayed empty on the client and **no client-realm policy ever ran in a real game**: registered, enabled, listed by `access-policies`, silent.

Found in a game where a client-realm paywall policy never raised its screen while the server-realm policy reading the same feature enforced normally.

Every existing test passed because they all call `AddPlayer` themselves — the wiring between the entry point and the service was the one thing untested.

## The fix

`AccessServiceClient.Start` adds the local player to the policy service, maid-owned.

The local player and nobody else: player instances replicate, so this realm can answer questions about everyone here, but a client-realm consequence is presentation *for the person at this client* — adding the rest would raise this client's screen on a stranger's verdict.

Read once, matching production: `Players.LocalPlayer` exists before any LocalScript runs, and a headless test designates its `PlayerMock` before booting bags for the same reason. A realm with neither runs no client policies.

## Tests

New `AccessServiceClient.spec.lua` boots the client entry point the way a game does: the regression, local-player-only scoping, server-realm skip, and booting with no local player.

Verified both directions with `nevermore test --cloud` in `src/access`: 311/311 green with the fix, and exactly one test fails with the fix reverted.

https://claude.ai/code/session_01FYFnBcgwPT624hfK9rw3GE