### PR TITLE
fix(nevermore-cli): tag only the script template as the batch test entry

### DIFF
--- a/tools/nevermore-cli/build-scripts/combine-test-places.luau
+++ b/tools/nevermore-cli/build-scripts/combine-test-places.luau
@@ -7,6 +7,11 @@
 --   1. Deserializes the .rbxl
 --   2. Reparents ServerScriptService children (the package root) into the combined ServerScriptService
 --   3. Reads the test script file and creates a Script under ReplicatedStorage._BatchScripts
+--
+-- The injected script is the ONLY thing tagged `_BatchTest_<slug>`, because that tag is how
+-- batch-test-runner picks what to execute and it can only execute one thing. This used to tag every
+-- Script under ServerScriptService instead, which is the same script right up until a project has
+-- two -- and then the runner ran whichever the tag happened to list first, silently testing nothing.
 
 local fs = require("@lune/fs")
 local process = require("@lune/process")
@@ -40,16 +45,32 @@ local baseContents = fs.readFile(packages[1].rbxlPath)
 local game = roblox.deserializePlace(baseContents)
 
 local HttpService = game:GetService("HttpService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local ServerScriptService = game:GetService("ServerScriptService")
 
 ServerScriptService.LoadStringEnabled = true
 
--- Process first package
-for _, descendant in ServerScriptService:GetDescendants() do
-	if descendant:IsA("Script") then
-		descendant:AddTag("_BatchTest_" .. packages[1].slug)
+local batchScripts = roblox.Instance.new("Folder")
+batchScripts.Name = "_BatchScripts"
+batchScripts.Parent = ReplicatedStorage
+
+-- Carries the package's entry point as source for the runner to loadstring. Never runs on its own:
+-- a Script under ReplicatedStorage is inert, and the runner wants to choose when it runs anyway.
+local function injectTestScript(pkg)
+	if not fs.isFile(pkg.scriptPath) then
+		print(`[CombinePlaces] No script template for {pkg.slug} at {pkg.scriptPath}`)
+		process.exit(1)
 	end
+
+	local testScript = roblox.Instance.new("Script")
+	testScript.Name = pkg.slug
+	testScript.Source = fs.readFile(pkg.scriptPath)
+	testScript:AddTag("_BatchTest_" .. pkg.slug)
+	testScript.Parent = batchScripts
 end
+
+-- Process first package
+injectTestScript(packages[1])
 
 -- Process remaining packages: deserialize each and reparent ServerScriptService children.
 -- NOTE: ObjectValues (links) within each package's subtree are preserved when the
@@ -69,11 +90,7 @@ for idx = 2, #packages do
 		HttpService.HttpEnabled = true
 	end
 
-	for _, descendant in packageServerScriptService:GetDescendants() do
-		if descendant:IsA("Script") then
-			descendant:AddTag("_BatchTest_" .. pkg.slug)
-		end
-	end
+	injectTestScript(pkg)
 
 	-- Reparent all ServerScriptService children (non-recursively, just move the roots)
 	for _, child in packageServerScriptService:GetChildren() do

--- a/tools/nevermore-cli/templates/batch-test-runner.luau
+++ b/tools/nevermore-cli/templates/batch-test-runner.luau
@@ -16,7 +16,15 @@ local scriptSources = {}
 for _, slug in packageSlugs do
 	local tagged = CollectionService:GetTagged(`_BatchTest_{slug}`)
 	local inst = tagged[1]
-	if inst then
+	if #tagged > 1 then
+		-- Refused rather than picked. Running whichever one the tag listed first is how this fails
+		-- quietly: a script that returns without erroring reports as a pass having tested nothing.
+		local fullNames = {}
+		for _, taggedInstance in tagged do
+			table.insert(fullNames, taggedInstance:GetFullName())
+		end
+		warn(`[BatchTest] {slug}: {#tagged} instances tagged _BatchTest_{slug}: {table.concat(fullNames, ", ")}`)
+	elseif inst then
 		scriptSources[slug] = inst.Source
 	else
 		warn(`[BatchTest] Failed to find script source for {slug}`)
@@ -42,7 +50,7 @@ for _, slug in packageSlugs do
 	local scriptSource = scriptSources[slug]
 	if not scriptSource then
 		print("===BATCH_TEST_BEGIN " .. slug .. "===")
-		warn(`[BatchTest] {slug}: No test script found for {slug}. Is it tagged with _BatchTest_{slug}?`)
+		warn(`[BatchTest] {slug}: No test script to run. Is exactly one instance tagged _BatchTest_{slug}?`)
 		print("===BATCH_TEST_END " .. slug .. " FAIL 0===")
 		table.insert(results, { slug = slug, success = false, durationMs = 0, error = "No test script found" })
 		continue


### PR DESCRIPTION
`batch test` can run the wrong script and report it as a pass. A game in my org
has had zero test coverage in CI since the moment it added a second server
script — the batch ran that script instead of the test bootstrap, and CI's only
complaint was `0ms` and `no jest report in output`.

## Why

`combine-test-places.luau` tags **every** `Script` under `ServerScriptService`:

```lua
for _, descendant in ServerScriptService:GetDescendants() do
	if descendant:IsA("Script") then
		descendant:AddTag("_BatchTest_" .. packages[1].slug)
	end
end
```

and `batch-test-runner.luau` loadstrings `CollectionService:GetTagged(...)[1]`.
With one script in the project those are the same script. With two, the runner
takes whichever the tag lists first — and since a script that returns without
erroring looks exactly like a passing test bootstrap, the marker says PASS and
the only symptom is an empty section.

Meanwhile `scriptPath` — the target's `scriptTemplate`, the thing the
single-package path actually executes — is passed all the way down to the lune
script and then ignored. The header comment says it becomes a Script under
`ReplicatedStorage._BatchScripts`; the code never did that.

## The change

- `combine-test-places.luau` injects the `scriptTemplate` file as a Script under
  `ReplicatedStorage._BatchScripts` and tags **only** that, for every package
  rather than only the first. It exits with a clear message if the file is
  missing, instead of silently producing a place with nothing to run. A Script
  under `ReplicatedStorage` is inert, so it is a source carrier and nothing else.
- `batch-test-runner.luau` refuses a tag that resolves to more than one instance
  and names them, rather than picking one. That is the state that used to be
  silent.

This also makes batch agree with the single-package path about what "the test
script" is, rather than agreeing by coincidence of project shape.

## Verification

Against a real game whose `src/scripts/Server` holds two scripts, using a local
build of the CLI:

| | result |
|---|---|
| published 4.42.0 | `FAILED (0ms)` — 7 log messages, none of them jest |
| this branch | `Passed (645/707)` in 1m21s |

The 645/707 matches what that repo's CI reported the day before it added the
second script, so the fix restores exactly the suite that went missing.

`npm test` in `tools/nevermore-cli`: 121 passed. No unit test added — the
regression lives in a lune script that needs a real `.rbxl` to exercise, and the
two guards this adds (a hard exit at combine time, a refusal at run time) are
what would have caught it.

https://claude.ai/code/session_01Ei9RRAgYwL3MGtMkr6vyKE
