### PR TITLE
fix(chatproviderservice): let a PlayerMock be chat tagged

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1169,6 +1169,9 @@ importers:
       '@quenty/playerbinder':
         specifier: workspace:*
         version: link:../playerbinder
+      '@quenty/playermock':
+        specifier: workspace:*
+        version: link:../player-mock
       '@quenty/playerutils':
         specifier: workspace:*
         version: link:../playerutils

--- a/src/chatproviderservice/package.json
+++ b/src/chatproviderservice/package.json
@@ -43,6 +43,7 @@
     "@quenty/nevermore-test-runner": "workspace:*",
     "@quenty/permissionprovider": "workspace:*",
     "@quenty/playerbinder": "workspace:*",
+    "@quenty/playermock": "workspace:*",
     "@quenty/playerutils": "workspace:*",
     "@quenty/preferredparentutils": "workspace:*",
     "@quenty/promise": "workspace:*",

--- a/src/chatproviderservice/src/Client/ChatProviderServiceClient.lua
+++ b/src/chatproviderservice/src/Client/ChatProviderServiceClient.lua
@@ -7,6 +7,7 @@ local require = require(script.Parent.loader).load(script)
 
 local HttpService = game:GetService("HttpService")
 local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
 local TextChatService = game:GetService("TextChatService")
 
 local Binder = require("Binder")
@@ -49,6 +50,12 @@ function ChatProviderServiceClient.Init(self: ChatProviderServiceClient, service
 end
 
 function ChatProviderServiceClient.Start(self: ChatProviderServiceClient): ()
+	-- The engine rejects this assignment outside a client, and a headless test that boots a client bag
+	-- on the server would take the whole bag down with it. Nothing to render there anyway.
+	if not RunService:IsClient() then
+		return
+	end
+
 	TextChatService.OnIncomingMessage = function(textChatMessage): TextChatMessageProperties?
 		self.MessageIncoming:Fire(textChatMessage)
 

--- a/src/chatproviderservice/src/Server/ChatProviderService.lua
+++ b/src/chatproviderservice/src/Server/ChatProviderService.lua
@@ -17,6 +17,7 @@ local LocalizedTextUtils = require("LocalizedTextUtils")
 local Maid = require("Maid")
 local Observable = require("Observable")
 local PermissionLevel = require("PermissionLevel")
+local PlayerMock = require("PlayerMock")
 local PreferredParentUtils = require("PreferredParentUtils")
 local Promise = require("Promise")
 local Rx = require("Rx")
@@ -173,7 +174,7 @@ function ChatProviderService.PromiseAddChatTag(
 	player: Player,
 	chatTagData: ChatTagDataUtils.ChatTagData
 ): Promise.Promise<Instance>
-	assert(typeof(player) == "Instance" and player:IsA("Player"), "Bad player")
+	assert((typeof(player) == "Instance" and player:IsA("Player")) or PlayerMock.isMock(player), "Bad player")
 	assert(ChatTagDataUtils.isChatTagData(chatTagData), "Bad chatTagData")
 
 	local hasChatTagBinder = self._serviceBag:GetService(HasChatTags)
@@ -189,7 +190,7 @@ end
 	@param player Player
 ]=]
 function ChatProviderService.ClearChatTags(self: ChatProviderService, player: Player)
-	assert(typeof(player) == "Instance" and player:IsA("Player"), "Bad player")
+	assert((typeof(player) == "Instance" and player:IsA("Player")) or PlayerMock.isMock(player), "Bad player")
 
 	local hasChatTagBinder = self._serviceBag:GetService(HasChatTags)
 	local hasChatTags = hasChatTagBinder:Get(player)

--- a/src/chatproviderservice/src/Server/ChatProviderService.spec.lua
+++ b/src/chatproviderservice/src/Server/ChatProviderService.spec.lua
@@ -1,0 +1,116 @@
+--!strict
+--[[
+	Coverage for the server chat-tag API against a PlayerMock. No real player joins a headless Open
+	Cloud place, so a mock has to be able to reach a chat tag the same way a joined player does --
+	through the PlayerBinder-backed HasChatTags, with the test creating nothing by hand but the mock.
+
+	The built-in (dev) and (mod) tags are switched off per test: they resolve through PermissionService,
+	which is a different question than whether a mock can be tagged at all.
+
+	@class ChatProviderService.spec.lua
+]]
+
+local require = require(script.Parent.loader).load(script)
+
+local ChatProviderService = require("ChatProviderService")
+local ChatTagConstants = require("ChatTagConstants")
+local ChatTagDataUtils = require("ChatTagDataUtils")
+local Jest = require("Jest")
+local PlayerMockService = require("PlayerMockService")
+local ServiceBag = require("ServiceBag")
+
+local afterEach = Jest.Globals.afterEach
+local describe = Jest.Globals.describe
+local expect = Jest.Globals.expect
+local it = Jest.Globals.it
+
+local DEMO_TAG = ChatTagDataUtils.createChatTagData({
+	TagText = "[DEMO]",
+	TagPriority = 5,
+	TagColor = Color3.fromRGB(245, 163, 27),
+})
+
+local activeController: any = nil
+
+afterEach(function()
+	if activeController then
+		local controller = activeController
+		activeController = nil
+		controller.destroy()
+	end
+end)
+
+local function setup()
+	local serviceBag = ServiceBag.new()
+	local container = Instance.new("Folder")
+	container.Name = "ChatProviderServiceSpecContainer"
+	container.Parent = workspace
+
+	local chatProviderService: any = serviceBag:GetService(ChatProviderService)
+	local playerMockService: any = serviceBag:GetService(PlayerMockService)
+
+	serviceBag:Init()
+	serviceBag:Start()
+
+	chatProviderService:SetDeveloperTag(nil)
+	chatProviderService:SetAdminTag(nil)
+
+	local mocks: { Player } = {}
+
+	local controller
+	controller = {
+		chatProviderService = chatProviderService,
+		newMock = function(): Player
+			local mock = playerMockService:CreatePlayer()
+			mock.Parent = container
+			table.insert(mocks, mock)
+			return mock
+		end,
+		destroy = function()
+			for _, mock in mocks do
+				mock:Destroy()
+			end
+			table.clear(mocks)
+
+			serviceBag:Destroy()
+			container:Destroy()
+		end,
+	}
+
+	activeController = controller
+	return controller
+end
+
+describe("ChatProviderService.PromiseAddChatTag", function()
+	it("tags a player mock", function()
+		local controller = setup()
+		local player = controller.newMock()
+
+		local tag = controller.chatProviderService:PromiseAddChatTag(player, DEMO_TAG):Wait()
+
+		expect(tag:GetAttribute(ChatTagConstants.TAG_TEXT_ATTRIBUTE)).toBe(DEMO_TAG.TagText)
+		expect(tag:IsDescendantOf(player)).toBe(true)
+	end)
+
+	it("drops the tag when the instance is destroyed", function()
+		local controller = setup()
+		local player = controller.newMock()
+
+		local tag = controller.chatProviderService:PromiseAddChatTag(player, DEMO_TAG):Wait()
+		tag:Destroy()
+
+		expect(tag:IsDescendantOf(player)).toBe(false)
+	end)
+end)
+
+describe("ChatProviderService.ClearChatTags", function()
+	it("clears a player mock's tags", function()
+		local controller = setup()
+		local player = controller.newMock()
+
+		local tag = controller.chatProviderService:PromiseAddChatTag(player, DEMO_TAG):Wait()
+		controller.chatProviderService:ClearChatTags(player)
+
+		expect(tag.Parent).toBe(nil)
+	end)
+end)


### PR DESCRIPTION
Two mock-safety gaps that stop the chat tag stack booting or being exercised headlessly.

## `PromiseAddChatTag` / `ClearChatTags` asserted a real `Player`

`HasChatTags` is a `PlayerBinder`, which already binds `PlayerMock`s, and every native member the binder touches (`_obj.Name`, parenting the tag container) works on a mock — it is a `Folder` in `Players`. The only thing in the way was the guard. Relaxed to the documented clause:

```lua
assert((typeof(player) == "Instance" and player:IsA("Player")) or PlayerMock.isMock(player), "Bad player")
```

`ChatProviderService.spec.lua` covers it end to end: a mock created through `PlayerMockService` takes a tag through discovery → bind → `AddChatTag`, with the test tagging nothing by hand. The built-in `(dev)`/`(mod)` tags are switched off per test — they resolve through `PermissionService`, which is a different question than whether a mock can be tagged at all.

## `ChatProviderServiceClient.Start` assigned `TextChatService.OnIncomingMessage` unconditionally

The engine rejects that outside a client, so any bag booting the client graph on the server (a headless dual-realm boot test) went down with it. It returns early there now — there is no chat to render in that context anyway.

## Testing

`nevermore test --cloud` in `src/chatproviderservice` — 6/6 (3 pre-existing + 3 new).

Found while adding a demo-player chat tag in a consumer game, which currently carries local workarounds for both of these and drops them once this publishes.

https://claude.ai/code/session_01MJ1WHz5RmWtj7TzZ1jaDrV