### PR TITLE
fix(teleportserviceutils): let a server teleport hear a refusal raised after acceptance

### DIFF
--- a/src/teleportserviceutils/src/Shared/TeleportServiceUtils.lua
+++ b/src/teleportserviceutils/src/Shared/TeleportServiceUtils.lua
@@ -69,7 +69,12 @@ export type MockTeleport = {
 	call may pass one on its own instead of a config. A client has only `teleportData`, which is read
 	back out of the options when a call passes those instead.
 
-	@type TeleportConfig { teleportData: { [string]: any }?, teleportOptions: TeleportOptions?, maxAttempts: number?, retryWait: number?, exponential: number?, printWarning: boolean? }
+	`initFailedGraceSeconds` is how long a *server* attempt keeps listening for a refusal the engine
+	raises after it has already accepted the request (see
+	[TeleportServiceUtils._promiseTeleportServerAttempt]). Unset -- the default -- resolves on acceptance,
+	which is what every server call did before this existed.
+
+	@type TeleportConfig { teleportData: { [string]: any }?, teleportOptions: TeleportOptions?, maxAttempts: number?, retryWait: number?, exponential: number?, printWarning: boolean?, initFailedGraceSeconds: number? }
 	@within TeleportServiceUtils
 ]=]
 export type TeleportConfig = {
@@ -79,6 +84,7 @@ export type TeleportConfig = {
 	retryWait: number?,
 	exponential: number?,
 	printWarning: boolean?,
+	initFailedGraceSeconds: number?,
 }
 
 --[=[
@@ -326,6 +332,13 @@ end
 	until they are. Destroying it stops the retries and rejects with nothing either way, so a caller can
 	tell its own teardown from a hop that genuinely failed.
 
+	A server teleport resolves as soon as the engine accepts the request, which is not the same as the
+	player going anywhere: a refusal raised afterwards (`Unauthorized`, most of all) would otherwise
+	never reach the caller at all. `config.initFailedGraceSeconds` holds each attempt open that long to
+	catch one -- see [TeleportServiceUtils._promiseTeleportServerAttempt]. Worth setting wherever
+	something is waiting on the hop, because without it a refused teleport is indistinguishable from one
+	still on its way.
+
 	Rejects with the [TeleportFailedReportUtils.TeleportReport] itself when a refusal ends it, and with
 	the retry wrapper's summary once the attempts are spent -- a report renders itself, so either reads
 	as text.
@@ -555,13 +568,76 @@ function TeleportServiceUtils._promiseTeleportOnce(
 			teleportOptions = options
 		end
 
-		return TeleportServiceUtils.promiseTeleportServerOnce(placeId, batch, teleportOptions)
+		return TeleportServiceUtils._promiseTeleportServerAttempt(
+			placeId,
+			batch,
+			teleportOptions,
+			config.initFailedGraceSeconds
+		)
 	end
 
 	local player: Player = if type(players) == "table" then players[1] else players :: Player
 	assert(player, "No player to teleport")
 
 	return TeleportServiceUtils.promiseTeleportClientOnce(placeId, player, config.teleportData) :: any
+end
+
+--[[
+	The server's own request, plus the grace window a config asked for.
+
+	`TeleportAsync` comes back as soon as the engine has ACCEPTED the request. A refusal it makes after
+	that -- a paid-access `Unauthorized` above all, which is raised rather than thrown -- arrives later
+	through `TeleportInitFailed`, by which time a promise that resolved on acceptance has already called
+	the hop underway and has nothing left to reject with. That is how a caller ends up waiting forever on
+	a teleport that is never coming: the request was accepted, so nothing ever failed, so nothing ever
+	settled.
+
+	A config that asks for a window holds the attempt open that long after acceptance and rejects with
+	the report if a refusal lands inside it -- handing the retry wrapper the same
+	[TeleportFailedReportUtils.TeleportReport] a client attempt would, so `Unauthorized` ends the hop at
+	once and `GameFull` spends an attempt like any other.
+
+	Opt-in, because resolving late changes when an existing server caller hears back. What a resolution
+	*means* is unchanged either way: the engine accepted the request.
+]]
+function TeleportServiceUtils._promiseTeleportServerAttempt(
+	placeId: number,
+	batch: { Player },
+	teleportOptions: TeleportOptions?,
+	graceSeconds: number?
+): Promise.Promise<TeleportAsyncResult?>
+	local accepted = TeleportServiceUtils.promiseTeleportServerOnce(placeId, batch, teleportOptions)
+	if graceSeconds == nil or graceSeconds <= 0 then
+		return accepted
+	end
+
+	local promise = Promise.new()
+
+	PromiseMaidUtils.whilePromise(promise, function(maid)
+		-- Listening starts before the request settles: the engine can refuse one player of a batch while
+		-- TeleportAsync is still yielding over the rest.
+		for _, player in batch do
+			TeleportServiceUtils._connectTeleportReported(maid, placeId, player, function(report)
+				if TeleportFailedReportUtils.isInFlight(report) then
+					return
+				end
+
+				promise:Reject(report)
+			end)
+		end
+
+		-- Not held by the maid: an engine request in flight cannot be cancelled, so there is nothing for
+		-- a teardown to take back. Its rejection is consumed here either way.
+		accepted:Then(function(result)
+			maid:GiveTask(task.delay(graceSeconds, function()
+				promise:Resolve(result)
+			end))
+		end, function(err)
+			promise:Reject(err)
+		end)
+	end)
+
+	return promise
 end
 
 --[[

--- a/src/teleportserviceutils/src/Shared/TeleportServiceUtils.spec.lua
+++ b/src/teleportserviceutils/src/Shared/TeleportServiceUtils.spec.lua
@@ -488,6 +488,102 @@ describe("TeleportServiceUtils.promiseTeleport (server)", function()
 		expect(outcome).toEqual("rejected")
 		expect(err).toContain("3 times")
 	end)
+
+	-- The engine accepts the request and refuses it a moment later, which is what a paid-access
+	-- destination does. Without a grace window that refusal reaches nobody: the promise has already
+	-- resolved, so whatever was waiting on the hop waits forever.
+	describe("initFailedGraceSeconds", function()
+		it("rejects with a refusal raised after the request was accepted", function()
+			local player = newMock(887010)
+
+			local promise = TeleportServiceUtils.promiseTeleport(844, { player }, {
+				maxAttempts = 1,
+				retryWait = 0,
+				printWarning = false,
+				initFailedGraceSeconds = 5,
+			})
+
+			awaitHop(player, 844)
+			report(player, 844, Enum.TeleportResult.Unauthorized, "buy the game")
+
+			local outcome, err = PromiseTestUtils.awaitOutcome(promise)
+			expect(outcome).toEqual("rejected")
+			expect(err.result).toEqual(Enum.TeleportResult.Unauthorized)
+			expect(tostring(err)).toContain("buy the game")
+		end)
+
+		it("resolves once the window passes quietly, the hop being underway", function()
+			local player = newMock(887011)
+
+			local promise = TeleportServiceUtils.promiseTeleport(845, { player }, {
+				maxAttempts = 1,
+				retryWait = 0,
+				initFailedGraceSeconds = 0.2,
+			})
+
+			expect(PromiseTestUtils.awaitSettled(promise, 5)).toEqual(true)
+			local ok, result = promise:Yield()
+			expect(ok).toEqual(true)
+			-- Nil is what an all-mock batch resolves with: no engine call was made to return a result.
+			expect(result).toEqual(nil)
+		end)
+
+		it("ignores a report that means the hop is still running", function()
+			local player = newMock(887012)
+
+			local promise = TeleportServiceUtils.promiseTeleport(846, { player }, {
+				maxAttempts = 1,
+				retryWait = 0,
+				initFailedGraceSeconds = 0.4,
+			})
+
+			awaitHop(player, 846)
+			report(player, 846, Enum.TeleportResult.Success, "on your way")
+
+			local ok = promise:Yield()
+			expect(ok).toEqual(true)
+		end)
+
+		it("spends an attempt on a refusal worth retrying", function()
+			local player = newMock(887013)
+			local attempts = 0
+
+			local promise = TeleportServiceUtils.promiseTeleport(847, { player }, {
+				maxAttempts = 2,
+				retryWait = 0,
+				printWarning = false,
+				initFailedGraceSeconds = 5,
+			})
+
+			-- Each attempt writes its own hop record; clearing it is how the next one becomes visible,
+			-- and the message has to differ or the backing attribute reports no change.
+			for _ = 1, 2 do
+				awaitHop(player, 847)
+				attempts += 1
+				clearHop(player, 847)
+				report(player, 847, Enum.TeleportResult.GameFull, `full {attempts}`)
+			end
+
+			local outcome = PromiseTestUtils.awaitOutcome(promise)
+			expect(outcome).toEqual("rejected")
+			expect(attempts).toEqual(2)
+		end)
+
+		it("resolves on acceptance without a window, as every server call did before", function()
+			local player = newMock(887014)
+
+			local promise = TeleportServiceUtils.promiseTeleport(848, { player }, { maxAttempts = 1, retryWait = 0 })
+
+			expect(PromiseTestUtils.awaitSettled(promise, 5)).toEqual(true)
+
+			-- Reported afterwards and unheard, which is the behaviour a caller opts out of by leaving the
+			-- window unset rather than something this test wants.
+			report(player, 848, Enum.TeleportResult.Unauthorized, "too late to matter")
+
+			local ok = promise:Yield()
+			expect(ok).toEqual(true)
+		end)
+	end)
 end)
 
 describe("TeleportServiceUtils.promiseTeleportClient", function()


### PR DESCRIPTION
A player pressed Continue, the splash said `Traveling`, and it never came down. No retry, no error, no kick — the client sat there indefinitely while the server log showed one line:

```
raiseTeleportInitFailedEvent: Teleport failed because You need to purchase access to this game before you can play. (Unauthorized)
```

## Accepted is not the same as underway

`TeleportAsync` returns as soon as the engine has **accepted** the request. A refusal it makes after that — a paid-access `Unauthorized` above all — is *raised*, not thrown: it arrives later through `TeleportInitFailed`, by which time `promiseTeleportServerOnce` has already resolved and reported the hop as underway.

So nothing failed, so nothing settled. `promiseTeleport`'s doc said a server teleport "resolves with its `TeleportAsyncResult` — the server is still here afterwards", which is true and, for anyone waiting on the hop, not enough: a refused teleport and one still on its way look identical. A consumer that raises a loading screen for the length of a teleport (and leaves it up because a successful hop never settles, by design) leaves it up forever.

`shouldRetry` already classifies `Unauthorized` as terminal, but only the **client** attempt path builds reports to classify. The server path had none — it returns `true` unconditionally for anything `TeleportAsync` threw — so the retry budget was also being spent on refusals that can never change their mind.

## The fix

`config.initFailedGraceSeconds` holds each server attempt open that long after acceptance and rejects with the report if a refusal lands inside it, handing the retry wrapper the same `TeleportFailedReportUtils.TeleportReport` a client attempt would. `Unauthorized` ends the hop immediately; `GameFull` spends an attempt like any other; `Success` and `IsTeleporting` are ignored, being the engine confirming rather than refusing.

Opt-in, because resolving late changes when an existing server caller hears back — no caller's behaviour changes until it asks. What a resolution *means* is unchanged either way: the engine accepted the request.

Listening starts before the request settles, since the engine can refuse one player of a batch while `TeleportAsync` is still yielding over the rest.

## Tests

`nevermore test --cloud` in `src/teleportserviceutils`: **144/144 green**.

Five new cases over the mock `TeleportInitFailed` seam this module already had: rejecting on a post-acceptance refusal, resolving when the window passes quietly, ignoring an in-flight report, spending an attempt on a retryable refusal, and resolving on acceptance when no window is asked for (the old behaviour, pinned).

Verified the tests exercise the new path rather than passing by accident: with the config field stubbed out at the call site, the new cases go red, and they pass again once it is restored.

## Consumer note

This does nothing on its own — a game has to ask for the window. The egg-hunt side is one field on the resume teleport, and I'll link it here once it's up.

https://claude.ai/code/session_01AaYt15KuYi84TeHPnhakWc

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @quenty/chatproviderservice@9.67.5-canary.779.30506325299.0
  npm install @quenty/saveslot@2.6.1-canary.779.30506325299.0
  npm install @quenty/softshutdown@10.3.4-canary.779.30506325299.0
  npm install @quenty/teleportserviceutils@10.3.1-canary.779.30506325299.0
  # or 
  yarn add @quenty/chatproviderservice@9.67.5-canary.779.30506325299.0
  yarn add @quenty/saveslot@2.6.1-canary.779.30506325299.0
  yarn add @quenty/softshutdown@10.3.4-canary.779.30506325299.0
  yarn add @quenty/teleportserviceutils@10.3.1-canary.779.30506325299.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
