### PR TITLE
docs(clienttranslator): write down that localization tables are per realm

### DIFF
--- a/docs/_AI_INDEX.md
+++ b/docs/_AI_INDEX.md
@@ -80,4 +80,4 @@ consumer-facing page has a matching package doc, link to it so readers can find 
 | [ides/vscode.md](ides/vscode.md) | VSCode/Cursor setup: extensions, luau-lsp config, settings |
 | [gotchas/tooling.md](gotchas/tooling.md) | Tooling gotchas: Lune, symlinks, Rojo, linter CLI tools, CI annotations |
 | [gotchas/troubleshooting.md](gotchas/troubleshooting.md) | Troubleshooting: setup failures, linting issues, test auth, Rojo errors |
-| [gotchas/localization.md](gotchas/localization.md) | Localization gotchas **for consumers**: which locale file a player gets (script vs region), missing-key behavior, self-correcting text, one entry per key. Design intent lives in `src/clienttranslator/docs/` |
+| [gotchas/localization.md](gotchas/localization.md) | Localization gotchas **for consumers**: which locale file a player gets (script vs region), missing-key behavior, runtime-generated keys belonging to the realm that generated them, self-correcting text, one entry per key. Design intent lives in `src/clienttranslator/docs/` |

--- a/docs/gotchas/localization.md
+++ b/docs/gotchas/localization.md
@@ -38,6 +38,34 @@ translation key itself (`quests.groups.theBeginning`), and one warning is logged
 signal that a key is missing everywhere, not just in the current language — a key missing only in
 the current language quietly falls back to the source locale instead.
 
+## Keys you generate at runtime belong to the realm that generated them
+
+`JSONTranslator:ToTranslationKey(prefix, text)` hands back a key *and* registers `text` as the
+source behind it — into that realm's localization table. The server and the client each have their
+own (`GeneratedJSONTable_Server` and `GeneratedJSONTable_Client`), and neither sees the other's.
+
+So if your server turns an authored string into a key and sends the client only the key, the client
+has nothing to render but the key. Uploaded cloud translations do not cover it either: they only
+know keys that existed when you exported the CSV, and this one was generated at runtime.
+
+Mint on the realm that renders. Send the text — or the prefix and the text — and let the client
+call `ToTranslationKey` or `ObserveTranslation`, which registers the source as it derives the same
+key:
+
+```lua
+-- Server: mint so the string lands in the CSV export, but send the text, not the key.
+translator:ToTranslationKey("npcs", displayName)
+remote:FireClient(player, displayName)
+
+-- Client: the same call derives the same key, and registers the source while doing it.
+maid:GiveTask(translator:ObserveTranslation("npcs", displayName):Subscribe(function(text)
+    label.Text = text
+end))
+```
+
+Unlike a key whose data is merely still queued, this does not fix itself a frame later — there is
+no translation on the way.
+
 ## Text may correct itself a frame after it appears
 
 `ObserveFormatByKey` emits immediately so a label is never blank, then re-emits the real

--- a/src/clienttranslator/docs/design.md
+++ b/src/clienttranslator/docs/design.md
@@ -23,6 +23,29 @@ JSONTranslator          per-translator: owns a loader, resolves text for a key
 Loaders only ever *queue*. Everything that touches the `LocalizationTable` goes through
 `TranslatorService`.
 
+## One table per realm, and what that costs
+
+`TranslatorService.GetLocalizationTable` names the table by realm — `GeneratedJSONTable_Server` on
+the server, `GeneratedJSONTable_Client` on the client — both under `LocalizationService`. They were
+a single `GeneratedJSONTable` until `c1a7b0a` (2023), whose message says only "fix localization
+table replication". The failure it removes is visible in the shape it replaced: with one name the
+server created the table, it replicated, and the client then wrote its own entries into a
+server-owned instance — writes that stay local, and that the server's next `SetEntries` re-
+replicates the whole entry list over.
+
+The consequence is easy to miss, because nothing in the API hints at it. `ToTranslationKey(prefix,
+text)` returns a key **and registers `text` as that key's source** — into the table of the realm it
+ran on. A key minted on the server therefore reaches the client with nothing behind it. The
+client's table never saw the source, and the cloud translator does not know keys registered at
+runtime either, so `_doTranslation` falls through every translator and returns the key, which is
+what the player reads. Nothing corrects it later: there is no translation on its way.
+
+**So mint on the realm that renders.** Send the authored text (or the prefix and text) rather than
+only the key, and let the reading realm call `ToTranslationKey` or `ObserveTranslation` — since
+registration is a side effect of minting, one call does both, and the derivation is deterministic
+so both realms land on the same key. The server may keep minting its own copy for the CSV export;
+the two registrations are the same entry with the same source.
+
 ## Writes are batched, and that is not negotiable
 
 Every raw write to a `LocalizationTable` invalidates every `AutoLocalize` entry in the engine. A
@@ -116,6 +139,19 @@ ValueObject that a locale subscription updates. Signal handlers fire **newest-co
 such a subscription can still hold the previous locale's translator while a reader is translating
 for the new one — which rendered the source language permanently when swapping back to an
 already-loaded locale.
+
+## Sharp edge: the source locale is a constant
+
+`ToTranslationKey` registers its source under `"en"` — not under the table's `SourceLocaleId`, and
+not under the locale the `JSONTranslator` was constructed for. Synchronous reads survive that by
+coincidence. `FormatByKey` lands its key through `FlushEntryForKey`, which flushes only the locales
+a read can consult (the current locale, the table's `SourceLocaleId`, and both language subtags),
+and a fresh `LocalizationTable`'s `SourceLocaleId` is `en-us`, whose subtag is `en`.
+
+Reuse a `GeneratedJSONTable_Client` shipped in a place file with a different source locale and the
+`"en"` value falls in none of those buckets: it stays queued past the read, `FormatByKey` misses,
+and since that path is one-shot the key renders for the life of whatever drew it. Taking the source
+locale from the translator would remove the coincidence. Not fixed today.
 
 ## Locale compatibility vs closest key
 


### PR DESCRIPTION
The server and the client keep separate generated localization tables, which means a translation key minted at runtime on one realm is unreadable on the other — it renders as the key, and nothing arrives later to fix it. That was not written down anywhere, so this records it in the package design notes and, in the form a game developer meets it, on the localization gotchas page. Also notes a sharp edge found while writing it up: ToTranslationKey registers its source under a hardcoded "en" and synchronous reads only work because a fresh table's source locale happens to be en-us.
