### PR TITLE
fix: Prevent redundant localization table rebuilding

### DIFF
--- a/src/clienttranslator/docs/design.md
+++ b/src/clienttranslator/docs/design.md
@@ -48,17 +48,85 @@ the two registrations are the same entry with the same source.
 
 ## Writes are batched, and that is not negotiable
 
-Every raw write to a `LocalizationTable` invalidates every `AutoLocalize` entry in the engine. A
+Every mutating call to a `LocalizationTable` — `SetEntries` and `SetEntryValue` alike — invalidates
+the engine's cached table contents, raises a property change, and fires its retranslation signal. A
 game streaming in registers thousands of entries in a single frame, so writing per entry is a
-frame-killer. `TranslatorService` accumulates deltas and applies them with **one `SetEntries` call
-per frame**, via `task.defer`.
+frame-killer. `TranslatorService` accumulates deltas and applies them **once per frame**, via
+`task.defer`.
 
 `TranslatorService.spec.lua` ("write cost while streaming in") pins this: the write count is `1`
 whether ten or five hundred entries register in the frame. If a change makes that number scale with
 entry count, the change is wrong, however clean it looks.
 
 The cost of batching is that **a key is not readable the instant it is registered**. Everything
-below exists to pay that cost without giving up the batching.
+under "Readiness is per key" exists to pay that cost without giving up the batching.
+
+### Two write regimes, chosen by batch size
+
+Batching alone is not enough, because `SetEntries` is not free either: it re-serializes **every**
+entry in the table. Once a game's table holds thousands of entries, rebuilding all of them so that
+one newly-shown label can register its key is its own frame cost — and that is the steady state,
+since text appearing on screen is what registers keys.
+
+So a flush picks:
+
+| Batch | Route | Why |
+|---|---|---|
+| Small relative to the table | one `SetEntryValue`/`SetEntryExample` per changed field | a few invalidations, nothing re-serialized |
+| Large relative to the table | one `SetEntries` | one invalidation instead of hundreds, at the price of one rebuild |
+
+The crossover is `INVALIDATION_ENTRY_COST` in `TranslatorService`: an invalidation is treated as
+costing about as much as re-serializing 100 entries. It is a judgment call about the ratio of two
+engine-internal costs, not a measured constant — tune it if the profile says otherwise, but keep
+both regimes. Loading a locale (hundreds of entries at once) must not become hundreds of
+invalidations, and showing one label must not rebuild the whole table.
+
+Pinned by "lands a later handful of keys without rebuilding the whole table" and "rebuilds rather
+than writing hundreds of entries one at a time", via `GetLocalizationRebuildCount`.
+
+The targeted route trusts each call to leave the rest of the entry alone, and only `SetEntryValue`
+is known to overwrite source and context in place. So a batch that changes only an entry's metadata
+is carried by a value write — rewriting a locale the entry already has — queued ahead of any
+example write for that entry, and a batch with no value to carry it goes to `SetEntries` instead.
+`SetEntryExample` is therefore never the call that lands new metadata. The three assumptions this
+rests on are pinned against the engine by "LocalizationTable behavior the targeted writes rest on"
+and written up in [`engine-behavior.md`](engine-behavior.md).
+
+### Registering unchanged text is free
+
+`ToTranslationKey` registers its source text as a side effect of minting the key, so **every** label
+built through `ObserveTranslation` re-registers text the table already holds. Queuing those would
+schedule a flush, take the key not-ready, and drive a re-translation pass through every reader of
+it — per label, per frame, in the source language, where there is nothing to translate at all.
+
+`SetEntryValue`/`SetEntryExample` therefore drop a write the table already agrees with before it
+queues. Source and context count as part of the value: a change in either still writes.
+
+### The table is mirrored
+
+Deciding any of the above means knowing what the table currently holds, and `GetEntries` copies and
+re-materializes every entry in it — an O(table) read per flush, which is the cost being avoided.
+
+So `TranslatorService` keeps a mirror of each table's entries, built once and kept in step with
+every write. It is keyed by the `LocalizationTable` instance (weakly) and **shared across
+`TranslatorService` instances**, because the table itself is shared: it is found by realm-scoped
+name, so a second service bag in the same realm — a story, a test — writes into the same instance,
+and a per-service mirror would go stale behind it.
+
+A mirror that disagrees with the table fails silently and permanently: a write the mirror thinks is
+already there is dropped, so the key never lands and nothing says so. Targeted writes cannot cause
+that — they touch one field of one entry — but a rebuild writes the whole entry list back, and
+would drop an entry the mirror never saw.
+
+So the rebuild path reads the table back first and re-applies the batch on top of what it finds.
+That is the O(table) read this mirror exists to avoid, and it is close to free next to the rebuild
+it precedes — while the hot path, the targeted writes, never pays it. It also re-syncs the mirror,
+so a foreign write costs at most the writes dropped between one rebuild and the next rather than
+poisoning the mirror for the life of the place.
+
+This package is still meant to be the only writer of `GeneratedJSONTable_*`, which the design
+already requires elsewhere. The reconciliation is what keeps a violation recoverable rather than
+fatal. Pinned by "preserves an entry written directly to the table after the mirror was built".
 
 ## Readiness is per key, not per batch
 

--- a/src/clienttranslator/docs/design.md
+++ b/src/clienttranslator/docs/design.md
@@ -84,13 +84,14 @@ invalidations, and showing one label must not rebuild the whole table.
 Pinned by "lands a later handful of keys without rebuilding the whole table" and "rebuilds rather
 than writing hundreds of entries one at a time", via `GetLocalizationRebuildCount`.
 
-The targeted route trusts each call to leave the rest of the entry alone, and only `SetEntryValue`
-is known to overwrite source and context in place. So a batch that changes only an entry's metadata
-is carried by a value write — rewriting a locale the entry already has — queued ahead of any
-example write for that entry, and a batch with no value to carry it goes to `SetEntries` instead.
-`SetEntryExample` is therefore never the call that lands new metadata. The three assumptions this
-rests on are pinned against the engine by "LocalizationTable behavior the targeted writes rest on"
-and written up in [`engine-behavior.md`](engine-behavior.md).
+The targeted route trusts each call to leave the rest of the entry alone, and source and context
+ride along only on a value write that actually changes a value — a `SetEntryValue` that rewrites the
+text a locale already holds lands nothing, new metadata included. So a batch that changes nothing
+but an entry's metadata is rebuilt rather than written. That is rare next to the value writes this
+path exists for, and the alternative is a metadata change that silently does not land. What the
+engine does and does not guarantee here is written up in
+[`engine-behavior.md`](engine-behavior.md), pinned by "LocalizationTable behavior the targeted
+writes rest on" and "queues a write that changes only the source or context".
 
 ### Registering unchanged text is free
 

--- a/src/clienttranslator/docs/engine-behavior.md
+++ b/src/clienttranslator/docs/engine-behavior.md
@@ -13,7 +13,12 @@ from these is in [`design.md`](design.md).
 Source and context are metadata; they do **not** widen an entry's identity.
 
 - `SetEntryValue(key, sourceA, contextA, ...)` then `SetEntryValue(key, sourceB, contextB, ...)`
-  leaves a **single** entry — the second call overwrites source/context in place.
+  leaves a **single** entry — the second call overwrites source/context in place, **provided it
+  also changes the value**. Called with the text the locale already holds it lands nothing at all,
+  source and context included: the new metadata is silently discarded. There is therefore no
+  targeted call that changes only an entry's metadata, and `TranslatorService` rebuilds the table
+  for a batch that changes nothing else. Pinned by `TranslatorService.spec.lua` ("queues a write
+  that changes only the source or context").
 - `SetEntries` **rejects** an array holding two entries that share a key, even with differing
   source and context:
 
@@ -43,10 +48,9 @@ rest on"), because `TranslatorService` lands small batches as targeted writes an
 result rather than reading the table back — a call that clobbered a neighbouring field would put
 the mirror permanently out of step with the table, silently.
 
-What is **not** established is whether `SetEntryExample` overwrites source and context in place the
-way `SetEntryValue` does. Only the `SetEntryValue` behavior above was verified, so the flush never
-lets an example write be the call that lands new metadata; see
-[`design.md`](design.md) ("Two write regimes").
+What is **not** established is whether `SetEntryExample` overwrites source and context in place at
+all. It does not need to be: no targeted call lands metadata on its own (see above), so the flush
+never asks an example write to carry it; see [`design.md`](design.md) ("Two write regimes").
 
 ## Write cost: assumed, not measured
 

--- a/src/clienttranslator/docs/engine-behavior.md
+++ b/src/clienttranslator/docs/engine-behavior.md
@@ -35,6 +35,32 @@ game registered the same key twice (e.g. `collectable.toolUnlocked` written as a
 and again as a generated dialog line), crashing the flush. Pinned by
 `TranslatorService.spec.lua` ("entry merging").
 
+## A targeted write leaves the rest of the entry alone
+
+`SetEntryValue` does not disturb the entry's example, and `SetEntryExample` does not disturb its
+values. Pinned by `TranslatorService.spec.lua` ("LocalizationTable behavior the targeted writes
+rest on"), because `TranslatorService` lands small batches as targeted writes and mirrors the
+result rather than reading the table back — a call that clobbered a neighbouring field would put
+the mirror permanently out of step with the table, silently.
+
+What is **not** established is whether `SetEntryExample` overwrites source and context in place the
+way `SetEntryValue` does. Only the `SetEntryValue` behavior above was verified, so the flush never
+lets an example write be the call that lands new metadata; see
+[`design.md`](design.md) ("Two write regimes").
+
+## Write cost: assumed, not measured
+
+The two write regimes rest on a cost model that was reasoned about rather than profiled:
+
+- every mutating call — `SetEntries` and `SetEntryValue` alike — invalidates the engine's cached
+  table contents, so N targeted writes cost N invalidations;
+- `SetEntries` additionally re-serializes every entry in the table, so its cost scales with the
+  table rather than with the batch.
+
+The symptom that motivated it is real and reproducible — a frame spike each time new text appeared
+on screen, on a table holding thousands of entries — but `INVALIDATION_ENTRY_COST` (the ratio
+between the two) is a judgment call. If you profile this properly, write the numbers here.
+
 ## `Translator:FormatByKey` raises for a missing key
 
 It does not return nil, and it does not fall back to the table's source locale. The error text is:

--- a/src/clienttranslator/src/Shared/JSONTranslator.TranslationReady.spec.lua
+++ b/src/clienttranslator/src/Shared/JSONTranslator.TranslationReady.spec.lua
@@ -193,18 +193,26 @@ describe("TranslatorService:ObserveIsTranslationReady", function()
 		controller:destroy()
 	end)
 
-	it("fires ready even when the queued value already matched the table", function()
+	-- A write the table already holds never gets queued at all (TranslatorService.spec.lua,
+	-- "does not queue a write the table already holds"), so the way a key reaches the flush
+	-- with nothing left to write is a single-key read landing its value first. The key is in
+	-- the table either way, and a key that never went ready would strand its readers.
+	it("fires ready even when the flush found nothing left to write", function()
 		local controller = TranslatorTestUtils.setup()
 		local service = controller.translatorService
 
 		service:SetEntryValue("k.one", "One", "ctx", "en", "One")
-		controller.awaitEntriesWritten()
-
 		local received = collect(controller, service:ObserveIsTranslationReady("k.one"))
-		service:SetEntryValue("k.one", "One", "ctx", "en", "One")
+		expect(received).toEqual({ false })
+
+		-- Lands the value and dequeues that locale, leaving the entry queued for the flush.
+		service:FlushEntryForKey("k.one")
+		local writesAfterRead = service:GetLocalizationWriteCount()
+
 		controller.awaitEntriesWritten()
 
-		expect(received).toEqual({ true, false, true })
+		expect(received).toEqual({ false, true })
+		expect(service:GetLocalizationWriteCount()).toBe(writesAfterRead)
 		controller:destroy()
 	end)
 

--- a/src/clienttranslator/src/Shared/JSONTranslator.lua
+++ b/src/clienttranslator/src/Shared/JSONTranslator.lua
@@ -456,7 +456,9 @@ function JSONTranslator.ToTranslationKey(self: JSONTranslator, prefix: string, t
 	local translationKey = TranslationKeyUtils.getTranslationKey(prefix, text)
 	local context = string.format("automatic.%s", translationKey)
 
-	-- TODO: Only set if we don't need it
+	-- Registration is unconditional, and cheap when nothing changed: the service drops a write
+	-- the table already agrees with before it queues anything. This is a hot path -- every
+	-- label built through ObserveTranslation mints its key -- so it has to stay that way.
 	self:SetEntryValue(translationKey, text, context, "en", text)
 
 	return translationKey

--- a/src/clienttranslator/src/Shared/TranslatorService.lua
+++ b/src/clienttranslator/src/Shared/TranslatorService.lua
@@ -594,14 +594,14 @@ function TranslatorService._landEntryLocale(
 	local cache = self:_getEntryCache(localizationTable)
 	local existing = cache.ByKey[entry.Key]
 
-	-- Already there (another translator registered the same text). Still dequeued, so the
-	-- flush does not write it either.
-	if
-		existing
-		and existing.Source == entry.Source
-		and existing.Context == entry.Context
-		and existing.Values[localeId] == text
-	then
+	-- The text a read needs is already there (another translator registered the same value).
+	-- Dequeued so the flush does not write it either.
+	--
+	-- Deliberately not conditioned on the source/context matching too: a SetEntryValue that
+	-- does not change the value does not land new metadata either (engine-behavior.md), so
+	-- writing here would move the mirror and not the table. A metadata change stays queued for
+	-- the flush, which rebuilds for it.
+	if existing and existing.Values[localeId] == text then
 		entry.Values[localeId] = nil
 		return
 	end
@@ -857,23 +857,15 @@ function TranslatorService._mergePendingEntries(
 			end
 		end
 
-		-- Source and context ride along on whichever call carries them, so a batch that
-		-- changes only those still needs one call to carry them: rewriting a locale it already
-		-- has does that, since SetEntryValue overwrites metadata in place.
-		--
-		-- Only SetEntryValue is known to do so (engine-behavior.md pins that call and no
-		-- other), so a metadata change is carried by a value write or not at all -- and it is
-		-- queued ahead of the example write below, so SetEntryExample is never the call that
-		-- has to land new metadata.
+		-- Source and context ride along on the value write that changes the entry, and there is
+		-- no targeted call that lands them on their own: SetEntryValue updates them only when
+		-- it actually changes a value, and rewriting a locale with the text it already holds is
+		-- a no-op the metadata does not survive (engine-behavior.md). So a batch that changes
+		-- nothing but metadata is rebuilt rather than written -- rare next to the value writes
+		-- this path exists for, and the alternative is a metadata change that silently does not
+		-- land.
 		if metadataChanged and not valueWritten then
-			local localeId = next(entry.Values)
-			if localeId ~= nil then
-				table.insert(writes, { Entry = entry, LocaleId = localeId })
-			else
-				-- Nothing to carry it: an entry holding no values at all can only be written
-				-- through SetEntries.
-				bulkRequired = true
-			end
+			bulkRequired = true
 		end
 
 		if delta.Example ~= nil and entry.Example ~= delta.Example then

--- a/src/clienttranslator/src/Shared/TranslatorService.lua
+++ b/src/clienttranslator/src/Shared/TranslatorService.lua
@@ -25,8 +25,17 @@ local ValueObject = require("ValueObject")
 local TranslatorService = {}
 TranslatorService.ServiceName = "TranslatorService"
 
--- An accumulated localization entry delta that is merged into the table and applied in a
--- single SetEntries call on flush.
+-- How many entries re-serializing costs about as much as one invalidation of the engine's
+-- cached table contents. Every mutating call to a LocalizationTable -- SetEntries and
+-- SetEntryValue alike -- invalidates that cache, raises a property change, and fires the
+-- engine's retranslation signal; on top of that SetEntries re-serializes every entry in the
+-- table, while SetEntryValue touches only one. So the surgical path wins while the batch is
+-- small *relative to the table it writes into*: rewriting 20 entries of 20 is a full rebuild
+-- either way, rewriting 20 of 8000 is not. See docs/design.md ("Writes are batched").
+local INVALIDATION_ENTRY_COST = 100
+
+-- An accumulated localization entry delta, merged into the table on flush along with the rest
+-- of the frame's batch.
 type PendingEntry = {
 	Key: string,
 	Source: string,
@@ -51,6 +60,44 @@ type ReadyObserver = {
 	Disconnected: boolean,
 }
 
+-- An entry as the LocalizationTable stores it (the shape GetEntries returns and SetEntries
+-- takes).
+type LocalizationEntry = {
+	Key: string,
+	Source: string,
+	Context: string,
+	Example: string,
+	Values: { [string]: string },
+}
+
+-- What the localization table currently holds, indexed both ways: the array is what a bulk
+-- SetEntries writes back, the map is how a write finds the entry for its key.
+type EntryCache = {
+	List: { LocalizationEntry },
+	ByKey: { [string]: LocalizationEntry },
+}
+
+-- One targeted table write the flush still owes: a locale's value, or (LocaleId nil) the
+-- entry's example.
+type PendingWrite = {
+	Entry: LocalizationEntry,
+	LocaleId: string?,
+}
+
+-- Mirrors of the localization tables' contents, so neither a write nor a flush has to read
+-- the table back. GetEntries copies and re-materializes every entry in the table, so calling
+-- it per flush makes a frame that touches one key cost O(table) -- exactly the cost the
+-- batching exists to avoid.
+--
+-- Keyed by the table itself, and shared across TranslatorService instances rather than held
+-- per service, because the table is shared: it is found by realm-scoped name, so a second
+-- service bag in the same realm (a story, a test) writes into the same instance and a
+-- private mirror would go stale behind it. Weak so a destroyed table's mirror goes with it.
+--
+-- This assumes this package is the only writer of GeneratedJSONTable_*, which the design
+-- already requires (everything goes through TranslatorService).
+local entryCachesByTable: { [LocalizationTable]: EntryCache } = setmetatable({}, { __mode = "k" }) :: any
+
 export type TranslatorService = typeof(setmetatable(
 	{} :: {
 		_maid: Maid.Maid,
@@ -69,6 +116,7 @@ export type TranslatorService = typeof(setmetatable(
 		_flushScheduled: boolean,
 		_pendingFlushPromise: Promise.Promise<()>?,
 		_localizationWriteCount: number,
+		_localizationRebuildCount: number,
 	},
 	{} :: typeof({ __index = TranslatorService })
 ))
@@ -85,6 +133,7 @@ function TranslatorService.Init(self: TranslatorService, serviceBag: ServiceBag.
 	self._isDestroyed = false
 	self._flushScheduled = false
 	self._localizationWriteCount = 0
+	self._localizationRebuildCount = 0
 
 	self._forcedLocaleId = self._maid:Add(ValueObject.new(nil))
 
@@ -141,6 +190,10 @@ end
 	[TranslatorService.ObserveIsTranslationReady], which tracks the key you are about to read
 	rather than whichever batch happened to be pending.
 
+	Registering what the table already holds is free: the write is dropped before it queues, so
+	it neither schedules a flush nor takes the key not-ready. Re-registering unchanged text is
+	the common case rather than the exception.
+
 	@param translationKey string
 	@param source string
 	@param context string
@@ -158,6 +211,10 @@ function TranslatorService.SetEntryValue(
 	if self._isDestroyed then
 		-- Dropped rather than queued: nothing will flush it, and a queued entry would pin the
 		-- key not-ready forever for anything that asks afterwards.
+		return
+	end
+
+	if self:_isEntryValueCurrent(translationKey, source, context, localeId, text) then
 		return
 	end
 
@@ -188,6 +245,10 @@ function TranslatorService.SetEntryExample(
 	example: string
 )
 	if self._isDestroyed then
+		return
+	end
+
+	if self:_isEntryExampleCurrent(translationKey, source, context, example) then
 		return
 	end
 
@@ -227,6 +288,74 @@ function TranslatorService._getPendingEntry(
 	end
 
 	return entry, false
+end
+
+-- The mirror of a table's entries, built from the table the first time anything needs it.
+function TranslatorService._getEntryCache(_self: TranslatorService, localizationTable: LocalizationTable): EntryCache
+	local existing = entryCachesByTable[localizationTable]
+	if existing then
+		return existing
+	end
+
+	local list: { LocalizationEntry } = localizationTable:GetEntries() :: any
+	local byKey: { [string]: LocalizationEntry } = {}
+	for _, entry in list do
+		byKey[entry.Key] = entry
+	end
+
+	local cache: EntryCache = { List = list, ByKey = byKey }
+	entryCachesByTable[localizationTable] = cache
+	return cache
+end
+
+-- Whether the table already holds exactly this value, making the write nothing but cost.
+--
+-- Re-registering unchanged text is the common case rather than the exception: minting a
+-- translation key ([JSONTranslator.ToTranslationKey]) registers its source text every time a
+-- label is built, and a loader re-queues a locale it has already loaded. Queuing such a write
+-- would schedule a flush, and -- because the key goes not-ready and back -- drive a
+-- re-translation pass through every reader of that key, all to write back what is there.
+function TranslatorService._isEntryValueCurrent(
+	self: TranslatorService,
+	translationKey: string,
+	source: string,
+	context: string,
+	localeId: string,
+	text: string
+): boolean
+	-- A key with a delta queued is mid-change; the flush decides what the table ends up with.
+	if self._pendingEntries[translationKey] then
+		return false
+	end
+
+	local entry = self:_getEntryCache(self:GetLocalizationTable()).ByKey[translationKey]
+	if not entry then
+		return false
+	end
+
+	-- Source and context are part of what a write would land, so a change in either is still
+	-- a change even when the text matches.
+	return entry.Source == source and entry.Context == context and entry.Values[localeId] == text
+end
+
+-- Whether the table already holds exactly this example. See [TranslatorService._isEntryValueCurrent].
+function TranslatorService._isEntryExampleCurrent(
+	self: TranslatorService,
+	translationKey: string,
+	source: string,
+	context: string,
+	example: string
+): boolean
+	if self._pendingEntries[translationKey] then
+		return false
+	end
+
+	local entry = self:_getEntryCache(self:GetLocalizationTable()).ByKey[translationKey]
+	if not entry then
+		return false
+	end
+
+	return entry.Source == source and entry.Context == context and entry.Example == example
 end
 
 --[=[
@@ -462,6 +591,40 @@ function TranslatorService._landEntryLocale(
 		return
 	end
 
+	local cache = self:_getEntryCache(localizationTable)
+	local existing = cache.ByKey[entry.Key]
+
+	-- Already there (another translator registered the same text). Still dequeued, so the
+	-- flush does not write it either.
+	if
+		existing
+		and existing.Source == entry.Source
+		and existing.Context == entry.Context
+		and existing.Values[localeId] == text
+	then
+		entry.Values[localeId] = nil
+		return
+	end
+
+	local cached: LocalizationEntry
+	if existing then
+		cached = existing
+	else
+		cached = {
+			Key = entry.Key,
+			Source = entry.Source,
+			Context = entry.Context,
+			Example = "",
+			Values = {},
+		}
+		cache.ByKey[entry.Key] = cached
+		table.insert(cache.List, cached)
+	end
+
+	cached.Source = entry.Source
+	cached.Context = entry.Context
+	cached.Values[localeId] = text
+
 	localizationTable:SetEntryValue(entry.Key, entry.Source, entry.Context, localeId, text)
 	entry.Values[localeId] = nil
 	self._localizationWriteCount += 1
@@ -476,6 +639,17 @@ end
 ]=]
 function TranslatorService.GetLocalizationWriteCount(self: TranslatorService): number
 	return self._localizationWriteCount
+end
+
+--[=[
+	Returns how many of those writes were full-table `SetEntries` rebuilds, which additionally
+	re-serialize every entry in the table. A flush picks between rebuilding and landing
+	targeted writes, so this is how a test tells which path a batch took.
+
+	@return number
+]=]
+function TranslatorService.GetLocalizationRebuildCount(self: TranslatorService): number
+	return self._localizationRebuildCount
 end
 
 function TranslatorService._scheduleFlush(self: TranslatorService)
@@ -534,25 +708,122 @@ function TranslatorService._flushWrites(self: TranslatorService)
 	end
 end
 
--- Merges the pending entry deltas into the table's current entries and writes them back
--- in a single SetEntries call, so a whole frame's worth of translation entries costs one
--- AutoLocalize invalidation instead of one per value/example.
+-- Merges the pending entry deltas into the table's entries and writes back whatever actually
+-- changed, by whichever route is cheaper for the size of the batch: a handful of targeted
+-- SetEntryValue/SetEntryExample calls, or one SetEntries that rebuilds the table.
 function TranslatorService._applyPendingEntries(self: TranslatorService, pendingEntries: PendingEntries)
 	local localizationTable = self:GetLocalizationTable()
+	local cache = self:_getEntryCache(localizationTable)
+
+	local writes = self:_mergePendingEntries(cache, pendingEntries)
+
+	-- Every queued write already matched the table, so there is nothing to land. Writing
+	-- anyway would invalidate the engine's cached contents for no reason.
+	if writes and #writes == 0 then
+		return
+	end
+
+	if writes and self:_shouldWriteIndividually(#writes, #cache.List) then
+		for _, write in writes do
+			local entry = write.Entry
+			local localeId = write.LocaleId
+			if localeId ~= nil then
+				localizationTable:SetEntryValue(
+					entry.Key,
+					entry.Source,
+					entry.Context,
+					localeId,
+					entry.Values[localeId]
+				)
+			else
+				localizationTable:SetEntryExample(entry.Key, entry.Source, entry.Context, entry.Example)
+			end
+			self._localizationWriteCount += 1
+		end
+		return
+	end
+
+	-- A rebuild writes the whole entry list back, so it is the one path that can drop an entry
+	-- the mirror never saw. Read the table back first and re-apply this batch on top: this is
+	-- the O(table) read the mirror exists to keep out of the hot path, and next to the rebuild
+	-- it is about to pay for it is close to free. It also re-syncs the mirror with anything
+	-- written behind our back, so a foreign write cannot leave the currency check dropping
+	-- writes against a stale mirror indefinitely.
+	self:_reconcileEntryCache(localizationTable, cache, pendingEntries)
+
+	localizationTable:SetEntries(cache.List :: any)
+	self._localizationWriteCount += 1
+	self._localizationRebuildCount += 1
+end
+
+-- Rebuilds the mirror from what the table actually holds, with this batch's merged entries
+-- kept on top. Anything a foreign writer added or changed is adopted; the keys in this batch
+-- win, since the table has not been told about their new values yet.
+function TranslatorService._reconcileEntryCache(
+	_self: TranslatorService,
+	localizationTable: LocalizationTable,
+	cache: EntryCache,
+	pendingEntries: PendingEntries
+)
+	local list: { LocalizationEntry } = localizationTable:GetEntries() :: any
+	local byKey: { [string]: LocalizationEntry } = {}
+
+	for index, entry in list do
+		local merged = if pendingEntries[entry.Key] then cache.ByKey[entry.Key] else nil
+		if merged then
+			list[index] = merged
+			byKey[entry.Key] = merged
+		else
+			byKey[entry.Key] = entry
+		end
+	end
+
+	-- Keys this batch is creating are not in the table yet, so the read back cannot have them.
+	for translationKey in pendingEntries do
+		if byKey[translationKey] == nil then
+			local merged = cache.ByKey[translationKey]
+			if merged then
+				byKey[translationKey] = merged
+				table.insert(list, merged)
+			end
+		end
+	end
+
+	cache.List = list
+	cache.ByKey = byKey
+end
+
+-- Whether to land this many targeted writes rather than rebuild the whole table. One
+-- SetEntries costs one invalidation plus re-serializing every entry; N targeted writes cost N
+-- invalidations and re-serialize nothing. See INVALIDATION_ENTRY_COST.
+function TranslatorService._shouldWriteIndividually(
+	_self: TranslatorService,
+	writeCount: number,
+	entryCount: number
+): boolean
+	return (writeCount - 1) * INVALIDATION_ENTRY_COST < entryCount
+end
+
+-- Merges the deltas into the mirror and returns the targeted writes that would bring the
+-- table in line with it, or nil when the batch cannot be expressed as targeted writes at all
+-- and has to go through SetEntries.
+function TranslatorService._mergePendingEntries(
+	_self: TranslatorService,
+	cache: EntryCache,
+	pendingEntries: PendingEntries
+): { PendingWrite }?
+	local writes: { PendingWrite } = {}
+	local bulkRequired = false
 
 	-- A LocalizationTable keys its entries by translation key alone: SetEntries rejects two
 	-- entries sharing a key even when their source/context differ, so we index existing
 	-- entries by key and merge each delta into the one entry for its key.
-	local existingByKey: { [string]: any } = {}
-	local entries = localizationTable:GetEntries()
-	for _, entry in entries do
-		existingByKey[entry.Key] = entry
-	end
-
-	local changed = false
 	for _, delta in pendingEntries do
-		local entry = existingByKey[delta.Key]
-		if not entry then
+		local existing = cache.ByKey[delta.Key]
+		local entry: LocalizationEntry
+		if existing then
+			entry = existing
+		else
 			entry = {
 				Key = delta.Key,
 				Source = delta.Source,
@@ -560,42 +831,62 @@ function TranslatorService._applyPendingEntries(self: TranslatorService, pending
 				Example = "",
 				Values = {},
 			}
-			existingByKey[delta.Key] = entry
-			table.insert(entries, entry)
-			changed = true
+			cache.ByKey[delta.Key] = entry
+			table.insert(cache.List, entry)
+
+			-- A targeted write lands on an entry that exists, and only SetEntryValue is known
+			-- to create one, so a new entry carrying nothing but an example cannot be
+			-- expressed that way.
+			if next(delta.Values) == nil then
+				bulkRequired = true
+			end
 		end
 
 		-- Keep the source/context in step with the latest write for this key, mirroring how
 		-- SetEntryValue overwrites them in place.
-		if entry.Source ~= delta.Source then
-			entry.Source = delta.Source
-			changed = true
-		end
-		if entry.Context ~= delta.Context then
-			entry.Context = delta.Context
-			changed = true
-		end
-		if delta.Example ~= nil and entry.Example ~= delta.Example then
-			entry.Example = delta.Example
-			changed = true
-		end
+		local metadataChanged = entry.Source ~= delta.Source or entry.Context ~= delta.Context
+		entry.Source = delta.Source
+		entry.Context = delta.Context
+
+		local valueWritten = false
 		for localeId, text in delta.Values do
 			if entry.Values[localeId] ~= text then
 				entry.Values[localeId] = text
-				changed = true
+				table.insert(writes, { Entry = entry, LocaleId = localeId })
+				valueWritten = true
 			end
+		end
+
+		-- Source and context ride along on whichever call carries them, so a batch that
+		-- changes only those still needs one call to carry them: rewriting a locale it already
+		-- has does that, since SetEntryValue overwrites metadata in place.
+		--
+		-- Only SetEntryValue is known to do so (engine-behavior.md pins that call and no
+		-- other), so a metadata change is carried by a value write or not at all -- and it is
+		-- queued ahead of the example write below, so SetEntryExample is never the call that
+		-- has to land new metadata.
+		if metadataChanged and not valueWritten then
+			local localeId = next(entry.Values)
+			if localeId ~= nil then
+				table.insert(writes, { Entry = entry, LocaleId = localeId })
+			else
+				-- Nothing to carry it: an entry holding no values at all can only be written
+				-- through SetEntries.
+				bulkRequired = true
+			end
+		end
+
+		if delta.Example ~= nil and entry.Example ~= delta.Example then
+			entry.Example = delta.Example
+			table.insert(writes, { Entry = entry, LocaleId = nil })
 		end
 	end
 
-	-- If every queued write already matched the table there is nothing to do. Skipping the
-	-- SetEntries call avoids invalidating every AutoLocalize entry for no reason (there is
-	-- no partial-update API that invalidates once, so a redundant SetEntries is pure cost).
-	if not changed then
-		return
+	if bulkRequired then
+		return nil
 	end
 
-	localizationTable:SetEntries(entries)
-	self._localizationWriteCount += 1
+	return writes
 end
 
 --[=[

--- a/src/clienttranslator/src/Shared/TranslatorService.lua
+++ b/src/clienttranslator/src/Shared/TranslatorService.lua
@@ -261,8 +261,16 @@ function TranslatorService.SetEntryExample(
 	end
 end
 
--- Returns the pending delta for a key, and whether this call is what made the key pending
--- (the caller announces that, once the write it is making has actually been stored).
+--[=[
+	Returns the pending delta for a key, and whether this call is what made the key pending
+	(the caller announces that, once the write it is making has actually been stored).
+
+	@param translationKey string
+	@param source string
+	@param context string
+	@return (PendingEntry, boolean)
+	@private
+]=]
 function TranslatorService._getPendingEntry(
 	self: TranslatorService,
 	translationKey: string,
@@ -290,7 +298,13 @@ function TranslatorService._getPendingEntry(
 	return entry, false
 end
 
--- The mirror of a table's entries, built from the table the first time anything needs it.
+--[=[
+	The mirror of a table's entries, built from the table the first time anything needs it.
+
+	@param localizationTable LocalizationTable
+	@return EntryCache
+	@private
+]=]
 function TranslatorService._getEntryCache(_self: TranslatorService, localizationTable: LocalizationTable): EntryCache
 	local existing = entryCachesByTable[localizationTable]
 	if existing then
@@ -308,13 +322,23 @@ function TranslatorService._getEntryCache(_self: TranslatorService, localization
 	return cache
 end
 
--- Whether the table already holds exactly this value, making the write nothing but cost.
---
--- Re-registering unchanged text is the common case rather than the exception: minting a
--- translation key ([JSONTranslator.ToTranslationKey]) registers its source text every time a
--- label is built, and a loader re-queues a locale it has already loaded. Queuing such a write
--- would schedule a flush, and -- because the key goes not-ready and back -- drive a
--- re-translation pass through every reader of that key, all to write back what is there.
+--[=[
+	Whether the table already holds exactly this value, making the write nothing but cost.
+
+	Re-registering unchanged text is the common case rather than the exception: minting a
+	translation key ([JSONTranslator.ToTranslationKey]) registers its source text every time a
+	label is built, and a loader re-queues a locale it has already loaded. Queuing such a write
+	would schedule a flush, and -- because the key goes not-ready and back -- drive a
+	re-translation pass through every reader of that key, all to write back what is there.
+
+	@param translationKey string
+	@param source string
+	@param context string
+	@param localeId string
+	@param text string
+	@return boolean
+	@private
+]=]
 function TranslatorService._isEntryValueCurrent(
 	self: TranslatorService,
 	translationKey: string,
@@ -338,7 +362,16 @@ function TranslatorService._isEntryValueCurrent(
 	return entry.Source == source and entry.Context == context and entry.Values[localeId] == text
 end
 
--- Whether the table already holds exactly this example. See [TranslatorService._isEntryValueCurrent].
+--[=[
+	Whether the table already holds exactly this example. See [TranslatorService._isEntryValueCurrent].
+
+	@param translationKey string
+	@param source string
+	@param context string
+	@param example string
+	@return boolean
+	@private
+]=]
 function TranslatorService._isEntryExampleCurrent(
 	self: TranslatorService,
 	translationKey: string,
@@ -495,9 +528,14 @@ function TranslatorService.ObserveIsTranslationReady(
 	end) :: any
 end
 
--- Tells a key's observers about a readiness change. The state is read per observer rather
--- than captured once: a handler earlier in the fan-out can re-queue the key, and handing the
--- observers after it a value that is already false would leave them believing the key landed.
+--[=[
+	Tells a key's observers about a readiness change. The state is read per observer rather
+	than captured once: a handler earlier in the fan-out can re-queue the key, and handing the
+	observers after it a value that is already false would leave them believing the key landed.
+
+	@param translationKey string
+	@private
+]=]
 function TranslatorService._fireTranslationReady(self: TranslatorService, translationKey: string)
 	local observers = self._readyObservers[translationKey]
 	if not observers then
@@ -577,9 +615,16 @@ function TranslatorService.FlushEntryForKey(self: TranslatorService, translation
 	end
 end
 
--- Writes one locale's value for a pending entry straight to the table and dequeues just
--- that locale, so the deferred batch flush does not write it again. No-ops if the entry has
--- nothing pending for the locale.
+--[=[
+	Writes one locale's value for a pending entry straight to the table and dequeues just
+	that locale, so the deferred batch flush does not write it again. No-ops if the entry has
+	nothing pending for the locale.
+
+	@param localizationTable LocalizationTable
+	@param entry PendingEntry
+	@param localeId string
+	@private
+]=]
 function TranslatorService._landEntryLocale(
 	self: TranslatorService,
 	localizationTable: LocalizationTable,
@@ -708,9 +753,14 @@ function TranslatorService._flushWrites(self: TranslatorService)
 	end
 end
 
--- Merges the pending entry deltas into the table's entries and writes back whatever actually
--- changed, by whichever route is cheaper for the size of the batch: a handful of targeted
--- SetEntryValue/SetEntryExample calls, or one SetEntries that rebuilds the table.
+--[=[
+	Merges the pending entry deltas into the table's entries and writes back whatever actually
+	changed, by whichever route is cheaper for the size of the batch: a handful of targeted
+	SetEntryValue/SetEntryExample calls, or one SetEntries that rebuilds the table.
+
+	@param pendingEntries PendingEntries
+	@private
+]=]
 function TranslatorService._applyPendingEntries(self: TranslatorService, pendingEntries: PendingEntries)
 	local localizationTable = self:GetLocalizationTable()
 	local cache = self:_getEntryCache(localizationTable)
@@ -756,9 +806,16 @@ function TranslatorService._applyPendingEntries(self: TranslatorService, pending
 	self._localizationRebuildCount += 1
 end
 
--- Rebuilds the mirror from what the table actually holds, with this batch's merged entries
--- kept on top. Anything a foreign writer added or changed is adopted; the keys in this batch
--- win, since the table has not been told about their new values yet.
+--[=[
+	Rebuilds the mirror from what the table actually holds, with this batch's merged entries
+	kept on top. Anything a foreign writer added or changed is adopted; the keys in this batch
+	win, since the table has not been told about their new values yet.
+
+	@param localizationTable LocalizationTable
+	@param cache EntryCache
+	@param pendingEntries PendingEntries
+	@private
+]=]
 function TranslatorService._reconcileEntryCache(
 	_self: TranslatorService,
 	localizationTable: LocalizationTable,
@@ -793,9 +850,16 @@ function TranslatorService._reconcileEntryCache(
 	cache.ByKey = byKey
 end
 
--- Whether to land this many targeted writes rather than rebuild the whole table. One
--- SetEntries costs one invalidation plus re-serializing every entry; N targeted writes cost N
--- invalidations and re-serialize nothing. See INVALIDATION_ENTRY_COST.
+--[=[
+	Whether to land this many targeted writes rather than rebuild the whole table. One
+	SetEntries costs one invalidation plus re-serializing every entry; N targeted writes cost N
+	invalidations and re-serialize nothing. See INVALIDATION_ENTRY_COST.
+
+	@param writeCount number
+	@param entryCount number
+	@return boolean
+	@private
+]=]
 function TranslatorService._shouldWriteIndividually(
 	_self: TranslatorService,
 	writeCount: number,
@@ -804,9 +868,16 @@ function TranslatorService._shouldWriteIndividually(
 	return (writeCount - 1) * INVALIDATION_ENTRY_COST < entryCount
 end
 
--- Merges the deltas into the mirror and returns the targeted writes that would bring the
--- table in line with it, or nil when the batch cannot be expressed as targeted writes at all
--- and has to go through SetEntries.
+--[=[
+	Merges the deltas into the mirror and returns the targeted writes that would bring the
+	table in line with it, or nil when the batch cannot be expressed as targeted writes at all
+	and has to go through SetEntries.
+
+	@param cache EntryCache
+	@param pendingEntries PendingEntries
+	@return { PendingWrite }?
+	@private
+]=]
 function TranslatorService._mergePendingEntries(
 	_self: TranslatorService,
 	cache: EntryCache,

--- a/src/clienttranslator/src/Shared/TranslatorService.spec.lua
+++ b/src/clienttranslator/src/Shared/TranslatorService.spec.lua
@@ -277,6 +277,44 @@ describe("TranslatorService localization write cost", function()
 		controller:destroy()
 	end)
 
+	it("does not queue a write the table already holds", function()
+		local controller = TranslatorTestUtils.setup()
+		local service = controller.translatorService
+
+		service:SetEntryValue("k.one", "One", "c1", "en", "One")
+		service:SetEntryExample("k.one", "One", "c1", "One")
+		controller.awaitEntriesWritten()
+
+		-- Registering unchanged text is the common case (every label built through
+		-- ObserveTranslation mints -- and so re-registers -- its key), so it has to be dropped
+		-- before it queues: a queued write schedules a flush and takes the key not-ready, which
+		-- drives a re-translation pass through every reader of it.
+		service:SetEntryValue("k.one", "One", "c1", "en", "One")
+		service:SetEntryExample("k.one", "One", "c1", "One")
+
+		expect(service:IsTranslationReady("k.one")).toBe(true)
+		expect(service:PromiseEntriesWritten():IsPending()).toBe(false)
+		controller:destroy()
+	end)
+
+	it("queues a write that changes only the source or context", function()
+		local controller = TranslatorTestUtils.setup()
+		local service = controller.translatorService
+
+		service:SetEntryValue("k.one", "One", "c1", "en", "One")
+		controller.awaitEntriesWritten()
+
+		service:SetEntryValue("k.one", "Uno", "c2", "en", "One")
+		expect(service:IsTranslationReady("k.one")).toBe(false)
+		controller.awaitEntriesWritten()
+
+		local entry = TranslatorTestUtils.getEntryMap(service:GetLocalizationTable())["k.one"]
+		expect(entry.Source).toBe("Uno")
+		expect(entry.Context).toBe("c2")
+		expect(entry.Values["en"]).toBe("One")
+		controller:destroy()
+	end)
+
 	it("writes when a queued entry changes an existing value", function()
 		local controller = TranslatorTestUtils.setup()
 		local service = controller.translatorService
@@ -342,6 +380,61 @@ describe("TranslatorService write cost while streaming in", function()
 
 		expect(service:GetLocalizationWriteCount()).toBe(1)
 		expect(Table.count(TranslatorTestUtils.getEntryMap(service:GetLocalizationTable()))).toBe(50)
+		controller:destroy()
+	end)
+
+	it("lands a later handful of keys without rebuilding the whole table", function()
+		local controller = TranslatorTestUtils.setup()
+		local service = controller.translatorService
+
+		for index = 1, 400 do
+			local key = string.format("streamed.key%d", index)
+			service:SetEntryValue(key, key, string.format("ctx%d", index), "en", key)
+		end
+		controller.awaitEntriesWritten()
+		expect(service:GetLocalizationRebuildCount()).toBe(1)
+
+		-- The load rebuilt the table once, which is right. A UI opening afterwards registers a
+		-- couple of keys into that same 400-entry table, and rebuilding it again for two keys
+		-- costs re-serializing all 400 -- so those land as targeted writes instead.
+		service:SetEntryValue("late.one", "Late one", "lc1", "en", "Late one")
+		service:SetEntryValue("late.two", "Late two", "lc2", "en", "Late two")
+		controller.awaitEntriesWritten()
+
+		expect(service:GetLocalizationRebuildCount()).toBe(1)
+		expect(service:GetLocalizationWriteCount()).toBe(3)
+
+		local entries = TranslatorTestUtils.getEntryMap(service:GetLocalizationTable())
+		expect(entries["late.one"].Values["en"]).toBe("Late one")
+		expect(entries["late.two"].Values["en"]).toBe("Late two")
+		-- The targeted writes must not have cost the entries already in the table.
+		expect(entries["streamed.key1"].Values["en"]).toBe("streamed.key1")
+		expect(entries["streamed.key400"].Values["en"]).toBe("streamed.key400")
+		controller:destroy()
+	end)
+
+	it("rebuilds rather than writing hundreds of entries one at a time", function()
+		local controller = TranslatorTestUtils.setup()
+		local service = controller.translatorService
+
+		for index = 1, 50 do
+			local key = string.format("streamed.key%d", index)
+			service:SetEntryValue(key, key, string.format("ctx%d", index), "en", key)
+		end
+		controller.awaitEntriesWritten()
+
+		-- A batch large next to the table it writes into goes the other way: each targeted
+		-- write invalidates the engine's cached contents just as hard as a rebuild does, so
+		-- hundreds of them cost hundreds of invalidations to save one re-serialization.
+		for index = 1, 300 do
+			local key = string.format("later.key%d", index)
+			service:SetEntryValue(key, key, string.format("lctx%d", index), "en", key)
+		end
+		controller.awaitEntriesWritten()
+
+		expect(service:GetLocalizationWriteCount()).toBe(2)
+		expect(service:GetLocalizationRebuildCount()).toBe(2)
+		expect(Table.count(TranslatorTestUtils.getEntryMap(service:GetLocalizationTable()))).toBe(350)
 		controller:destroy()
 	end)
 
@@ -459,5 +552,75 @@ describe("TranslatorService entry merging", function()
 		expect(entries["internal.key"].Values["en"]).toBe("Internal")
 		expect(service:GetLocalizationWriteCount()).toBe(1)
 		controller:destroy()
+	end)
+
+	-- The service mirrors the table's contents rather than reading it back per flush, so an
+	-- entry written behind that mirror is one a rebuild could drop: a rebuild writes the whole
+	-- entry list back. The rebuild path reads the table first for exactly this reason.
+	it("preserves an entry written directly to the table after the mirror was built", function()
+		local controller = TranslatorTestUtils.setup()
+		local service = controller.translatorService
+		local localizationTable = service:GetLocalizationTable()
+
+		-- Builds the mirror, so the write below lands behind it rather than in front of it.
+		service:SetEntryValue("internal.one", "Internal one", "intctx", "en", "Internal one")
+		controller.awaitEntriesWritten()
+
+		localizationTable:SetEntryValue("external.key", "External", "extctx", "en", "External")
+
+		-- A batch large next to the table it writes into rebuilds rather than landing targeted
+		-- writes, so this is the flush that writes the whole list back.
+		for index = 1, 50 do
+			local key = string.format("internal.key%d", index)
+			service:SetEntryValue(key, key, string.format("ctx%d", index), "en", key)
+		end
+		controller.awaitEntriesWritten()
+		expect(service:GetLocalizationRebuildCount()).toBe(2)
+
+		local entries = TranslatorTestUtils.getEntryMap(localizationTable)
+		expect(entries["external.key"].Values["en"]).toBe("External")
+		expect(entries["internal.one"].Values["en"]).toBe("Internal one")
+		expect(entries["internal.key50"].Values["en"]).toBe("internal.key50")
+		expect(Table.count(entries)).toBe(52)
+		controller:destroy()
+	end)
+end)
+
+-- The batched flush lands small batches as targeted SetEntryValue/SetEntryExample calls
+-- rather than rebuilding the table, which means trusting those calls to leave the rest of the
+-- entry alone. Nothing in the package would notice if they stopped: the mirror would simply
+-- disagree with the table from then on, and a write it thinks is redundant is dropped. So the
+-- assumptions are pinned here, against the engine, not against the service.
+--
+-- The third assumption -- that SetEntryValue overwrites source/context in place -- is written
+-- up in docs/engine-behavior.md and pinned by "queues a write that changes only the source or
+-- context" above.
+describe("LocalizationTable behavior the targeted writes rest on", function()
+	it("SetEntryValue leaves the entry's example alone", function()
+		local localizationTable = Instance.new("LocalizationTable")
+
+		localizationTable:SetEntryValue("k.one", "One", "ctx", "en", "One")
+		localizationTable:SetEntryExample("k.one", "One", "ctx", "An example")
+		localizationTable:SetEntryValue("k.one", "One", "ctx", "fr", "Un")
+
+		local entry = TranslatorTestUtils.getEntryMap(localizationTable)["k.one"]
+		expect(entry.Example).toBe("An example")
+		expect(entry.Values["en"]).toBe("One")
+		expect(entry.Values["fr"]).toBe("Un")
+		localizationTable:Destroy()
+	end)
+
+	it("SetEntryExample leaves the entry's values alone", function()
+		local localizationTable = Instance.new("LocalizationTable")
+
+		localizationTable:SetEntryValue("k.one", "One", "ctx", "en", "One")
+		localizationTable:SetEntryValue("k.one", "One", "ctx", "fr", "Un")
+		localizationTable:SetEntryExample("k.one", "One", "ctx", "An example")
+
+		local entry = TranslatorTestUtils.getEntryMap(localizationTable)["k.one"]
+		expect(entry.Values["en"]).toBe("One")
+		expect(entry.Values["fr"]).toBe("Un")
+		expect(entry.Example).toBe("An example")
+		localizationTable:Destroy()
 	end)
 end)

--- a/src/clienttranslator/src/Shared/TranslatorService.spec.lua
+++ b/src/clienttranslator/src/Shared/TranslatorService.spec.lua
@@ -575,7 +575,8 @@ describe("TranslatorService entry merging", function()
 			service:SetEntryValue(key, key, string.format("ctx%d", index), "en", key)
 		end
 		controller.awaitEntriesWritten()
-		expect(service:GetLocalizationRebuildCount()).toBe(2)
+		-- The first flush landed its one entry as a targeted write, so this is the first rebuild.
+		expect(service:GetLocalizationRebuildCount()).toBe(1)
 
 		local entries = TranslatorTestUtils.getEntryMap(localizationTable)
 		expect(entries["external.key"].Values["en"]).toBe("External")


### PR DESCRIPTION
Displaying text caused a frame spike because every label registered its source text again as it was built, and each of those registrations rewrote the entire localization table even though nothing had changed. Registering text the table already holds is now dropped before it is queued, and a flush that does have changes picks between writing just the changed entries and rebuilding the table, based on how large the batch is relative to the table.

Translation behavior is unchanged, including reacting to a language change.