### PR TITLE
fix(chatproviderservice): let a PlayerMock be chat tagged

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1169,6 +1169,9 @@ importers:
       '@quenty/playerbinder':
         specifier: workspace:*
         version: link:../playerbinder
+      '@quenty/playermock':
+        specifier: workspace:*
+        version: link:../player-mock
       '@quenty/playerutils':
         specifier: workspace:*
         version: link:../playerutils

--- a/src/chatproviderservice/package.json
+++ b/src/chatproviderservice/package.json
@@ -43,6 +43,7 @@
     "@quenty/nevermore-test-runner": "workspace:*",
     "@quenty/permissionprovider": "workspace:*",
     "@quenty/playerbinder": "workspace:*",
+    "@quenty/playermock": "workspace:*",
     "@quenty/playerutils": "workspace:*",
     "@quenty/preferredparentutils": "workspace:*",
     "@quenty/promise": "workspace:*",

--- a/src/chatproviderservice/src/Client/ChatProviderServiceClient.lua
+++ b/src/chatproviderservice/src/Client/ChatProviderServiceClient.lua
@@ -7,6 +7,7 @@ local require = require(script.Parent.loader).load(script)
 
 local HttpService = game:GetService("HttpService")
 local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
 local TextChatService = game:GetService("TextChatService")
 
 local Binder = require("Binder")
@@ -49,6 +50,12 @@ function ChatProviderServiceClient.Init(self: ChatProviderServiceClient, service
 end
 
 function ChatProviderServiceClient.Start(self: ChatProviderServiceClient): ()
+	-- The engine rejects this assignment outside a client, and a headless test that boots a client bag
+	-- on the server would take the whole bag down with it. Nothing to render there anyway.
+	if not RunService:IsClient() then
+		return
+	end
+
 	TextChatService.OnIncomingMessage = function(textChatMessage): TextChatMessageProperties?
 		self.MessageIncoming:Fire(textChatMessage)
 

--- a/src/chatproviderservice/src/Server/ChatProviderService.lua
+++ b/src/chatproviderservice/src/Server/ChatProviderService.lua
@@ -301,4 +301,15 @@ function ChatProviderService._promiseSpeaker(self: ChatProviderService, speakerN
 	end)
 end
 
+--[=[
+	Cleans up the service. Should be done via [ServiceBag].
+
+	Load-bearing rather than tidy: the developer and admin tags hold a subscription to every player in
+	the place, which outlived this service without it. A destroyed bag then went on resolving
+	permissions and tagging players through services it no longer owns.
+]=]
+function ChatProviderService.Destroy(self: ChatProviderService)
+	self._maid:DoCleaning()
+end
+
 return ChatProviderService

--- a/src/chatproviderservice/src/Server/ChatProviderService.lua
+++ b/src/chatproviderservice/src/Server/ChatProviderService.lua
@@ -17,6 +17,7 @@ local LocalizedTextUtils = require("LocalizedTextUtils")
 local Maid = require("Maid")
 local Observable = require("Observable")
 local PermissionLevel = require("PermissionLevel")
+local PlayerMock = require("PlayerMock")
 local PreferredParentUtils = require("PreferredParentUtils")
 local Promise = require("Promise")
 local Rx = require("Rx")
@@ -173,7 +174,7 @@ function ChatProviderService.PromiseAddChatTag(
 	player: Player,
 	chatTagData: ChatTagDataUtils.ChatTagData
 ): Promise.Promise<Instance>
-	assert(typeof(player) == "Instance" and player:IsA("Player"), "Bad player")
+	assert((typeof(player) == "Instance" and player:IsA("Player")) or PlayerMock.isMock(player), "Bad player")
 	assert(ChatTagDataUtils.isChatTagData(chatTagData), "Bad chatTagData")
 
 	local hasChatTagBinder = self._serviceBag:GetService(HasChatTags)
@@ -189,7 +190,7 @@ end
 	@param player Player
 ]=]
 function ChatProviderService.ClearChatTags(self: ChatProviderService, player: Player)
-	assert(typeof(player) == "Instance" and player:IsA("Player"), "Bad player")
+	assert((typeof(player) == "Instance" and player:IsA("Player")) or PlayerMock.isMock(player), "Bad player")
 
 	local hasChatTagBinder = self._serviceBag:GetService(HasChatTags)
 	local hasChatTags = hasChatTagBinder:Get(player)

--- a/src/chatproviderservice/src/Server/ChatProviderService.spec.lua
+++ b/src/chatproviderservice/src/Server/ChatProviderService.spec.lua
@@ -15,7 +15,10 @@ local require = require(script.Parent.loader).load(script)
 local ChatProviderService = require("ChatProviderService")
 local ChatTagConstants = require("ChatTagConstants")
 local ChatTagDataUtils = require("ChatTagDataUtils")
+local HasChatTagsConstants = require("HasChatTagsConstants")
 local Jest = require("Jest")
+local PermissionProviderUtils = require("PermissionProviderUtils")
+local PermissionService = require("PermissionService")
 local PlayerMockService = require("PlayerMockService")
 local ServiceBag = require("ServiceBag")
 
@@ -40,39 +43,84 @@ afterEach(function()
 	end
 end)
 
-local function setup()
+local remoteNameCounter = 0
+
+-- Polls rather than observes: the tag arrives through a binder, a permission promise and an Rx chain,
+-- and the point of these tests is the end state rather than which hop delivered it.
+local function waitForTagCount(player: Player, expected: number, timeout: number): number
+	local deadline = os.clock() + timeout
+
+	repeat
+		local container = player:FindFirstChild(HasChatTagsConstants.TAG_CONTAINER_NAME)
+		local count = if container then #container:GetChildren() else 0
+		if count == expected then
+			return count
+		end
+		task.wait(0.1)
+	until os.clock() > deadline
+
+	local container = player:FindFirstChild(HasChatTagsConstants.TAG_CONTAINER_NAME)
+	return if container then #container:GetChildren() else 0
+end
+
+-- creatorUserId, when given, makes that user the creator so the built-in developer tag actually
+-- applies to them. Left nil, both built-in tags are switched off: they resolve through
+-- PermissionService, which is a different question than whether a mock can be tagged at all.
+local function setup(creatorUserId: number?)
 	local serviceBag = ServiceBag.new()
 	local container = Instance.new("Folder")
 	container.Name = "ChatProviderServiceSpecContainer"
 	container.Parent = workspace
 
 	local chatProviderService: any = serviceBag:GetService(ChatProviderService)
+	local permissionService: any = serviceBag:GetService(PermissionService)
 	local playerMockService: any = serviceBag:GetService(PlayerMockService)
 
 	serviceBag:Init()
+
+	if creatorUserId then
+		remoteNameCounter += 1
+		permissionService:SetProviderFromConfig(PermissionProviderUtils.createSingleUserConfig({
+			userId = creatorUserId,
+			remoteFunctionName = string.format("ChatProviderServiceSpecRemote%d", remoteNameCounter),
+		}))
+	end
+
 	serviceBag:Start()
 
-	chatProviderService:SetDeveloperTag(nil)
-	chatProviderService:SetAdminTag(nil)
+	if not creatorUserId then
+		chatProviderService:SetDeveloperTag(nil)
+		chatProviderService:SetAdminTag(nil)
+	end
 
 	local mocks: { Player } = {}
+	local bagDestroyed = false
+
+	local function destroyBag()
+		if not bagDestroyed then
+			bagDestroyed = true
+			serviceBag:Destroy()
+		end
+	end
 
 	local controller
 	controller = {
 		chatProviderService = chatProviderService,
-		newMock = function(): Player
-			local mock = playerMockService:CreatePlayer()
+		newMock = function(userId: number?): Player
+			local mock = playerMockService:CreatePlayer(if userId then { UserId = userId } else nil)
 			mock.Parent = container
 			table.insert(mocks, mock)
 			return mock
 		end,
+		destroyBag = destroyBag,
 		destroy = function()
+			destroyBag()
+
 			for _, mock in mocks do
 				mock:Destroy()
 			end
 			table.clear(mocks)
 
-			serviceBag:Destroy()
 			container:Destroy()
 		end,
 	}
@@ -100,6 +148,38 @@ describe("ChatProviderService.PromiseAddChatTag", function()
 		tag:Destroy()
 
 		expect(tag:IsDescendantOf(player)).toBe(false)
+	end)
+end)
+
+describe("ChatProviderService.SetDeveloperTag", function()
+	local CREATOR_USER_ID = 4242
+
+	it("tags the creator", function()
+		local controller = setup(CREATOR_USER_ID)
+		local player = controller.newMock(CREATOR_USER_ID)
+
+		expect(waitForTagCount(player, 1, 10)).toBe(1)
+	end)
+
+	it("leaves everybody else alone", function()
+		local controller = setup(CREATOR_USER_ID)
+		local player = controller.newMock(CREATOR_USER_ID + 1)
+
+		expect(waitForTagCount(player, 0, 3)).toBe(0)
+	end)
+
+	--[[
+		The tag holds a subscription to every player in the place, so without a Destroy it outlived its
+		own bag: a destroyed service went on resolving permissions and reaching for binders through
+		services it no longer owned.
+	]]
+	it("stops tagging once its bag is destroyed", function()
+		local controller = setup(CREATOR_USER_ID)
+		controller.destroyBag()
+
+		local player = controller.newMock(CREATOR_USER_ID)
+
+		expect(waitForTagCount(player, 0, 3)).toBe(0)
 	end)
 end)
 

--- a/src/chatproviderservice/src/Server/ChatProviderService.spec.lua
+++ b/src/chatproviderservice/src/Server/ChatProviderService.spec.lua
@@ -1,0 +1,116 @@
+--!strict
+--[[
+	Coverage for the server chat-tag API against a PlayerMock. No real player joins a headless Open
+	Cloud place, so a mock has to be able to reach a chat tag the same way a joined player does --
+	through the PlayerBinder-backed HasChatTags, with the test creating nothing by hand but the mock.
+
+	The built-in (dev) and (mod) tags are switched off per test: they resolve through PermissionService,
+	which is a different question than whether a mock can be tagged at all.
+
+	@class ChatProviderService.spec.lua
+]]
+
+local require = require(script.Parent.loader).load(script)
+
+local ChatProviderService = require("ChatProviderService")
+local ChatTagConstants = require("ChatTagConstants")
+local ChatTagDataUtils = require("ChatTagDataUtils")
+local Jest = require("Jest")
+local PlayerMockService = require("PlayerMockService")
+local ServiceBag = require("ServiceBag")
+
+local afterEach = Jest.Globals.afterEach
+local describe = Jest.Globals.describe
+local expect = Jest.Globals.expect
+local it = Jest.Globals.it
+
+local DEMO_TAG = ChatTagDataUtils.createChatTagData({
+	TagText = "[DEMO]",
+	TagPriority = 5,
+	TagColor = Color3.fromRGB(245, 163, 27),
+})
+
+local activeController: any = nil
+
+afterEach(function()
+	if activeController then
+		local controller = activeController
+		activeController = nil
+		controller.destroy()
+	end
+end)
+
+local function setup()
+	local serviceBag = ServiceBag.new()
+	local container = Instance.new("Folder")
+	container.Name = "ChatProviderServiceSpecContainer"
+	container.Parent = workspace
+
+	local chatProviderService: any = serviceBag:GetService(ChatProviderService)
+	local playerMockService: any = serviceBag:GetService(PlayerMockService)
+
+	serviceBag:Init()
+	serviceBag:Start()
+
+	chatProviderService:SetDeveloperTag(nil)
+	chatProviderService:SetAdminTag(nil)
+
+	local mocks: { Player } = {}
+
+	local controller
+	controller = {
+		chatProviderService = chatProviderService,
+		newMock = function(): Player
+			local mock = playerMockService:CreatePlayer()
+			mock.Parent = container
+			table.insert(mocks, mock)
+			return mock
+		end,
+		destroy = function()
+			for _, mock in mocks do
+				mock:Destroy()
+			end
+			table.clear(mocks)
+
+			serviceBag:Destroy()
+			container:Destroy()
+		end,
+	}
+
+	activeController = controller
+	return controller
+end
+
+describe("ChatProviderService.PromiseAddChatTag", function()
+	it("tags a player mock", function()
+		local controller = setup()
+		local player = controller.newMock()
+
+		local tag = controller.chatProviderService:PromiseAddChatTag(player, DEMO_TAG):Wait()
+
+		expect(tag:GetAttribute(ChatTagConstants.TAG_TEXT_ATTRIBUTE)).toBe(DEMO_TAG.TagText)
+		expect(tag:IsDescendantOf(player)).toBe(true)
+	end)
+
+	it("drops the tag when the instance is destroyed", function()
+		local controller = setup()
+		local player = controller.newMock()
+
+		local tag = controller.chatProviderService:PromiseAddChatTag(player, DEMO_TAG):Wait()
+		tag:Destroy()
+
+		expect(tag:IsDescendantOf(player)).toBe(false)
+	end)
+end)
+
+describe("ChatProviderService.ClearChatTags", function()
+	it("clears a player mock's tags", function()
+		local controller = setup()
+		local player = controller.newMock()
+
+		local tag = controller.chatProviderService:PromiseAddChatTag(player, DEMO_TAG):Wait()
+		controller.chatProviderService:ClearChatTags(player)
+
+		expect(tag.Parent).toBe(nil)
+	end)
+end)


### PR DESCRIPTION
Three gaps in the chat tag stack, all found by a consumer game registering `ChatProviderService` for the first time.

## The service never cleaned up after itself

`SetDeveloperTag` / `SetAdminTag` each hold a subscription to **every player in the place**, and `ChatProviderService` had no `Destroy` — so its maid outlived its own `ServiceBag`. A destroyed bag went on resolving permissions and reaching for binders through services it no longer owned.

In a long-lived server that is invisible. In a headless test place it is loud: the leaked subscription keeps firing for PlayerMocks created by later specs, into a Jest module context that has been reset, so the provider's class table is gone and you get

```
attempt to call missing method 'PromiseIsPermissionLevel' of table
```

once per player, forever — which reads as a `PermissionService` bug and is not one.

## `PromiseAddChatTag` / `ClearChatTags` asserted a real `Player`

`HasChatTags` is a `PlayerBinder`, which already binds `PlayerMock`s, and every native member the binder touches (`_obj.Name`, parenting the tag container) works on a mock — it is a `Folder` in `Players`. Only the guard was in the way. Relaxed to the documented clause:

```lua
assert((typeof(player) == "Instance" and player:IsA("Player")) or PlayerMock.isMock(player), "Bad player")
```

## `ChatProviderServiceClient.Start` assigned `TextChatService.OnIncomingMessage` unconditionally

The engine rejects that outside a client, so any bag booting the client graph on the server (a headless dual-realm boot test) went down with it. It returns early there now — there is no chat to render in that context anyway.

## Testing

`nevermore test --cloud` in `src/chatproviderservice` — 9/9 (3 pre-existing + 6 new), covering the tag pipeline end to end: a mock takes a tag through discovery → bind → `AddChatTag` with nothing tagged by hand, the creator takes a `(dev)` tag, nobody else does, and a destroyed bag tags no one.

Worth knowing about that last one: **without the `Destroy` it still passes its assertion and the run reports failed on the traceback** — the same shape the bug took downstream. The cross-spec module-context symptom is not reproducible in-process, so the test pins the lifecycle contract rather than the exotic failure.

_(Supersedes #775, which was opened on a misnamed branch.)_

https://claude.ai/code/session_01MJ1WHz5RmWtj7TzZ1jaDrV