### PR TITLE
fix(clienttranslator): freeze the translation key derivation

### DIFF
--- a/docs/gotchas/localization.md
+++ b/docs/gotchas/localization.md
@@ -76,6 +76,18 @@ it with the new language's text and never with a fallback.
 You do not need to wait for anything to make this work. Every read path — `ObserveFormatByKey`,
 `PromiseFormatByKey`, `FormatByKey`, `ObserveTranslation` — already handles it.
 
+## A generated key is a data format, not a detail
+
+`ToTranslationKey` and `ObserveTranslation` derive their key from your source text, so that key ends
+up written down: in whatever locale tables your build step produced, in the cloud localization table,
+and in any key your game replicates or stores. None of that is regenerated when the derivation
+changes.
+
+That makes the derivation frozen, and it is pinned by vectors in `TranslationKeyUtils.spec.lua`. If
+you maintain your own build step that has to produce the same keys, derive its vectors from that
+module rather than reimplementing the rule — the two drifting apart is invisible until a player sees
+English, because an unbound key falls back to its registered source text.
+
 ## One entry per translation key
 
 A `LocalizationTable` treats the translation key as the whole identity of an entry. Registering the

--- a/src/clienttranslator/src/Shared/JSONTranslator.spec.lua
+++ b/src/clienttranslator/src/Shared/JSONTranslator.spec.lua
@@ -168,7 +168,7 @@ describe("JSONTranslator:ToTranslationKey", function()
 	it("derives a stable translation key from a prefix and text", function()
 		local controller = TranslatorTestUtils.setup()
 		local translator = controller.newTranslator({})
-		expect(translator:ToTranslationKey("button", "Play Now")).toBe("button.playNow")
+		expect(translator:ToTranslationKey("button", "Play Now")).toBe("button.playnow")
 		controller:destroy()
 	end)
 

--- a/src/clienttranslator/src/Shared/Utils/TranslationKeyUtils.lua
+++ b/src/clienttranslator/src/Shared/Utils/TranslationKeyUtils.lua
@@ -17,10 +17,12 @@ local TranslationKeyUtils = {}
 	@return string
 ]=]
 function TranslationKeyUtils.getTranslationKey(prefix: string, text: string): string
-	-- Camel-case first so spaces act as word boundaries ("Play Now" -> "playNow"),
-	-- then cap the result. Stripping whitespace up-front would collapse the boundaries
-	-- and lowercase everything ("playnow").
-	local firstWords = string.sub(String.toLowerCamelCase(text), 1, 20)
+	--[[
+		Frozen derivation -- the key it returns is a persisted identifier, not an implementation
+		detail. See TranslationKeyUtils.spec.lua before touching it.
+	]]
+	local firstWordsBeginning = string.sub(string.gsub(text, "%s", ""), 1, 20)
+	local firstWords = String.toLowerCamelCase(firstWordsBeginning)
 
 	return prefix .. "." .. firstWords
 end

--- a/src/clienttranslator/src/Shared/Utils/TranslationKeyUtils.spec.lua
+++ b/src/clienttranslator/src/Shared/Utils/TranslationKeyUtils.spec.lua
@@ -2,9 +2,19 @@
 --[[
 	@class TranslationKeyUtils.spec.lua
 
-	Covers [TranslationKeyUtils.getTranslationKey]. Spaced and underscore-separated
-	source text both camelCase consistently ("Play Now" / "hello_world" ->
-	"playNow" / "helloWorld"), and the derived key is capped at 20 characters.
+	Covers [TranslationKeyUtils.getTranslationKey].
+
+	These vectors are frozen, not merely current. The derived key is a persisted identifier: it is
+	baked into every locale table a consumer has already built, into the cloud localization table,
+	and into any key a game replicates. Rederiving it does not migrate that data -- it unbinds it,
+	and every affected line silently falls back to its source language.
+
+	This happened. #737 made spaced text camelCase ("Play Now" -> "playNow" rather than "playnow")
+	and shipped as a patch, which unbound 6,849 of egg-hunt-2026's 8,585 built entries. Nothing
+	failed, nothing warned; the game just rendered English.
+
+	So a change here is a breaking data-format change. It needs a major version and a migration that
+	re-keys every consumer's tables, not a fix. If you only want prettier keys, that is not a reason.
 ]]
 
 local require = require(script.Parent.loader).load(script)
@@ -22,18 +32,25 @@ describe("TranslationKeyUtils.getTranslationKey", function()
 		expect(TranslationKeyUtils.getTranslationKey("menu", "Settings")).toBe("menu.settings")
 	end)
 
-	it("camelCases spaced text (spaces are treated as word boundaries)", function()
-		expect(TranslationKeyUtils.getTranslationKey("button", "Play Now")).toBe("button.playNow")
-		expect(TranslationKeyUtils.getTranslationKey("hint", "Press E")).toBe("hint.pressE")
+	it("collapses spaces instead of treating them as word boundaries", function()
+		expect(TranslationKeyUtils.getTranslationKey("button", "Play Now")).toBe("button.playnow")
+		expect(TranslationKeyUtils.getTranslationKey("hint", "Press E")).toBe("hint.presse")
 	end)
 
 	it("camelCases underscore-separated text", function()
 		expect(TranslationKeyUtils.getTranslationKey("x", "hello_world")).toBe("x.helloWorld")
 	end)
 
-	it("truncates the derived key to a maximum length", function()
-		local key = TranslationKeyUtils.getTranslationKey("x", "abcdefghijklmnopqrstuvwxyz")
-		-- Everything after the "x." prefix is capped at 20 characters.
-		expect(key).toBe("x.abcdefghijklmnopqrst")
+	it("drops punctuation", function()
+		expect(TranslationKeyUtils.getTranslationKey("line", "That's amore!")).toBe("line.thatsamore")
+	end)
+
+	it("caps the derived key at 20 characters of the whitespace-stripped source", function()
+		expect(TranslationKeyUtils.getTranslationKey("x", "abcdefghijklmnopqrstuvwxyz")).toBe("x.abcdefghijklmnopqrst")
+		-- Whitespace is removed before the cap, so the cut lands 20 characters into the stripped
+		-- text rather than 20 characters into a camelCased rendering of it.
+		expect(TranslationKeyUtils.getTranslationKey("line", "Once upon a time long ago there was a king")).toBe(
+			"line.onceuponatimelongago"
+		)
 	end)
 end)


### PR DESCRIPTION
## What

Restores the pre-#737 `TranslationKeyUtils.getTranslationKey` derivation and pins it as **frozen** rather than merely current.

## Why

#737 changed the derivation to camel-case before capping, so spaced source text began deriving `button.playNow` where it had derived `button.playnow`.

The derived key is not an implementation detail — it is a persisted identifier:

- `ToTranslationKey` writes it into the localization table
- build steps bake it into shipped locale tables
- cloud translations are uploaded under it
- games replicate and store it (e.g. a `TitleTranslationKey` attribute)

Rederiving it migrates none of that. It *unbinds* it. And because `ToTranslationKey` registers `en = text` behind every key it mints, an unbound line renders its English source rather than failing — so there is no error, no warning, and no failing test.

`egg-hunt-2026` lost **6,849 of its 8,585 built entries** this way, across all 19 locales. It surfaced as a player noticing two labels in the wrong language, eleven days later:

| built key | key the game asked for after #737 |
|---|---|
| `locations.welcometo` | `locations.welcomeTo` |
| `locations.cometpointpark` | `locations.cometPointPark` |
| `settings.camera.aimwithgyroscope` | `settings.camera.aimWithGyroscope` |

## Why revert rather than re-key the tables

The tables are derived data; the derivation is the authority. Reverting is one function and fixes every consumer at once. Re-keying instead means 6,849 renames per consumer, per locale — and only fixes the consumer that does it, while orphaning cloud entries uploaded under the old keys.

Checked before reverting: **nothing depends on the post-#737 shape.** Of egg-hunt's 8,585 entries, 6,849 match the old derivation only, 941 match both, 732 are explicit, and the 63 that match the new shape only are hand-authored keys that merely coincide (`actions.getUp` is a literal `ObserveFormatByKey("actions.getUp")` in `platforming`, not a minted key). Raven's own shipped translator tables (`secretsanta`, `astrolabecommands`) are hand-keyed and algorithm-independent.

⚠️ The one exposure: if you rebuilt auto-keyed locale tables between 2026-07-17 and today *against a dynamic mirror of the engine rule*, those tables are keyed to the new shape and need rebuilding after this lands. A build step with its own hardcoded copy of the old rule (which is what egg-hunt has) is already correct.

## Not reverted

The rest of #737 stands: batched localization writes, the single `SetEntries` flush, lazy per-locale loading, and the duplicate-key crash fix are untouched.

## Also

- `TranslationKeyUtils.spec.lua` now says *why* the vectors are frozen and what a change to them costs, so the next person reads the constraint before the code.
- `docs/gotchas/localization.md` gains a section for consumers, including the advice that a build step needing to mint the same keys should derive its vectors from `TranslationKeyUtils` rather than reimplement the rule. egg-hunt's pipeline reimplemented it, stayed green against its own copy, and disagreed with the engine — which is why this went unnoticed.

## Testing

- `nevermore test --cloud --timeout 300` in `src/clienttranslator` → **156/156 passed**
- `stylua --check`, `selene` clean on the package

https://claude.ai/code/session_01Fqcn8nWtRTDt3CYT4CeoEg

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/access@1.3.6-canary.774.30421612562.0
  npm install @quenty/chatproviderservice@9.67.3-canary.774.30421612562.0
  npm install @quenty/clienttranslator@14.47.3-canary.774.30421612562.0
  npm install @quenty/gameconfig@12.62.3-canary.774.30421612562.0
  npm install @quenty/gameproductservice@14.66.4-canary.774.30421612562.0
  npm install @quenty/inputkeymaputils@14.53.3-canary.774.30421612562.0
  npm install @quenty/scoredactionservice@16.54.3-canary.774.30421612562.0
  npm install @quenty/settings-inputkeymap@10.70.3-canary.774.30421612562.0
  npm install @quenty/softshutdown@10.3.3-canary.774.30421612562.0
  # or 
  yarn add @quenty/access@1.3.6-canary.774.30421612562.0
  yarn add @quenty/chatproviderservice@9.67.3-canary.774.30421612562.0
  yarn add @quenty/clienttranslator@14.47.3-canary.774.30421612562.0
  yarn add @quenty/gameconfig@12.62.3-canary.774.30421612562.0
  yarn add @quenty/gameproductservice@14.66.4-canary.774.30421612562.0
  yarn add @quenty/inputkeymaputils@14.53.3-canary.774.30421612562.0
  yarn add @quenty/scoredactionservice@16.54.3-canary.774.30421612562.0
  yarn add @quenty/settings-inputkeymap@10.70.3-canary.774.30421612562.0
  yarn add @quenty/softshutdown@10.3.3-canary.774.30421612562.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
