### PR TITLE
fix(receiptprocessing): unregister a receipt processor instead of erroring

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4212,6 +4212,9 @@ importers:
       '@quenty/maid':
         specifier: workspace:*
         version: link:../maid
+      '@quenty/nevermore-test-runner':
+        specifier: workspace:*
+        version: link:../nevermore-test-runner
       '@quenty/playermock':
         specifier: workspace:*
         version: link:../player-mock
@@ -4230,6 +4233,9 @@ importers:
       '@quenty/valueobject':
         specifier: workspace:*
         version: link:../valueobject
+      '@quentystudios/jest-lua':
+        specifier: 3.10.0-quenty.2
+        version: 3.10.0-quenty.2
 
   src/rectutils:
     dependencies:

--- a/src/receiptprocessing/deploy.nevermore.json
+++ b/src/receiptprocessing/deploy.nevermore.json
@@ -1,0 +1,10 @@
+{
+  "targets": {
+    "test": {
+      "universeId": 9716264427,
+      "placeId": 130126340232883,
+      "project": "test/default.project.json",
+      "scriptTemplate": "test/scripts/Server/ServerMain.server.lua"
+    }
+  }
+}

--- a/src/receiptprocessing/package.json
+++ b/src/receiptprocessing/package.json
@@ -31,12 +31,14 @@
     "@quenty/enumutils": "workspace:*",
     "@quenty/loader": "workspace:*",
     "@quenty/maid": "workspace:*",
+    "@quenty/nevermore-test-runner": "workspace:*",
     "@quenty/playermock": "workspace:*",
     "@quenty/promise": "workspace:*",
     "@quenty/rx": "workspace:*",
     "@quenty/servicebag": "workspace:*",
     "@quenty/signal": "workspace:*",
-    "@quenty/valueobject": "workspace:*"
+    "@quenty/valueobject": "workspace:*",
+    "@quentystudios/jest-lua": "3.10.0-quenty.2"
   },
   "publishConfig": {
     "access": "public"

--- a/src/receiptprocessing/src/Server/ReceiptProcessingService.lua
+++ b/src/receiptprocessing/src/Server/ReceiptProcessingService.lua
@@ -110,6 +110,7 @@ export type ReceiptProcessor = (
 
 	@param processor (receiptInfo) -> ProductPurchaseDecision | Promise<ProductPurchaseDecision> | nil
 	@param priority number?
+	@return function -- Unregisters the processor. Safe to call after [ReceiptProcessingService.Destroy].
 ]=]
 function ReceiptProcessingService:RegisterReceiptProcessor(processor: ReceiptProcessor, priority: number?): () -> ()
 	assert(self._processors, "Not initialized")
@@ -135,9 +136,14 @@ function ReceiptProcessingService:RegisterReceiptProcessor(processor: ReceiptPro
 	end)
 
 	return function()
-		local index = table.find(self._handles, data)
+		-- Destroy clears the list, and a maid holding this task will run it after that.
+		if not self._processors then
+			return
+		end
+
+		local index = table.find(self._processors, data)
 		if index then
-			table.remove(self._handles, index)
+			table.remove(self._processors, index)
 		end
 	end
 end

--- a/src/receiptprocessing/src/Server/ReceiptProcessingService.spec.lua
+++ b/src/receiptprocessing/src/Server/ReceiptProcessingService.spec.lua
@@ -1,0 +1,118 @@
+--!strict
+--[[
+	The processor chain, driven directly rather than through MarketplaceService: Start is what installs
+	the engine callback, and nothing here needs the engine to route a receipt.
+
+	@class ReceiptProcessingService.spec.lua
+]]
+
+local require = require(script.Parent.loader).load(script)
+
+local Jest = require("Jest")
+local Maid = require("Maid")
+local ReceiptProcessingService = require("ReceiptProcessingService")
+local ServiceBag = require("ServiceBag")
+
+local describe = Jest.Globals.describe
+local expect = Jest.Globals.expect
+local it = Jest.Globals.it
+
+local function receiptInfo(productId: number): any
+	return {
+		PurchaseId = 1,
+		PlayerId = 55234567,
+		ProductId = productId,
+		PlaceIdWherePurchased = 1,
+		CurrencySpent = 100,
+		CurrencyType = Enum.CurrencyType.Robux,
+		ProductPurchaseChannel = Enum.ProductPurchaseChannel.InExperience,
+	}
+end
+
+local function setup()
+	local maid = Maid.new()
+
+	local serviceBag = maid:Add(ServiceBag.new())
+	local service = serviceBag:GetService(ReceiptProcessingService) :: any
+
+	serviceBag:Init()
+
+	return {
+		maid = maid,
+		service = service,
+	}
+end
+
+describe("ReceiptProcessingService.RegisterReceiptProcessor", function()
+	it("routes receipts to the registered processor", function()
+		local context = setup()
+
+		local seen = {}
+		context.service:RegisterReceiptProcessor(function(info)
+			table.insert(seen, info.ProductId)
+			return Enum.ProductPurchaseDecision.PurchaseGranted
+		end)
+
+		expect(context.service:_handleProcessReceiptAsync(receiptInfo(11))).toBe(
+			Enum.ProductPurchaseDecision.PurchaseGranted
+		)
+		expect(seen).toEqual({ 11 })
+
+		context.maid:DoCleaning()
+	end)
+
+	it("stops routing once the returned unregister is called", function()
+		local context = setup()
+
+		local calls = 0
+		local unregister = context.service:RegisterReceiptProcessor(function()
+			calls += 1
+			return Enum.ProductPurchaseDecision.PurchaseGranted
+		end)
+
+		context.service:_handleProcessReceiptAsync(receiptInfo(11))
+		unregister()
+		context.service:_handleProcessReceiptAsync(receiptInfo(11))
+
+		expect(calls).toBe(1)
+
+		context.maid:DoCleaning()
+	end)
+
+	it("unregisters only its own processor", function()
+		local context = setup()
+
+		local otherCalls = 0
+		context.service:RegisterReceiptProcessor(function()
+			otherCalls += 1
+			return Enum.ProductPurchaseDecision.PurchaseGranted
+		end)
+
+		local unregister = context.service:RegisterReceiptProcessor(function()
+			return nil
+		end)
+		unregister()
+
+		context.service:_handleProcessReceiptAsync(receiptInfo(11))
+
+		expect(otherCalls).toBe(1)
+
+		context.maid:DoCleaning()
+	end)
+
+	-- A maid holding the unregister as a task runs it during teardown, after Destroy has cleared the list.
+	-- Throwing there takes the rest of the teardown down with it.
+	it("survives being called after the service is destroyed", function()
+		local context = setup()
+
+		local unregister = context.service:RegisterReceiptProcessor(function()
+			return Enum.ProductPurchaseDecision.PurchaseGranted
+		end)
+
+		context.maid:DoCleaning()
+
+		expect(function()
+			unregister()
+		end).never.toThrow()
+	end)
+end)

--- a/src/receiptprocessing/src/jest.config.lua
+++ b/src/receiptprocessing/src/jest.config.lua
@@ -1,0 +1,4 @@
+return {
+	testMatch = { "**/*.spec" },
+	passWithNoTests = true,
+}

--- a/src/receiptprocessing/test/default.project.json
+++ b/src/receiptprocessing/test/default.project.json
@@ -1,0 +1,17 @@
+{
+  "name": "ReceiptProcessingTest",
+  "tree": {
+    "$className": "DataModel",
+    "ServerScriptService": {
+      "$properties": {
+        "LoadStringEnabled": true
+      },
+      "receiptprocessing": {
+        "$path": ".."
+      },
+      "Script": {
+        "$path": "scripts/Server"
+      }
+    }
+  }
+}

--- a/src/receiptprocessing/test/scripts/Server/ServerMain.server.lua
+++ b/src/receiptprocessing/test/scripts/Server/ServerMain.server.lua
@@ -1,0 +1,22 @@
+--!nonstrict
+--[[
+	@class ServerMain
+]]
+
+local ServerScriptService = game:GetService("ServerScriptService")
+
+local root = ServerScriptService.receiptprocessing
+local loader = root:FindFirstChild("LoaderUtils", true).Parent
+local require = require(loader).bootstrapGame(root)
+
+local NevermoreTestRunnerUtils = require("NevermoreTestRunnerUtils")
+
+if NevermoreTestRunnerUtils.runTestsIfNeededAsync(root) then
+	return
+end
+
+local serviceBag = require("ServiceBag").new()
+serviceBag:GetService(require("ReceiptProcessingService"))
+
+serviceBag:Init()
+serviceBag:Start()


### PR DESCRIPTION
## The unregister closure could never unregister anything

`RegisterReceiptProcessor` returns a closure meant to remove the processor. It
indexed `self._handles` — a field the service never creates:

```lua
return function()
	local index = table.find(self._handles, data)  -- self._handles is always nil
	...
end
```

So calling it threw `invalid argument #1 to 'find' (table expected, got nil)`
instead of unregistering. Two consequences:

1. A processor could not be removed for the lifetime of the service.
2. The usual way to hold that closure is `maid:GiveTask(unregister)` — so the
   throw lands during teardown and takes the rest of the maid's tasks with it.

Points it at `_processors`, where the processor actually lives, and returns early
once `Destroy` has cleared the list. That second guard is not defensive padding:
a maid runs its tasks *after* `Destroy` nils `_processors`, which is precisely
when this closure gets called.

## Tests

The package had no specs, so this adds a test target for it following
`docs/testing/testing.md` — `deploy.nevermore.json` (via `nevermore deploy init`),
`test/default.project.json`, the `ServerMain` script template, `jest.config.lua`,
and the `jest-lua` / `nevermore-test-runner` dependencies.

Four cases: the chain routes to a registered processor, the returned unregister
stops routing, it unregisters only its own processor, and it is safe to call after
`Destroy`.

Not a placebo — verified by reintroducing the `_handles` lookup:

| | with `_handles` (old) | with this fix |
|---|---|---|
| routes receipts to the registered processor | ✅ | ✅ |
| stops routing once unregister is called | ❌ | ✅ |
| unregisters only its own processor | ❌ | ✅ |
| survives being called after Destroy | ❌ | ✅ |

## Verification

`nevermore test --cloud` from `src/receiptprocessing`: 4/4 passed.
`nevermore batch test --cloud` (dependents with test targets): `@quenty/access`
311/311, `@quenty/gameproductservice` 80/80.

https://claude.ai/code/session_01KPgnohqfGZQQwWv6PnToJC
