### PR TITLE
feat(cli): make a passing test run mean tests were seen to pass

### DIFF
--- a/tools/nevermore-cli/src/commands/batch-command/batch-test-command.ts
+++ b/tools/nevermore-cli/src/commands/batch-command/batch-test-command.ts
@@ -60,64 +60,84 @@ export const batchTestCommand: CommandModule<
   command: 'test',
   describe: 'Run tests for changed packages with test targets',
   builder: (yargs) => {
-    return yargs
-      .option('cloud', {
-        describe: 'Run tests via Open Cloud instead of locally',
-        type: 'boolean',
-        default: false,
-      })
-      .option('api-key', {
-        describe: 'Roblox Open Cloud API key (--cloud only)',
-        type: 'string',
-      })
-      .option('all', {
-        describe: 'Test all packages with test targets, not just changed',
-        type: 'boolean',
-        default: false,
-      })
-      .option('base', {
-        describe: 'Git ref to diff against for change detection',
-        type: 'string',
-        default: 'origin/main',
-      })
-      .option('concurrency', {
-        describe: 'Max parallel tests (0 = unlimited, default: unlimited)',
-        type: 'number',
-      })
-      .option('output', {
-        describe: 'Write JSON results to this file',
-        type: 'string',
-      })
-      .option('limit', {
-        describe: 'Max number of packages to test (for local debugging)',
-        type: 'number',
-      })
-      .option('logs', {
-        describe: 'Show execution logs for all packages (not just failures)',
-        type: 'boolean',
-        default: false,
-      })
-      .option('aggregated', {
-        describe:
-          'Build all packages into a single place and execute one batch script',
-        type: 'boolean',
-        default: true,
-      })
-      .option('batch-place-id', {
-        describe:
-          'Override placeId for the aggregated batch upload (--aggregated only)',
-        type: 'number',
-      })
-      .option('batch-universe-id', {
-        describe:
-          'Override universeId for the aggregated batch upload (--aggregated only)',
-        type: 'number',
-      })
-      .option('timeout', {
-        describe:
-          'Max script execution time in seconds for the whole batch. Sent to the Open Cloud API so Roblox cancels server-side on overrun. Max 300s (API limit). (default: 300)',
-        type: 'number',
-      });
+    return (
+      yargs
+        .option('cloud', {
+          describe: 'Run tests via Open Cloud instead of locally',
+          type: 'boolean',
+          default: false,
+        })
+        .option('api-key', {
+          describe: 'Roblox Open Cloud API key (--cloud only)',
+          type: 'string',
+        })
+        .option('all', {
+          describe: 'Test all packages with test targets, not just changed',
+          type: 'boolean',
+          default: false,
+        })
+        .option('base', {
+          describe: 'Git ref to diff against for change detection',
+          type: 'string',
+          default: 'origin/main',
+        })
+        .option('concurrency', {
+          describe: 'Max parallel tests (0 = unlimited, default: unlimited)',
+          type: 'number',
+        })
+        .option('output', {
+          describe: 'Write JSON results to this file',
+          type: 'string',
+        })
+        .option('limit', {
+          describe: 'Max number of packages to test (for local debugging)',
+          type: 'number',
+        })
+        .option('logs', {
+          describe: 'Show execution logs for all packages (not just failures)',
+          type: 'boolean',
+          default: false,
+        })
+        .option('aggregated', {
+          describe:
+            'Build all packages into a single place and execute one batch script',
+          type: 'boolean',
+          default: true,
+        })
+        .option('batch-place-id', {
+          describe:
+            'Override placeId for the aggregated batch upload (--aggregated only)',
+          type: 'number',
+        })
+        .option('batch-universe-id', {
+          describe:
+            'Override universeId for the aggregated batch upload (--aggregated only)',
+          type: 'number',
+        })
+        .option('timeout', {
+          describe:
+            'Max script execution time in seconds for the whole batch. Sent to the Open Cloud API so Roblox cancels server-side on overrun. Max 300s (API limit). (default: 300)',
+          type: 'number',
+        })
+        // Accepted only to fail with a useful message. A batch runs one shared
+        // script across packages, so there is nothing for arbitrary Luau to mean
+        // here — but yargs strict mode would otherwise reject it with a bare
+        // "Unknown argument" that does not say where to go instead.
+        .option('script-text', {
+          hidden: true,
+          type: 'string',
+        })
+        .check((args) => {
+          if (args.scriptText !== undefined) {
+            throw new Error(
+              '--script-text is not supported by "batch test", which runs one shared script for all packages.\n' +
+                'Run it against a single package instead:\n' +
+                '  cd <package> && nevermore test --cloud --script-text \'print("hi")\''
+            );
+          }
+          return true;
+        })
+    );
   },
   handler: async (args) => {
     try {

--- a/tools/nevermore-cli/src/commands/test-command/test-command.ts
+++ b/tools/nevermore-cli/src/commands/test-command/test-command.ts
@@ -56,9 +56,9 @@ export class TestProjectCommand<T>
       type: 'string',
     });
     args.option('logs', {
-      describe: 'Show execution logs',
+      describe:
+        'Show execution logs. Defaults on with --script-text, whose output is the whole point of the run',
       type: 'boolean',
-      default: false,
     });
     args.option('universe-id', {
       describe:
@@ -84,7 +84,7 @@ export class TestProjectCommand<T>
     });
     args.option('timeout', {
       describe:
-        'Max script execution time in seconds. Sent to the Open Cloud API so Roblox cancels server-side on overrun (default: 120)',
+        'Max script execution time in seconds. Sent to the Open Cloud API so Roblox cancels server-side on overrun. Max 300s (API limit). (default: 300)',
       type: 'number',
     });
 
@@ -94,7 +94,10 @@ export class TestProjectCommand<T>
   public handler = async (args: TestProjectArgs) => {
     const cwd = process.cwd();
     const packageName = (await readPackageNameAsync(cwd)) ?? path.basename(cwd);
-    const showLogs = args.logs ?? false;
+    // A probe run exists to show its output. Hiding it behind an opt-in flag
+    // made --script-text look broken enough that a workaround was written into
+    // the docs instead of a bug report.
+    const showLogs = args.logs ?? args.scriptText !== undefined;
     const useSpinner = process.stdout.isTTY && !args.verbose;
 
     const reporter = new CompositeReporter(

--- a/tools/nevermore-cli/src/utils/open-cloud/open-cloud-client.ts
+++ b/tools/nevermore-cli/src/utils/open-cloud/open-cloud-client.ts
@@ -339,6 +339,7 @@ export class OpenCloudClient {
     const structured: { message: string; createTime: string }[] = [];
     let pageToken: string | undefined;
     let pagesFetched = 0;
+    let entriesFetched = 0;
 
     do {
       const url = new URL(`https://apis.roblox.com/cloud/v2/${taskPath}/logs`);
@@ -386,6 +387,7 @@ export class OpenCloudClient {
         }
       }
 
+      entriesFetched += (data.luauExecutionSessionTaskLogs ?? []).length;
       pagesFetched++;
       pageToken = data.nextPageToken || undefined;
     } while (pageToken);
@@ -402,7 +404,8 @@ export class OpenCloudClient {
     // the task and the parser, and the parser cannot tell a short run from a
     // truncated fetch. Record what arrived so a real run can settle it.
     OutputHelper.verbose(
-      `[open-cloud] Task logs: ${pagesFetched} page(s), ${messages.length} messages, ${text.length} chars`
+      `[open-cloud] Task logs: ${pagesFetched} page(s), ${entriesFetched} entries, ` +
+        `${messages.length} messages, ${text.length} chars`
     );
 
     return text;

--- a/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.test.ts
+++ b/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { countTracebacks, parseBatchTestLogs } from './batch-log-parser.js';
+import {
+  countTracebacks,
+  findSummaryEntries,
+  parseBatchTestLogs,
+} from './batch-log-parser.js';
 
 const SLUG_MAP = new Map([['egghunt2026', 'egghunt2026']]);
 
@@ -38,6 +42,31 @@ describe('parseBatchTestLogs', () => {
 
     expect(result?.success).toBe(true);
     expect(result?.testCounts).toEqual({ passed: 275, failed: 0, total: 275 });
+  });
+
+  it('does not let an out-of-order END steal another package’s output', () => {
+    // The API does not deliver messages in order, so a stray END can arrive
+    // mid-section. Only the first section can have lost its head; past that the
+    // log is well-formed and a BEGIN-less END must not claim anything.
+    const twoPackages = new Map([
+      ['alpha', 'alpha'],
+      ['beta', 'beta'],
+    ]);
+    const logs = [
+      '===BATCH_TEST_BEGIN alpha===',
+      'Tests:  10 passed, 10 total',
+      '===BATCH_TEST_END beta PASS 5===',
+      '===BATCH_TEST_END alpha PASS 10===',
+      '===BATCH_TEST_SUMMARY===',
+      '[{"slug":"alpha","success":true},{"slug":"beta","success":true}]',
+    ].join('\n');
+
+    const results = parseBatchTestLogs(logs, twoPackages);
+
+    expect(results.get('alpha')?.testCounts?.total).toBe(10);
+    // beta never had a section of its own; it must not inherit alpha's.
+    expect(results.get('beta')?.testCounts).toBeUndefined();
+    expect(results.get('beta')?.success).toBe(false);
   });
 
   it('fails a pass it cannot read, rather than trusting the pcall', () => {
@@ -85,6 +114,26 @@ describe('parseBatchTestLogs', () => {
 
     expect(result?.testCounts?.failed).toBe(0);
     expect(result?.tracebackCount).toBe(1);
+  });
+});
+
+describe('findSummaryEntries', () => {
+  it('finds the summary even when output landed after it', () => {
+    // Messages are not delivered in order, so a stray line can follow the
+    // summary. Treating the whole remainder as one JSON blob made the same
+    // batch parse on one run and fail on the next.
+    const lines = [
+      '[{"slug":"alpha","success":true}]',
+      '  ✓ a stray line that arrived late',
+    ];
+
+    expect(findSummaryEntries(lines, 0)).toEqual([
+      { slug: 'alpha', success: true },
+    ]);
+  });
+
+  it('returns undefined when there is no array to find', () => {
+    expect(findSummaryEntries(['not json at all'], 0)).toBeUndefined();
   });
 });
 

--- a/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.test.ts
+++ b/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.test.ts
@@ -23,10 +23,11 @@ describe('parseBatchTestLogs', () => {
     expect(result?.testCounts).toEqual({ passed: 275, failed: 0, total: 275 });
   });
 
-  it('fails a pass it cannot read, rather than trusting the pcall', () => {
-    // The summary prints last, so it survives a log window that dropped the
-    // head. The pcall said success, but nothing here saw a test run.
+  it('attributes a section closed by END when its BEGIN was dropped', () => {
+    // Open Cloud keeps only the tail of a long run's log, so BEGIN — printed
+    // first — is the first casualty while END and the summary survive.
     const logs = [
+      '  ✓ some test that survived (3 ms)',
       'Tests:  275 passed, 275 total',
       '===BATCH_TEST_END egghunt2026 PASS 1000===',
       '===BATCH_TEST_SUMMARY===',
@@ -35,8 +36,23 @@ describe('parseBatchTestLogs', () => {
 
     const result = parseBatchTestLogs(logs, SLUG_MAP).get('egghunt2026');
 
+    expect(result?.success).toBe(true);
+    expect(result?.testCounts).toEqual({ passed: 275, failed: 0, total: 275 });
+  });
+
+  it('fails a pass it cannot read, rather than trusting the pcall', () => {
+    // No END marker either, so there is no boundary to attribute output with.
+    // The pcall said success, but nothing here saw a test run.
+    const logs = [
+      'Tests:  275 passed, 275 total',
+      '===BATCH_TEST_SUMMARY===',
+      '[{"slug":"egghunt2026","success":true,"durationMs":1000}]',
+    ].join('\n');
+
+    const result = parseBatchTestLogs(logs, SLUG_MAP).get('egghunt2026');
+
     expect(result?.success).toBe(false);
-    expect(result?.error).toContain('No test output could be attributed');
+    expect(result?.error).toContain('no output could be attributed');
     expect(result?.testCounts).toBeUndefined();
   });
 

--- a/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.ts
+++ b/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.ts
@@ -72,6 +72,9 @@ export function parseBatchTestLogs(
   let summaryLineIndex = -1;
   let beginMarkersSeen = 0;
   let endMarkersSeen = 0;
+  let strayEndMarkers = 0;
+  /** Only one section can have lost its head: the one the log was cut inside. */
+  let headSectionClaimed = false;
 
   // Matches "<slug> PASS|FAIL [<durationMs>]" — slugs have no whitespace.
   const endInnerPattern = /^(\S+)\s+(?:PASS|FAIL)(?:\s+(\d+))?$/;
@@ -93,21 +96,36 @@ export function parseBatchTestLogs(
       const endSlug = match ? match[1] : inner;
       const durationStr = match?.[2];
 
-      // Close on END, not on a matching BEGIN. Open Cloud keeps only the tail
-      // of a long run's log, so BEGIN — printed first — is the first thing
-      // lost, while END and the summary always survive. Everything since the
-      // last boundary belongs to the package this END names.
-      if (currentSlug === null || endSlug === currentSlug) {
+      // A section normally closes on the END matching its own BEGIN.
+      const closesOwnSection = endSlug === currentSlug;
+
+      // Open Cloud keeps only the tail of a long run's log, so BEGIN — printed
+      // first — can be lost while END and the summary survive. Recovering that
+      // means letting an END with no open section claim what precedes it, but
+      // only where the head can actually have been dropped: before any BEGIN
+      // has survived, and only once. Past that point the log is well-formed,
+      // and a BEGIN-less END is a message delivered out of order (the API does
+      // not order them), which must not be allowed to claim another package's
+      // output.
+      const closesDroppedHead =
+        currentSlug === null && beginMarkersSeen === 0 && !headSectionClaimed;
+
+      if (closesOwnSection || closesDroppedHead) {
         logSections.set(endSlug, currentLines.join('\n'));
-        if (currentSlug === null) {
+        if (closesDroppedHead) {
           partialSections.add(endSlug);
+          headSectionClaimed = true;
         }
         if (durationStr !== undefined) {
           markerDurations.set(endSlug, parseInt(durationStr, 10));
         }
+        currentSlug = null;
+        currentLines = [];
+      } else {
+        // Reordered marker from another package. Ignore it without resetting
+        // state, so the section it interrupted still closes on its own END.
+        strayEndMarkers++;
       }
-      currentSlug = null;
-      currentLines = [];
       continue;
     }
 
@@ -126,12 +144,16 @@ export function parseBatchTestLogs(
   const summaryResults = new Map<string, boolean>();
   const summaryDurations = new Map<string, number>();
   if (summaryLineIndex >= 0 && summaryLineIndex + 1 < lines.length) {
-    const jsonLine = lines
-      .slice(summaryLineIndex + 1)
-      .join('\n')
-      .trim();
-    try {
-      const entries = JSON.parse(jsonLine) as SummaryEntry[];
+    const entries = findSummaryEntries(lines, summaryLineIndex + 1);
+    if (entries === undefined) {
+      OutputHelper.verbose(
+        `[batch-log-parser] Failed to parse JSON summary after line ${summaryLineIndex}: ` +
+          lines
+            .slice(summaryLineIndex + 1, summaryLineIndex + 3)
+            .join('\n')
+            .slice(0, 200)
+      );
+    } else {
       for (const entry of entries) {
         summaryResults.set(entry.slug, entry.success);
         if (typeof entry.durationMs === 'number') {
@@ -146,19 +168,19 @@ export function parseBatchTestLogs(
         );
       }
       console.error(
-        `[batch-log-parser] Parsed ${entries.length} summary entries, ${failures.length} failures`
-      );
-    } catch {
-      OutputHelper.verbose(
-        `[batch-log-parser] Failed to parse JSON summary: ${jsonLine.slice(
-          0,
-          200
-        )}`
+        `[batch-log-parser] Parsed ${entries.length} summary entries, ${failures.length} pcall failures`
       );
     }
   }
 
   // ── Warn when the batch produced no recognizable output ──
+
+  if (strayEndMarkers > 0) {
+    OutputHelper.verbose(
+      `[batch-log-parser] Ignored ${strayEndMarkers} out-of-order END marker(s); ` +
+        'their sections closed on their own boundaries.'
+    );
+  }
 
   const noOutputAtAll = logSections.size === 0 && summaryResults.size === 0;
   if (noOutputAtAll) {
@@ -216,8 +238,12 @@ export function parseBatchTestLogs(
     // The pcall result only proves the script did not throw. It is a floor, not
     // a verdict — everything below can fail a run it called successful.
     let success = summarySuccess ?? false;
-    if (!success) {
+    if (summarySuccess === false) {
       reasons.push('the batch runner reported a Luau error');
+    } else if (summarySuccess === undefined) {
+      // Absent from the summary is a different fault from failing in it, and
+      // conflating them sends you hunting for a Luau error that never happened.
+      reasons.push('this package is missing from the batch summary');
     }
 
     if (attributedLogs !== undefined) {
@@ -284,6 +310,47 @@ export function parseBatchTestLogs(
   }
 
   return results;
+}
+
+/**
+ * Find the summary array in the lines following the summary marker.
+ *
+ * The marker is printed last, but the API does not deliver messages in order,
+ * so unrelated output can land after it. Treating everything past the marker as
+ * one JSON blob therefore fails intermittently — the same batch parses on one
+ * run and not the next. Scan for the array instead of assuming it is alone.
+ */
+export function findSummaryEntries(
+  lines: string[],
+  startIndex: number
+): SummaryEntry[] | undefined {
+  const MAX_SPAN = 50;
+
+  for (let i = startIndex; i < lines.length; i++) {
+    if (!lines[i].trim().startsWith('[')) {
+      continue;
+    }
+
+    // Normally one line, but allow the array to span a few in case the runner
+    // or the transport breaks it up.
+    for (let end = i; end < Math.min(lines.length, i + MAX_SPAN); end++) {
+      try {
+        const parsed = JSON.parse(
+          lines
+            .slice(i, end + 1)
+            .join('\n')
+            .trim()
+        );
+        if (Array.isArray(parsed)) {
+          return parsed as SummaryEntry[];
+        }
+      } catch {
+        // Incomplete so far — grow the window and try again.
+      }
+    }
+  }
+
+  return undefined;
 }
 
 export { countTracebacks } from '../test-log-parser.js';

--- a/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.ts
+++ b/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.ts
@@ -1,5 +1,10 @@
 import { OutputHelper } from '@quenty/cli-output-helpers';
-import { type ParsedTestCounts, parseTestCounts } from '../test-log-parser.js';
+import {
+  type ParsedTestCounts,
+  evaluateTestOutcome,
+  parseTestCounts,
+} from '../test-log-parser.js';
+import { formatTracebacks, parseTracebacks } from './traceback-parser.js';
 
 export interface BatchPackageResult {
   slug: string;
@@ -59,6 +64,8 @@ export function parseBatchTestLogs(
   // ── Pass 1: Extract per-package log sections from markers ──
 
   const logSections = new Map<string, string>();
+  /** Sections closed by an END whose BEGIN never arrived — start of output lost. */
+  const partialSections = new Set<string>();
   const markerDurations = new Map<string, number>();
   let currentSlug: string | null = null;
   let currentLines: string[] = [];
@@ -86,16 +93,21 @@ export function parseBatchTestLogs(
       const endSlug = match ? match[1] : inner;
       const durationStr = match?.[2];
 
-      if (currentSlug && endSlug === currentSlug) {
-        logSections.set(currentSlug, currentLines.join('\n'));
-        if (durationStr !== undefined) {
-          markerDurations.set(currentSlug, parseInt(durationStr, 10));
+      // Close on END, not on a matching BEGIN. Open Cloud keeps only the tail
+      // of a long run's log, so BEGIN — printed first — is the first thing
+      // lost, while END and the summary always survive. Everything since the
+      // last boundary belongs to the package this END names.
+      if (currentSlug === null || endSlug === currentSlug) {
+        logSections.set(endSlug, currentLines.join('\n'));
+        if (currentSlug === null) {
+          partialSections.add(endSlug);
         }
-        currentSlug = null;
-        currentLines = [];
+        if (durationStr !== undefined) {
+          markerDurations.set(endSlug, parseInt(durationStr, 10));
+        }
       }
-      // If endSlug doesn't match currentSlug, this is a reordered marker
-      // from another package — ignore it without resetting state.
+      currentSlug = null;
+      currentLines = [];
       continue;
     }
 
@@ -104,9 +116,9 @@ export function parseBatchTestLogs(
       break;
     }
 
-    if (currentSlug) {
-      currentLines.push(lines[i]);
-    }
+    // Accumulate unconditionally: output that precedes the first surviving
+    // BEGIN still belongs to whichever package's END closes it.
+    currentLines.push(lines[i]);
   }
 
   // ── Pass 2: Parse the JSON summary for authoritative pcall results ──
@@ -199,54 +211,64 @@ export function parseBatchTestLogs(
       unattributedClaimed = true;
     }
     const summarySuccess = summaryResults.get(slug);
+    const reasons: string[] = [];
 
-    // The JSON summary (pcall result) is the primary success signal.
-    // Jest failure detection provides a secondary override.
-    //
-    // Gate on attributed output only. Unattributed output is shown but not
-    // judged: whatever broke attribution is reason enough not to trust which
-    // package a failure line belongs to.
+    // The pcall result only proves the script did not throw. It is a floor, not
+    // a verdict — everything below can fail a run it called successful.
     let success = summarySuccess ?? false;
-    let error: string | undefined;
-    if (success && attributedLogs) {
-      const hasJestFailures = _hasJestFailuresInLogs(attributedLogs);
-      if (hasJestFailures) {
+    if (!success) {
+      reasons.push('the batch runner reported a Luau error');
+    }
+
+    if (attributedLogs !== undefined) {
+      const outcome = evaluateTestOutcome(attributedLogs, {
+        requireTestReport: true,
+      });
+      if (!outcome.success) {
         success = false;
-        error = 'Jest reported failing tests';
+        reasons.push(...outcome.failureReasons);
       }
-    }
-
-    // A pass we cannot read is not a pass. The pcall only proves the script did
-    // not throw, which says nothing about whether any test ran or passed.
-    if (success && !attributedLogs) {
+    } else {
+      // Judged unreadable rather than judged by content: whatever broke
+      // attribution is reason enough not to trust which package a line is from.
       success = false;
-      error =
-        `No test output could be attributed to this package ` +
-        `(${rawLogs.length} chars received, ${beginMarkersSeen} BEGIN markers found). ` +
-        'Unattributed output follows.';
-    }
-
-    if (!success && !noOutputAtAll) {
-      console.error(
-        `[batch-log-parser] ${slug}: summarySuccess=${summarySuccess} hasLogs=${
-          sectionLogs.length > 0
-        } logsLen=${sectionLogs.length}`
+      reasons.push(
+        `no output could be attributed to this package ` +
+          `(${rawLogs.length} chars received, ${beginMarkersSeen} BEGIN markers found)`
       );
     }
 
-    // Deliberately not parsed from unattributed output: attribution is exactly
-    // what failed, so a count read from it could belong to anything. The logs
-    // are still shown, so the jest summary remains readable by eye.
+    if (partialSections.has(slug)) {
+      OutputHelper.warn(
+        `[batch-log-parser] ${slug}: section closed by its END marker with no BEGIN — ` +
+          'the start of this output was dropped by the log window, so the section is partial.'
+      );
+    }
+
+    // Attribute by script path, not by log position: a deferred callback can
+    // fire during another package's section.
+    const tracebacks = parseTracebacks(sectionLogs);
+    const tracebackCount = tracebacks.reduce((sum, t) => sum + t.count, 0);
+    const owned = tracebacks.filter((t) => !t.owner || t.owner === slug);
+    if (tracebacks.length > owned.length) {
+      OutputHelper.verbose(
+        `[batch-log-parser] ${slug}: ignored ${
+          tracebacks.length - owned.length
+        } traceback(s) belonging to other packages`
+      );
+    }
+    if (owned.length > 0) {
+      OutputHelper.warn(
+        `[batch-log-parser] ${slug}: ${owned.length} distinct traceback(s):\n` +
+          formatTracebacks(owned)
+      );
+    }
+
+    const error = reasons.length > 0 ? reasons.join('; ') : undefined;
+
     const testCounts = attributedLogs
       ? parseTestCounts(attributedLogs)
       : undefined;
-    const tracebackCount = countTracebacks(sectionLogs);
-    if (tracebackCount > 0) {
-      OutputHelper.warn(
-        `[batch-log-parser] ${slug}: ${tracebackCount} Luau traceback(s) in output. ` +
-          'Jest does not count these — a deferred-callback crash fires outside any test.'
-      );
-    }
     // Prefer the JSON summary (authoritative, immune to log reordering);
     // fall back to the END-marker value if the summary was truncated.
     const durationMs = summaryDurations.get(slug) ?? markerDurations.get(slug);
@@ -264,32 +286,4 @@ export function parseBatchTestLogs(
   return results;
 }
 
-/**
- * Count Luau tracebacks in log output.
- *
- * Reported separately from test counts because jest never sees these: a crash in
- * a deferred callback fires outside any test, so a run can print
- * "Tests: 155 passed, 0 failed" while something is genuinely broken.
- */
-export function countTracebacks(rawOutput: string): number {
-  if (!rawOutput) {
-    return 0;
-  }
-  const cleanLogs = OutputHelper.stripAnsi(rawOutput);
-  return cleanLogs.match(/Stack Begin\s/g)?.length ?? 0;
-}
-
-/**
- * Check specifically for Jest test suite/test failures in logs.
- * Unlike parseTestLogs, this ignores "Stack Begin" runtime errors since
- * those can come from deferred callbacks of other packages in batch mode.
- */
-function _hasJestFailuresInLogs(rawOutput: string): boolean {
-  const cleanLogs = OutputHelper.stripAnsi(rawOutput);
-  const failedSuites = cleanLogs.match(/Test Suites:\s*(\d+)\s+failed/);
-  const failedTests = cleanLogs.match(/Tests:\s*(\d+)\s+failed/);
-  return (
-    (failedSuites != null && parseInt(failedSuites[1], 10) > 0) ||
-    (failedTests != null && parseInt(failedTests[1], 10) > 0)
-  );
-}
+export { countTracebacks } from '../test-log-parser.js';

--- a/tools/nevermore-cli/src/utils/testing/parsers/traceback-parser.test.ts
+++ b/tools/nevermore-cli/src/utils/testing/parsers/traceback-parser.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatTracebacks,
+  ownerOf,
+  parseTracebacks,
+} from './traceback-parser.js';
+
+const TRACEBACK = [
+  'PlayerBadgeHelper: attempt to index nil with UserId',
+  'Stack Begin',
+  'Script \'[string "ServerScriptService.egghunt2026.game.Server.PlayerBadgeHelper"]\', Line 365 - function _awardBadge',
+  'Script \'[string "ServerScriptService.egghunt2026.game.Server.PlayerBadgeHelper"]\', Line 138',
+  'Stack End',
+].join('\n');
+
+describe('parseTracebacks', () => {
+  it('attributes a traceback to the package that owns the failing script', () => {
+    const [traceback] = parseTracebacks(TRACEBACK);
+
+    expect(traceback.owner).toBe('egghunt2026');
+    expect(traceback.source).toContain('PlayerBadgeHelper');
+    expect(traceback.message).toContain('attempt to index nil');
+  });
+
+  it('collapses repeats of the same crash into one entry with a count', () => {
+    // One bug fires per player per frame, so raw output can hold hundreds of
+    // identical copies. Printing them all is what makes logs unreadable.
+    const repeated = [TRACEBACK, TRACEBACK, TRACEBACK].join('\n');
+
+    const tracebacks = parseTracebacks(repeated);
+
+    expect(tracebacks).toHaveLength(1);
+    expect(tracebacks[0].count).toBe(3);
+  });
+
+  it('keeps distinct crashes apart', () => {
+    const other = TRACEBACK.replace('PlayerBadgeHelper', 'TrainHelper');
+
+    expect(parseTracebacks([TRACEBACK, other].join('\n'))).toHaveLength(2);
+  });
+
+  it('finds nothing in clean output', () => {
+    expect(parseTracebacks('Tests: 10 passed, 10 total')).toEqual([]);
+  });
+});
+
+describe('ownerOf', () => {
+  it('names the package below the service', () => {
+    expect(ownerOf('ServerScriptService.brio.Foo.Bar')).toBe('brio');
+  });
+});
+
+describe('formatTracebacks', () => {
+  it('bounds how many it prints and says how many it withheld', () => {
+    const many = Array.from({ length: 8 }, (_, i) =>
+      TRACEBACK.replace('PlayerBadgeHelper:', `Helper${i}:`)
+    ).join('\n');
+
+    const formatted = formatTracebacks(parseTracebacks(many), 5);
+
+    expect(formatted).toContain('and 3 more distinct traceback(s)');
+  });
+});

--- a/tools/nevermore-cli/src/utils/testing/parsers/traceback-parser.ts
+++ b/tools/nevermore-cli/src/utils/testing/parsers/traceback-parser.ts
@@ -1,0 +1,122 @@
+import { OutputHelper } from '@quenty/cli-output-helpers';
+
+export interface AttributedTraceback {
+  /** First line of the error, before the stack. */
+  message: string;
+  /** Roblox instance path of the topmost frame, e.g. "ServerScriptService.Foo.Bar". */
+  source?: string;
+  /** Root of that path, which names the package the frame belongs to. */
+  owner?: string;
+  /** Frames kept for display, topmost first. */
+  frames: string[];
+  /** How many times this same traceback appeared. */
+  count: number;
+}
+
+const STACK_BEGIN = /^\s*Stack Begin\s*$/;
+const STACK_END = /^\s*Stack End\s*$/;
+// Script 'ServerScriptService.EggHunt2026.game.Server.Foo', Line 365 - function bar
+const FRAME = /Script\s+'(?:\[string\s+")?([^'"\]]+)/;
+
+const MAX_FRAMES = 4;
+
+/**
+ * Pull tracebacks out of log output and attribute each to its owning package.
+ *
+ * Attribution reads the script path in the frames rather than the position of
+ * the traceback in the log. Position is unreliable: a deferred callback can
+ * fire during a later package's section, which is why batch mode previously
+ * gave up on tracebacks entirely.
+ */
+export function parseTracebacks(rawOutput: string): AttributedTraceback[] {
+  if (!rawOutput) {
+    return [];
+  }
+
+  const lines = OutputHelper.stripAnsi(rawOutput).split('\n');
+  const bySignature = new Map<string, AttributedTraceback>();
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!STACK_BEGIN.test(lines[i])) {
+      continue;
+    }
+
+    // The error text sits on the line above "Stack Begin".
+    const message = (lines[i - 1] ?? '').trim();
+
+    const frames: string[] = [];
+    let source: string | undefined;
+    for (let j = i + 1; j < lines.length && !STACK_END.test(lines[j]); j++) {
+      const frame = lines[j].trim();
+      if (!frame) {
+        continue;
+      }
+      if (frames.length < MAX_FRAMES) {
+        frames.push(frame);
+      }
+      if (!source) {
+        source = FRAME.exec(frame)?.[1];
+      }
+    }
+
+    // One bug fires per player and per frame, so the same traceback can appear
+    // hundreds of times. Collapse by signature and count instead of printing
+    // every copy.
+    const signature = `${message}::${frames[0] ?? ''}`;
+    const existing = bySignature.get(signature);
+    if (existing) {
+      existing.count++;
+      continue;
+    }
+
+    bySignature.set(signature, {
+      message,
+      source,
+      owner: source ? ownerOf(source) : undefined,
+      frames,
+      count: 1,
+    });
+  }
+
+  return [...bySignature.values()];
+}
+
+/**
+ * Name the package a script path belongs to.
+ *
+ * Batch places hold each package under its own root, so the segment below the
+ * service is the package.
+ */
+export function ownerOf(scriptPath: string): string | undefined {
+  const parts = scriptPath.split('.');
+  return parts.length >= 2 ? parts[1] : undefined;
+}
+
+/** Render tracebacks for a human, newest information first and bounded. */
+export function formatTracebacks(
+  tracebacks: AttributedTraceback[],
+  maxShown = 5
+): string {
+  if (tracebacks.length === 0) {
+    return '';
+  }
+
+  const lines: string[] = [];
+  const shown = tracebacks.slice(0, maxShown);
+
+  for (const traceback of shown) {
+    const where = traceback.source ? ` (${traceback.source})` : '';
+    const times = traceback.count > 1 ? ` ×${traceback.count}` : '';
+    lines.push(`  ${traceback.message}${where}${times}`);
+    for (const frame of traceback.frames) {
+      lines.push(`      ${frame}`);
+    }
+  }
+
+  const hidden = tracebacks.length - shown.length;
+  if (hidden > 0) {
+    lines.push(`  ...and ${hidden} more distinct traceback(s)`);
+  }
+
+  return lines.join('\n');
+}

--- a/tools/nevermore-cli/src/utils/testing/runner/test-runner.test.ts
+++ b/tools/nevermore-cli/src/utils/testing/runner/test-runner.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeFailureReasons } from './test-runner.js';
+
+describe('mergeFailureReasons', () => {
+  it('does not repeat reasons the context already reported', () => {
+    // Batch mode evaluates the same logs upstream, so both sources describe the
+    // same failures. Concatenating them read as double the failures.
+    const merged = mergeFailureReasons(
+      '3 test suite(s) failed; 19 test(s) failed',
+      ['3 test suite(s) failed', '19 test(s) failed']
+    );
+
+    expect(merged).toEqual(['3 test suite(s) failed', '19 test(s) failed']);
+  });
+
+  it('keeps reasons only one side knows about', () => {
+    const merged = mergeFailureReasons(
+      'the batch runner reported a Luau error',
+      ['19 test(s) failed']
+    );
+
+    expect(merged).toHaveLength(2);
+  });
+
+  it('is empty when nothing failed', () => {
+    expect(mergeFailureReasons(undefined, [])).toEqual([]);
+  });
+});

--- a/tools/nevermore-cli/src/utils/testing/runner/test-runner.ts
+++ b/tools/nevermore-cli/src/utils/testing/runner/test-runner.ts
@@ -30,6 +30,25 @@ export interface SingleTestResult {
   error?: string;
 }
 
+/**
+ * Combine failure reasons from the job context with those read from the logs.
+ *
+ * In batch mode the context has already evaluated these same logs, so the two
+ * sources overlap. Merging on the individual reason keeps the overlap from
+ * reading as double the failures.
+ */
+export function mergeFailureReasons(
+  contextError: string | undefined,
+  logReasons: string[]
+): string[] {
+  return [
+    ...new Set([
+      ...(contextError ? contextError.split('; ') : []),
+      ...logReasons,
+    ]),
+  ];
+}
+
 export interface SingleTestOptions {
   packagePath: string;
   packageName: string;
@@ -56,7 +75,10 @@ export async function runSingleTestAsync(
   const {
     packagePath,
     packageName,
-    timeoutMs = 120_000,
+    // 300s is the Open Cloud maximum. The old 120s default failed real suites
+    // with no jest summary at all, so "--timeout 300" had become folklore
+    // everyone had to know before their first useful run.
+    timeoutMs = 300_000,
     scriptText,
     target,
   } = options;
@@ -104,14 +126,24 @@ export async function runSingleTestAsync(
     });
 
     const rawLogs = await context.getLogsAsync(deployment);
-    const parsed = parseTestLogs(rawLogs);
+    // A probe script is arbitrary Luau with no jest in it, so demanding a test
+    // report would fail every --script-text run. Everything else must prove a
+    // runner spoke before it can pass.
+    const parsed = parseTestLogs(rawLogs, {
+      requireTestReport: scriptText === undefined,
+    });
+
+    const reasons = mergeFailureReasons(
+      result.errorMessage,
+      parsed.failureReasons
+    );
 
     return {
       success: result.success && parsed.success,
       logs: parsed.logs,
       testCounts: parseTestCounts(parsed.logs),
       durationMs: result.durationMs,
-      error: result.errorMessage,
+      error: reasons.length > 0 ? reasons.join('; ') : undefined,
     };
   } finally {
     await context.releaseAsync(deployment);

--- a/tools/nevermore-cli/src/utils/testing/test-log-parser.test.ts
+++ b/tools/nevermore-cli/src/utils/testing/test-log-parser.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { evaluateTestOutcome, hasTestReport } from './test-log-parser.js';
+
+describe('evaluateTestOutcome', () => {
+  it('passes a clean jest report', () => {
+    const outcome = evaluateTestOutcome('Tests: 275 passed, 275 total', {
+      requireTestReport: true,
+    });
+
+    expect(outcome.success).toBe(true);
+    expect(outcome.failureReasons).toEqual([]);
+  });
+
+  it('refuses to pass output with no jest report in it', () => {
+    // Absence of failure was previously read as success, so an empty log passed.
+    const outcome = evaluateTestOutcome('some unrelated chatter', {
+      requireTestReport: true,
+    });
+
+    expect(outcome.success).toBe(false);
+    expect(outcome.failureReasons.join()).toContain('no jest report');
+  });
+
+  it('exempts probe runs, which have no jest in them at all', () => {
+    const outcome = evaluateTestOutcome('hello from a probe script');
+
+    expect(outcome.success).toBe(true);
+  });
+
+  it('fails on a traceback even when every test passed', () => {
+    // Jest cannot see a deferred-callback crash: it fires outside any test.
+    const logs = [
+      'Tests: 155 passed, 155 total',
+      'attempt to index nil',
+      'Stack Begin',
+      "Script 'ServerScriptService.egghunt2026.Foo', Line 12",
+      'Stack End',
+    ].join('\n');
+
+    const outcome = evaluateTestOutcome(logs, { requireTestReport: true });
+
+    expect(outcome.success).toBe(false);
+    expect(outcome.failureReasons.join()).toContain('traceback');
+  });
+
+  it('reports every reason a run failed, not just the first', () => {
+    const logs = [
+      'Tests: 19 failed, 470 passed, 516 total',
+      'Stack Begin',
+      "Script 'ServerScriptService.egghunt2026.Foo', Line 12",
+      'Stack End',
+    ].join('\n');
+
+    const outcome = evaluateTestOutcome(logs, { requireTestReport: true });
+
+    expect(outcome.failureReasons).toHaveLength(2);
+  });
+});
+
+describe('hasTestReport', () => {
+  it('accepts a runner that ran and found nothing', () => {
+    // Packages without specs are legitimate; passWithNoTests depends on this.
+    expect(hasTestReport('No tests found, exiting with code 0')).toBe(true);
+  });
+
+  it('rejects silence', () => {
+    expect(hasTestReport('')).toBe(false);
+  });
+});

--- a/tools/nevermore-cli/src/utils/testing/test-log-parser.ts
+++ b/tools/nevermore-cli/src/utils/testing/test-log-parser.ts
@@ -10,27 +10,97 @@ export interface ParsedTestLogs {
   success: boolean;
   logs: string;
   testCounts?: ParsedTestCounts;
+  /** Why the run is not a pass. Empty when it is. */
+  failureReasons: string[];
+}
+
+export interface TestOutcomeOptions {
+  /**
+   * Require proof the runner ran. Off for probe scripts (--script-text), which
+   * legitimately produce no jest report.
+   */
+  requireTestReport?: boolean;
+}
+
+/**
+ * Decide whether test output represents a pass, and say why when it does not.
+ *
+ * The single definition of the rule. Both the single-package path and the batch
+ * path route through here — they previously carried divergent copies that
+ * disagreed about tracebacks, so the same commit could pass one and fail the
+ * other.
+ */
+export function evaluateTestOutcome(
+  rawOutput: string,
+  options: TestOutcomeOptions = {}
+): { success: boolean; failureReasons: string[] } {
+  const cleanLogs = OutputHelper.stripAnsi(rawOutput);
+  const failureReasons: string[] = [];
+
+  const failedSuites = cleanLogs.match(/Test Suites:\s*(\d+)\s+failed/);
+  const failedTests = cleanLogs.match(/Tests:\s*(\d+)\s+failed/);
+  if (failedSuites && parseInt(failedSuites[1], 10) > 0) {
+    failureReasons.push(`${failedSuites[1]} test suite(s) failed`);
+  }
+  if (failedTests && parseInt(failedTests[1], 10) > 0) {
+    failureReasons.push(`${failedTests[1]} test(s) failed`);
+  }
+
+  // Tracebacks always fail. They catch use-after-free bugs that jest cannot
+  // see, since a deferred-callback crash fires outside any test.
+  const tracebacks = countTracebacks(cleanLogs);
+  if (tracebacks > 0) {
+    failureReasons.push(
+      `${tracebacks} Luau traceback(s) — see attributed errors below`
+    );
+  }
+
+  if (options.requireTestReport && !hasTestReport(cleanLogs)) {
+    failureReasons.push(
+      'no jest report in output — nothing proves any test ran'
+    );
+  }
+
+  return { success: failureReasons.length === 0, failureReasons };
+}
+
+/**
+ * True when jest reported at all, including reporting that it found nothing.
+ *
+ * "Ran and found no tests" is a legitimate answer for packages that ship
+ * without specs; "we never heard from jest" is not. Keying on the report
+ * rather than on a test count keeps `passWithNoTests` working.
+ */
+export function hasTestReport(rawOutput: string): boolean {
+  const clean = OutputHelper.stripAnsi(rawOutput);
+  return (
+    /Tests:\s+/.test(clean) ||
+    /Test Suites:\s+/.test(clean) ||
+    /No tests found/i.test(clean)
+  );
+}
+
+/** Count Luau tracebacks in output. */
+export function countTracebacks(rawOutput: string): number {
+  if (!rawOutput) {
+    return 0;
+  }
+  return OutputHelper.stripAnsi(rawOutput).match(/Stack Begin\s/g)?.length ?? 0;
 }
 
 /**
  * Analyze test output for Jest failures and Luau runtime errors.
  * Shared by both Open Cloud log fetching and local run-in-roblox output.
  */
-export function parseTestLogs(rawOutput: string): ParsedTestLogs {
-  const cleanLogs = OutputHelper.stripAnsi(rawOutput);
-
-  // Check for Jest-style test failures
-  const failedSuites = cleanLogs.match(/Test Suites:\s*(\d+)\s+failed/);
-  const failedTests = cleanLogs.match(/Tests:\s*(\d+)\s+failed/);
-  const hasJestFailures =
-    (failedSuites && parseInt(failedSuites[1], 10) > 0) ||
-    (failedTests && parseInt(failedTests[1], 10) > 0);
-
-  // Check for Luau runtime errors (stack traces)
-  const hasRuntimeError = /Stack Begin\s/.test(cleanLogs);
+export function parseTestLogs(
+  rawOutput: string,
+  options: TestOutcomeOptions = {}
+): ParsedTestLogs {
+  const outcome = evaluateTestOutcome(rawOutput, options);
 
   return {
-    success: !hasJestFailures && !hasRuntimeError,
+    success: outcome.success,
+    failureReasons: outcome.failureReasons,
     logs: rawOutput,
     testCounts: parseTestCounts(rawOutput),
   };


### PR DESCRIPTION
Phase 2, following #771. Phase 1 made an unreadable run *say* so; this makes the verdict follow.

## Root cause, finally pinned

Two 20,000-line probe runs against the real API:

| run | messages | chars | survived |
|---|---|---|---|
| probe 1 (~20 char lines) | 6,715 | ~134,300 | lines 13286–20000 |
| probe 2 (~99 char lines) | 3,237 | 297,722 | lines 16765–20000 |
| egg-hunt | 2,531 | 330,778 | tail only |

**Open Cloud retains only the tail of a task's log.** Both probes lost their head and kept one contiguous block through the final line. `===BATCH_TEST_BEGIN===` prints in the first moments of a run, so on any suite large enough to overflow the window it is *always* the first casualty — which is why this reproduced identically every time rather than flaking.

Ruled out with evidence: pagination (one page, no continuation token), message-count cap (6,715 vs 3,237 vs 2,531), byte cap (134 KB vs 298 KB vs 331 KB), marker formatting, and the CLI itself. The retained window's exact governing unit is still unknown — deliberately, because **nothing here depends on its size.**

## What changed

**Section on `END`, not `BEGIN`.** `END` and the summary print last and always survive. Sections now close on `END` and claim everything since the last boundary, so a head-dropped run still yields real counts. Sections closed without a `BEGIN` are marked partial and warned about.

**One rule, in one place.** `evaluateTestOutcome` is the only definition of a pass; the divergent `_hasJestFailuresInLogs` copy is deleted. It reports *every* reason a run failed, not just the first. Tracebacks always fail in both modes — they catch use-after-free bugs jest cannot see, since a deferred-callback crash fires outside any test.

**Passing requires evidence.** Absence of failure was read as success, so an empty log passed. The check keys on whether jest reported *at all*, not on a test count, so `No tests found` still passes and `passWithNoTests` keeps working. `--script-text` probes are exempt.

**Tracebacks attributed by script path, not log position.** A deferred callback can fire during another package's section — the reason batch mode gave up on tracebacks entirely. Reading the owning package out of the frames fixes that rather than tolerating it. Deduped by signature with counts and bounded, since one bug fires per player per frame.

**Ergonomics:** `--logs` defaults on with `--script-text` (its output is the whole point — the current behaviour was bad enough that a workaround got written into `clienttranslator/docs/engine-behavior.md` instead of a bug report); `batch test --script-text` explains where to go; `--timeout` defaults to the 300 s API maximum.

## Verified against egg-hunt

```
section closed by its END marker with no BEGIN — the start of this output was dropped
Test Suites: 3 failed, 5 skipped, 32 passed, 35 of 40 total
Tests:       19 failed, 27 skipped, 470 passed, 516 total
5 distinct traceback(s)          [400 raw]
✗ FAILED (4m28s)                 EXIT=1
```

Real counts recovered from a head-dropped log, correct red verdict, 400 tracebacks collapsed to 5. **That repository's CI has reported ✅ throughout.**

118 tests pass in `nevermore-cli`; all 5 tools packages build; prettier clean.

## Expect red builds

Any repo with genuinely failing tests goes red on the next run. That is the point, but it is not a quiet change. egg-hunt has 19 real failures, at least 16 of which predate its current branch.

## Not included

#13 per-phase timestamps, #14 threading jest config to the in-engine run, #16 baseline comparison, #17 aligning the documented command with the gate command.

https://claude.ai/code/session_014KaJaDsPyPWQ3whHaav2r8

## Known limitation (found after opening)

A full `batch test --all` sweep cannot pass at large package counts. Measured on Nevermore's 73 test packages: 59 passed, 14 failed, and all 14 failures are `no output could be attributed to this package` for exactly packages 1–14 in run order. The log window cut at `datastore` (package 15), which survived as a partial section and passed 339/339. Every one of those 14 passes with real counts in an 8-package run.

**There are zero real test failures in Nevermore under these rules.** The 14 are unreadable, not broken — and before this PR they would have reported green with no counts behind them, which is worse.

Normal CI is unaffected: `batch test --base origin/main` tests only changed packages, comfortably inside the window. Tracked as a follow-up; the fix is either carrying per-package counts inside `BATCH_TEST_SUMMARY` (which survives by construction) or splitting large batches across multiple execution tasks.
