### PR TITLE
fix: Prevent more redundant localization table rebuilding

### DIFF
--- a/src/clienttranslator/docs/design.md
+++ b/src/clienttranslator/docs/design.md
@@ -84,12 +84,13 @@ invalidations, and showing one label must not rebuild the whole table.
 Pinned by "lands a later handful of keys without rebuilding the whole table" and "rebuilds rather
 than writing hundreds of entries one at a time", via `GetLocalizationRebuildCount`.
 
-The targeted route trusts each call to leave the rest of the entry alone, and source and context
-ride along only on a value write that actually changes a value — a `SetEntryValue` that rewrites the
-text a locale already holds lands nothing, new metadata included. So a batch that changes nothing
-but an entry's metadata is rebuilt rather than written. That is rare next to the value writes this
-path exists for, and the alternative is a metadata change that silently does not land. What the
-engine does and does not guarantee here is written up in
+The targeted route trusts each call to leave the rest of the entry alone, and it cannot carry source
+or context: on an entry that already exists those are arguments `SetEntryValue` matches on rather
+than fields it writes, so the entry keeps the metadata it was created with. A batch that changes any
+metadata is therefore rebuilt rather than written — rare next to the value writes this path exists
+for, and the alternative is a metadata change that silently does not land while the mirror believes
+it did. The same reason keeps `FlushEntryForKey` from moving the mirror's metadata when it lands a
+value early. What the engine does and does not guarantee here is written up in
 [`engine-behavior.md`](engine-behavior.md), pinned by "LocalizationTable behavior the targeted
 writes rest on" and "queues a write that changes only the source or context".
 

--- a/src/clienttranslator/docs/design.md
+++ b/src/clienttranslator/docs/design.md
@@ -103,6 +103,47 @@ it — per label, per frame, in the source language, where there is nothing to t
 `SetEntryValue`/`SetEntryExample` therefore drop a write the table already agrees with before it
 queues. Source and context count as part of the value: a change in either still writes.
 
+#### …but minting does not ask about context
+
+That last sentence had a sharp edge, and it cost a frame spike per line of dialog.
+
+An authored line is normally registered **twice**: once by the loader at boot, from the locale
+file, and again by `ToTranslationKey` the first time the line is shown. They agree on the key, the
+source, and the text, and they disagree on the context — the loader writes `Generated from <name>
+with key <key>`, minting writes `automatic.<key>`. So the currency check above let the write
+through, and it was a write that changed *nothing but metadata*, which no targeted call can land
+(see "Two write regimes"). Every such line therefore rebuilt the whole table on the frame it first
+reached the screen: correct output, one full re-serialization per new line of dialog, and silence
+afterwards because the mirror then agreed.
+
+So `ToTranslationKey` asks `TranslatorService:IsEntryRegistered`, which compares key, source and
+text and is **blind to context**. Nothing a player or a reader can observe depends on which of the
+two descriptions won, and the CSV export is fine with either.
+
+The context still matters where it is load-bearing — it is what keeps `SetEntries` from rejecting
+two entries as duplicates — so it is written whenever the entry is created, and a genuine
+metadata change still rebuilds. What is gone is the manufactured one. Pinned by "does not
+re-register a key a locale file already loaded".
+
+Which of the two descriptions an entry ends up carrying is decided by flush timing, and that is
+fine but worth knowing before you go looking for it in a CSV export. A key that is minted after
+its loader's batch has landed keeps the loader's context, because the mint is skipped outright. A
+key minted in the *same frame* as the load — the ordinary boot, where `Init` queues the source
+locale and the UI paints from it before the deferred flush runs — is still pending, so
+`IsEntryRegistered` refuses to conclude anything (see `_getCurrentEntry`), the mint proceeds, and
+it overwrites the queued entry's context with `automatic.<key>`. That costs no rebuild — the two
+writes merge into one pending entry that has yet to be created — and uniqueness survives either
+way, since both spellings are derived from the key. So a real table holds a mix of both, split on
+when each line first reached the screen.
+
+Minting was also carrying something it had no business carrying: the Studio pseudo-locale value,
+written as a side effect of `SetEntryValue` on that second registration. Skipping the second
+registration therefore took pseudo-localization with it for keys the loaders own — silently, and
+only in Studio, where no cloud test can see it. The parser had been attaching that value to the
+entry all along (`LocalizationEntryParserUtils`); `TableLocaleLoader` forwarded it and
+`InstanceLocaleLoader` did not. Now both do, on the source-locale pass, which is where it is
+derived from anyway. Minting backfilling it was always the accident.
+
 ### The table is mirrored
 
 Deciding any of the above means knowing what the table currently holds, and `GetEntries` copies and
@@ -273,6 +314,19 @@ everything else about the change is mechanical.
 Warning per miss floods the console with one line per key per locale swap — the cloud translator
 does not know keys registered at runtime, and a queued key is not readable yet by design. Both are
 routine, neither is a problem.
+
+"Ready" is per locale, and per locale means per fallback set. A key queued under `en` is not ready
+for a player on `en-us`, because that is the value the read would have resolved through
+(engine-behavior.md, "A regional translator resolves values stored under the bare language").
+Comparing the exact locale alone made the gate a no-op for every regional player: a boot warned
+once for each key the first frame it was painted, all of them real keys that read correctly a frame
+later.
+
+The fallback set includes the table's source locale, so the gate is now nearly as wide as
+`IsTranslationReady` — almost every queued entry carries a source-locale value. The cost is a
+genuine "this key has no French" going unwarned while anything is queued under `en` for it, which
+is the right trade here: the alternative is the flood above, and a missing translation is visible
+in the output either way. Anything that needs the strict answer should ask a translator, not this.
 
 ## Testing notes
 

--- a/src/clienttranslator/docs/engine-behavior.md
+++ b/src/clienttranslator/docs/engine-behavior.md
@@ -13,12 +13,18 @@ from these is in [`design.md`](design.md).
 Source and context are metadata; they do **not** widen an entry's identity.
 
 - `SetEntryValue(key, sourceA, contextA, ...)` then `SetEntryValue(key, sourceB, contextB, ...)`
-  leaves a **single** entry — the second call overwrites source/context in place, **provided it
-  also changes the value**. Called with the text the locale already holds it lands nothing at all,
-  source and context included: the new metadata is silently discarded. There is therefore no
-  targeted call that changes only an entry's metadata, and `TranslatorService` rebuilds the table
-  for a batch that changes nothing else. Pinned by `TranslatorService.spec.lua` ("queues a write
-  that changes only the source or context").
+  leaves a **single** entry, and it keeps `sourceA`/`contextA`. On an entry that already exists the
+  source and context are matched against, not written — the second call updates the value and
+  silently discards the new metadata, whether or not it changes a value. There is therefore **no
+  targeted call that lands metadata at all**, and `TranslatorService` rebuilds the table for any
+  batch that changes some. Pinned by `TranslatorService.spec.lua` ("SetEntryValue leaves an
+  existing entry's source and context alone", "queues a write that changes only the source or
+  context", "rewrites a key with a new source/context across flushes without duplicating it").
+
+  This was first written down as metadata landing *provided the call also changed a value*, which
+  was a guess that read plausibly and was never pinned: the spec behind it went through the rebuild
+  path. It cost a silent mirror desync — the mirror recorded metadata the table had refused — until
+  a test asserted the source after a value-changing rewrite.
 - `SetEntries` **rejects** an array holding two entries that share a key, even with differing
   source and context:
 

--- a/src/clienttranslator/docs/engine-behavior.md
+++ b/src/clienttranslator/docs/engine-behavior.md
@@ -65,6 +65,14 @@ The symptom that motivated it is real and reproducible — a frame spike each ti
 on screen, on a table holding thousands of entries — but `INVALIDATION_ENTRY_COST` (the ratio
 between the two) is a judgment call. If you profile this properly, write the numbers here.
 
+The symptom outlived the first fix in a narrower form: a spike on text the player had not seen
+before, and none on repeats. That was not the cost model being wrong, it was a metadata-only write
+manufactured per line by `ToTranslationKey`, forcing the rebuild path; see
+[`design.md`](design.md) ("…but minting does not ask about context"). Worth remembering as a
+diagnostic: `GetLocalizationRebuildCount` climbing once per newly-shown line means something is
+queueing a change that cannot be expressed as a targeted write, not that the crossover is
+mistuned.
+
 ## `Translator:FormatByKey` raises for a missing key
 
 It does not return nil, and it does not fall back to the table's source locale. The error text is:
@@ -101,6 +109,21 @@ Not `en`. Relevant because loaders key source-locale data under whatever the fol
 (usually `en`), so the table's source locale and the data's source locale are not the same string.
 `FlushEntryForKey` therefore lands the locale, the table's source locale, and the bare language
 subtag of each.
+
+## A regional translator resolves values stored under the bare language
+
+A translator for `en-us` answers keys whose entry only carries an `en` value, and reports
+`LocaleId = "en-us"` while doing it. Checked against a running game whose table stored every value
+under `en`:
+
+```lua
+tbl:GetTranslator("en-us"):FormatByKey("adventureLog.eggs") --> "Eggs"
+```
+
+This is what makes the loaders' `en`-keyed data readable for a real player at all, so anything
+reasoning about whether a key is readable **in a locale** has to reason about the same fallback
+set — a queued `en` value blocks a read for `en-us`, even though the entry has nothing queued
+under `en-us` (`IsTranslationReadyForLocale`).
 
 ## How to check any of this yourself
 

--- a/src/clienttranslator/src/Shared/JSONTranslator.TranslationReady.spec.lua
+++ b/src/clienttranslator/src/Shared/JSONTranslator.TranslationReady.spec.lua
@@ -449,6 +449,31 @@ describe("TranslatorService:IsTranslationReadyForLocale", function()
 		expect(controller.translatorService:IsTranslationReadyForLocale("never.registered", "en")).toBe(true)
 		controller:destroy()
 	end)
+
+	it("is false for a regional locale while the language value it falls back to is queued", function()
+		local controller = TranslatorTestUtils.setup()
+		controller.setForcedLocaleId("en-us")
+		local service = controller.translatorService
+
+		service:SetEntryValue("k.one", "One", "ctx", "en", "One")
+		expect(service:IsTranslationReadyForLocale("k.one", "en-us")).toBe(false)
+
+		controller.awaitEntriesWritten()
+
+		expect(service:IsTranslationReadyForLocale("k.one", "en-us")).toBe(true)
+		controller:destroy()
+	end)
+
+	it("is true while only a locale the read cannot consult is queued", function()
+		local controller = TranslatorTestUtils.setup()
+		controller.setForcedLocaleId("en-us")
+		local service = controller.translatorService
+
+		service:SetEntryValue("k.one", "One", "ctx", "fr", "Un")
+
+		expect(service:IsTranslationReadyForLocale("k.one", "en-us")).toBe(true)
+		controller:destroy()
+	end)
 end)
 
 describe("TranslatorService teardown", function()

--- a/src/clienttranslator/src/Shared/JSONTranslator.lua
+++ b/src/clienttranslator/src/Shared/JSONTranslator.lua
@@ -454,11 +454,21 @@ function JSONTranslator.ToTranslationKey(self: JSONTranslator, prefix: string, t
 	assert(type(text) == "string", "Bad text")
 
 	local translationKey = TranslationKeyUtils.getTranslationKey(prefix, text)
-	local context = string.format("automatic.%s", translationKey)
 
-	-- Registration is unconditional, and cheap when nothing changed: the service drops a write
-	-- the table already agrees with before it queues anything. This is a hot path -- every
-	-- label built through ObserveTranslation mints its key -- so it has to stay that way.
+	-- This is a hot path -- every label built through ObserveTranslation mints its key, and the
+	-- keys a game shows are new to the table one at a time as text reaches the screen -- so the
+	-- registration has to cost nothing once the key is there.
+	--
+	-- Asked ignoring context, because the context below is not the one a key loaded from a locale
+	-- file carries, and an authored line is normally both: loaded at boot and minted again when
+	-- it is first shown. Registering over it would change nothing but metadata, and a
+	-- metadata-only write cannot be landed by a targeted call -- so it rebuilt the whole table,
+	-- once per line, on the frame that line first appeared.
+	if self._translatorService:IsEntryRegistered(translationKey, text, "en", text) then
+		return translationKey
+	end
+
+	local context = string.format("automatic.%s", translationKey)
 	self:SetEntryValue(translationKey, text, context, "en", text)
 
 	return translationKey

--- a/src/clienttranslator/src/Shared/JSONTranslator.spec.lua
+++ b/src/clienttranslator/src/Shared/JSONTranslator.spec.lua
@@ -188,6 +188,47 @@ describe("JSONTranslator:ToTranslationKey", function()
 		expect(entry.Source).toBe("Play Now")
 		controller:destroy()
 	end)
+
+	it("does not re-register a key a locale file already loaded", function()
+		local controller = TranslatorTestUtils.setup()
+		local service = controller.translatorService
+		local translator = controller.newTranslator({ button = { playnow = "Play Now" } })
+
+		controller.awaitEntriesWritten()
+		local rebuildsAfterLoad = service:GetLocalizationRebuildCount()
+
+		-- An authored line is normally both loaded at boot and minted again when it is first
+		-- shown, and the two describe the same entry with different contexts. A metadata-only
+		-- write cannot be landed by a targeted call, so registering over it rebuilt the whole
+		-- table -- once per line, on the frame that line first reached the screen.
+		local key = translator:ToTranslationKey("button", "Play Now")
+
+		expect(service:IsTranslationReady(key)).toBe(true)
+		expect(service:PromiseEntriesWritten():IsPending()).toBe(false)
+
+		controller.awaitEntriesWritten()
+		expect(service:GetLocalizationRebuildCount()).toBe(rebuildsAfterLoad)
+		controller:destroy()
+	end)
+
+	it("still registers when the text behind an existing key changed", function()
+		local controller = TranslatorTestUtils.setup()
+		local service = controller.translatorService
+		local translator = controller.newTranslator({ button = { playnow = "Play Now" } })
+		controller.awaitEntriesWritten()
+
+		-- The key derivation folds whitespace, so different text can mint the same key. Skipping
+		-- registration is only safe while the source text agrees.
+		local key = translator:ToTranslationKey("button", "Play  Now")
+		expect(key).toBe("button.playnow")
+		expect(service:IsTranslationReady(key)).toBe(false)
+
+		controller.awaitEntriesWritten()
+		local entry = TranslatorTestUtils.getEntryMap(controller.getLocalizationTable())[key]
+		expect(entry.Source).toBe("Play  Now")
+		expect(entry.Values["en"]).toBe("Play  Now")
+		controller:destroy()
+	end)
 end)
 
 describe("JSONTranslator:GetLocalizationTable / GetLocaleId", function()

--- a/src/clienttranslator/src/Shared/Loaders/InstanceLocaleLoader.lua
+++ b/src/clienttranslator/src/Shared/Loaders/InstanceLocaleLoader.lua
@@ -14,6 +14,7 @@
 local require = require(script.Parent.loader).load(script)
 
 local LocalizationEntryParserUtils = require("LocalizationEntryParserUtils")
+local PseudoLocalize = require("PseudoLocalize")
 local ResolveLocaleUtils = require("ResolveLocaleUtils")
 local ServiceBag = require("ServiceBag")
 local TranslatorService = require("TranslatorService")
@@ -129,14 +130,28 @@ function InstanceLocaleLoader._loadFile(self: InstanceLocaleLoader, fileLocale: 
 		self._lookupTable
 	)
 
+	local pseudoLocaleId = PseudoLocalize.getDefaultPseudoLocaleId()
+
 	for _, item in entries do
 		local text = item.Values[fileLocale]
 		if text ~= nil then
 			self._translatorService:SetEntryValue(item.Key, item.Source, item.Context, fileLocale, text)
 		end
-		-- The example only comes from the source locale.
+
+		-- The example and the pseudo-localized value both come from the source locale only --
+		-- the parser derives the latter from the source text, in Studio, and no other file's
+		-- decode produces one.
 		if fileLocale == self._sourceLocaleId then
 			self._translatorService:SetEntryExample(item.Key, item.Source, item.Context, item.Example)
+
+			-- Queued here because nothing else does it: a key a locale file already registered
+			-- is not re-registered by [JSONTranslator.ToTranslationKey] when it first appears on
+			-- screen, so the pseudo value it used to backfill would never reach the table and
+			-- the forced pseudo locale would fall back to the source language in Studio.
+			local pseudoText = item.Values[pseudoLocaleId]
+			if pseudoText ~= nil then
+				self._translatorService:SetEntryValue(item.Key, item.Source, item.Context, pseudoLocaleId, pseudoText)
+			end
 		end
 	end
 end

--- a/src/clienttranslator/src/Shared/Loaders/InstanceLocaleLoader.spec.lua
+++ b/src/clienttranslator/src/Shared/Loaders/InstanceLocaleLoader.spec.lua
@@ -12,6 +12,7 @@ local require = require(script.Parent.loader).load(script)
 local InstanceLocaleLoader = require("InstanceLocaleLoader")
 local Jest = require("Jest")
 local LocaleLoaderTestUtils = require("LocaleLoaderTestUtils")
+local LocalizationEntryParserUtils = require("LocalizationEntryParserUtils")
 
 local describe = Jest.Globals.describe
 local expect = Jest.Globals.expect
@@ -33,6 +34,23 @@ describe("InstanceLocaleLoader.LoadSourceLocale", function()
 		expect(entry.Values["fr"]).toBeNil()
 		-- The source locale carries the example.
 		expect(entry.Example).toBe("Hello")
+
+		controller:destroy()
+	end)
+
+	it("writes every value the source decode produced, including the Studio pseudo locale", function()
+		local controller = LocaleLoaderTestUtils.setup()
+		local loader, folder =
+			controller.newInstanceLoader({ en = { greeting = "Hello" }, fr = { greeting = "Bonjour" } })
+
+		loader:LoadSourceLocale()
+		controller.flush()
+
+		-- Decoded again rather than hardcoded, because the parser attaches a pseudo-localized
+		-- value only in Studio: the invariant is that the loader forwards whatever the decode
+		-- produced, which holds in both environments. Nothing else queues that value.
+		local decoded = LocalizationEntryParserUtils.decodeLocaleFromInstance("T", "en", "en", folder, {})[1]
+		expect(controller.getEntryMap()["greeting"].Values).toEqual(decoded.Values)
 
 		controller:destroy()
 	end)

--- a/src/clienttranslator/src/Shared/TranslatorService.lua
+++ b/src/clienttranslator/src/Shared/TranslatorService.lua
@@ -323,6 +323,66 @@ function TranslatorService._getEntryCache(_self: TranslatorService, localization
 end
 
 --[=[
+	Whether the table already carries this key with this source text, whatever context it was
+	registered under.
+
+	This is the question [JSONTranslator.ToTranslationKey] asks before registering, and it is
+	deliberately blind to context: a key loaded from a locale file and the same key minted at
+	runtime describe themselves differently ("Generated from X with key Y" vs "automatic.Y")
+	while meaning the same thing. Rewriting the context changes nothing a reader can observe,
+	and there is no targeted call that lands metadata on its own -- so it would cost a full
+	table rebuild (see [TranslatorService._mergePendingEntries]) for every authored line the
+	first time it appeared on screen.
+
+	Takes the same arguments as [TranslatorService.SetEntryValue] minus the context it ignores,
+	and in the same order. Worth keeping that way: at the only call site the source and the text
+	are the same string, so a transposition would type-check, pass these asserts, and read
+	correctly.
+
+	@param translationKey string
+	@param source string
+	@param localeId string
+	@param text string
+	@return boolean
+]=]
+function TranslatorService.IsEntryRegistered(
+	self: TranslatorService,
+	translationKey: string,
+	source: string,
+	localeId: string,
+	text: string
+): boolean
+	assert(type(translationKey) == "string", "Bad translationKey")
+	assert(type(source) == "string", "Bad source")
+	assert(type(localeId) == "string", "Bad localeId")
+	assert(type(text) == "string", "Bad text")
+
+	local entry = self:_getCurrentEntry(translationKey)
+	if not entry then
+		return false
+	end
+
+	return entry.Source == source and entry.Values[localeId] == text
+end
+
+--[=[
+	The entry the table currently holds for a key, or nil when it holds none -- or when the key
+	has a delta queued, which makes it mid-change: the flush decides what the table ends up
+	with, so nothing may be concluded from what is there now.
+
+	@param translationKey string
+	@return LocalizationEntry?
+	@private
+]=]
+function TranslatorService._getCurrentEntry(self: TranslatorService, translationKey: string): LocalizationEntry?
+	if self._pendingEntries[translationKey] then
+		return nil
+	end
+
+	return self:_getEntryCache(self:GetLocalizationTable()).ByKey[translationKey]
+end
+
+--[=[
 	Whether the table already holds exactly this value, making the write nothing but cost.
 
 	Re-registering unchanged text is the common case rather than the exception: minting a
@@ -347,12 +407,7 @@ function TranslatorService._isEntryValueCurrent(
 	localeId: string,
 	text: string
 ): boolean
-	-- A key with a delta queued is mid-change; the flush decides what the table ends up with.
-	if self._pendingEntries[translationKey] then
-		return false
-	end
-
-	local entry = self:_getEntryCache(self:GetLocalizationTable()).ByKey[translationKey]
+	local entry = self:_getCurrentEntry(translationKey)
 	if not entry then
 		return false
 	end
@@ -379,11 +434,7 @@ function TranslatorService._isEntryExampleCurrent(
 	context: string,
 	example: string
 ): boolean
-	if self._pendingEntries[translationKey] then
-		return false
-	end
-
-	local entry = self:_getEntryCache(self:GetLocalizationTable()).ByKey[translationKey]
+	local entry = self:_getCurrentEntry(translationKey)
 	if not entry then
 		return false
 	end
@@ -433,7 +484,11 @@ end
 
 --[=[
 	Whether a read of this key **in this locale** would see everything queued for it. Narrower
-	than [TranslatorService.IsTranslationReady], which is false while any locale is queued.
+	than [TranslatorService.IsTranslationReady], which is false while any locale is queued --
+	though only barely, in practice. The fallback set below includes the table's source locale,
+	and nearly every queued entry carries a source-locale value (the loaders write the source
+	file first, minting writes `en`), so the two answers differ only for an entry queued
+	*exclusively* in a locale this one cannot read through.
 
 	:::warning
 	This is an implementation detail of the translation stack, exposed for diagnostics.
@@ -443,6 +498,12 @@ end
 	which lands the locales a read can consult but leaves the entry queued for the rest. The
 	key is readable in that locale while still not ready overall, so a failure to translate it
 	is a real failure and worth reporting.
+
+	Readable means readable the way a translator reads: every locale a read of this locale may
+	fall back through has to have landed, not just the exact locale asked about. Loaders key
+	their data under the language ("en"), while a player's locale is normally a regional variant
+	("en-us"), so asking about the regional locale alone would call every queued key ready --
+	its pending values are under the language it would fall back to.
 
 	@param translationKey string
 	@param localeId string
@@ -461,7 +522,42 @@ function TranslatorService.IsTranslationReadyForLocale(
 		return true
 	end
 
-	return entry.Values[localeId] == nil
+	for _, readLocale in self:_getReadLocales(localeId) do
+		if entry.Values[readLocale] ~= nil then
+			return false
+		end
+	end
+
+	return true
+end
+
+-- Appends a locale to the read set, skipping the ones already in it.
+local function insertReadLocale(readLocales: { string }, localeId: string?)
+	if localeId ~= nil and not table.find(readLocales, localeId) then
+		table.insert(readLocales, localeId)
+	end
+end
+
+--[=[
+	The locales a read for this locale may consult, without repeats: the locale itself and the
+	table's source locale, each plus its bare language subtag, since the Roblox translator falls
+	a regional locale back to its language (e.g. en-us -> en, and the loaders key the source
+	under "en").
+
+	@param localeId string
+	@return { string }
+	@private
+]=]
+function TranslatorService._getReadLocales(self: TranslatorService, localeId: string): { string }
+	local sourceLocaleId = self:GetLocalizationTable().SourceLocaleId
+
+	local readLocales: { string } = {}
+	insertReadLocale(readLocales, localeId)
+	insertReadLocale(readLocales, sourceLocaleId)
+	insertReadLocale(readLocales, ResolveLocaleUtils.getLanguageSubtag(localeId))
+	insertReadLocale(readLocales, ResolveLocaleUtils.getLanguageSubtag(sourceLocaleId))
+
+	return readLocales
 end
 
 --[=[
@@ -592,24 +688,13 @@ function TranslatorService.FlushEntryForKey(self: TranslatorService, translation
 
 	local localizationTable = self:GetLocalizationTable()
 
-	-- The locales a synchronous read may consult: the current locale and the table's source
-	-- locale, each plus its bare language subtag, since the Roblox translator falls a
-	-- regional locale back to its language (e.g. en-us -> en, and the loaders key the source
-	-- under "en"). Landing just these avoids writing every locale in the entry.
-	local localeId = self:GetLocaleId()
-	local sourceLocaleId = localizationTable.SourceLocaleId
-	local readLocales = { localeId, sourceLocaleId }
-	local localeSubtag = ResolveLocaleUtils.getLanguageSubtag(localeId)
-	if localeSubtag then
-		table.insert(readLocales, localeSubtag)
-	end
-	local sourceSubtag = ResolveLocaleUtils.getLanguageSubtag(sourceLocaleId)
-	if sourceSubtag then
-		table.insert(readLocales, sourceSubtag)
-	end
+	-- Landing only the locales a synchronous read may consult avoids writing every locale in
+	-- the entry.
+	local readLocales = self:_getReadLocales(self:GetLocaleId())
 
-	-- Land each read locale for this key's pending entry. A landed locale is dequeued, so a
-	-- repeated read locale (e.g. localeId already its own subtag) just no-ops the second time.
+	-- Land each read locale for this key's pending entry. A landed locale is dequeued, and the
+	-- read set carries no repeats, so this is at most one write per distinct locale a read of
+	-- this key could resolve through.
 	for _, readLocale in readLocales do
 		self:_landEntryLocale(localizationTable, entry, readLocale)
 	end

--- a/src/clienttranslator/src/Shared/TranslatorService.lua
+++ b/src/clienttranslator/src/Shared/TranslatorService.lua
@@ -738,8 +738,14 @@ function TranslatorService._landEntryLocale(
 
 	local cached: LocalizationEntry
 	if existing then
+		-- The mirror keeps the metadata it has, because the table does: the source and context
+		-- below are matched against an existing entry rather than written to it
+		-- (engine-behavior.md). Moving them here would put the mirror out of step with the table
+		-- and, worse, hide the change from the flush -- which rebuilds for it, and is the only
+		-- thing that can land it.
 		cached = existing
 	else
+		-- A new entry is created by the write below, carrying this metadata.
 		cached = {
 			Key = entry.Key,
 			Source = entry.Source,
@@ -751,8 +757,6 @@ function TranslatorService._landEntryLocale(
 		table.insert(cache.List, cached)
 	end
 
-	cached.Source = entry.Source
-	cached.Context = entry.Context
 	cached.Values[localeId] = text
 
 	localizationTable:SetEntryValue(entry.Key, entry.Source, entry.Context, localeId, text)
@@ -1004,23 +1008,20 @@ function TranslatorService._mergePendingEntries(
 		entry.Source = delta.Source
 		entry.Context = delta.Context
 
-		local valueWritten = false
 		for localeId, text in delta.Values do
 			if entry.Values[localeId] ~= text then
 				entry.Values[localeId] = text
 				table.insert(writes, { Entry = entry, LocaleId = localeId })
-				valueWritten = true
 			end
 		end
 
-		-- Source and context ride along on the value write that changes the entry, and there is
-		-- no targeted call that lands them on their own: SetEntryValue updates them only when
-		-- it actually changes a value, and rewriting a locale with the text it already holds is
-		-- a no-op the metadata does not survive (engine-behavior.md). So a batch that changes
-		-- nothing but metadata is rebuilt rather than written -- rare next to the value writes
-		-- this path exists for, and the alternative is a metadata change that silently does not
-		-- land.
-		if metadataChanged and not valueWritten then
+		-- No targeted call lands source or context on an entry that already exists: they are
+		-- arguments SetEntryValue matches on, not fields it writes, so the entry keeps the
+		-- metadata it was created with whether or not the call also changes a value
+		-- (engine-behavior.md). So any batch that changes metadata is rebuilt rather than
+		-- written -- rare next to the value writes this path exists for, and the alternative is
+		-- a metadata change that silently does not land while the mirror believes it did.
+		if metadataChanged then
 			bulkRequired = true
 		end
 

--- a/src/clienttranslator/src/Shared/TranslatorService.spec.lua
+++ b/src/clienttranslator/src/Shared/TranslatorService.spec.lua
@@ -555,7 +555,13 @@ describe("TranslatorService entry merging", function()
 			end
 		end
 		expect(matching).toBe(1)
-		expect(TranslatorTestUtils.getEntryMap(service:GetLocalizationTable())["k.one"].Values["en"]).toBe("Uno")
+
+		-- The new metadata has to land with the value. A targeted write would have kept the old
+		-- source and context (see "SetEntryValue leaves an existing entry's source and context
+		-- alone") while the mirror recorded the new ones, so this batch takes the rebuild.
+		local entry = TranslatorTestUtils.getEntryMap(service:GetLocalizationTable())["k.one"]
+		expect(entry.Values["en"]).toBe("Uno")
+		expect(entry.Context).toBe("ctx-b")
 		controller:destroy()
 	end)
 
@@ -630,6 +636,25 @@ describe("LocalizationTable behavior the targeted writes rest on", function()
 		expect(entry.Example).toBe("An example")
 		expect(entry.Values["en"]).toBe("One")
 		expect(entry.Values["fr"]).toBe("Un")
+		localizationTable:Destroy()
+	end)
+
+	it("SetEntryValue leaves an existing entry's source and context alone", function()
+		local localizationTable = Instance.new("LocalizationTable")
+
+		localizationTable:SetEntryValue("k.one", "One", "ctx-a", "en", "One")
+
+		-- Even though this call does change the value: on an entry that already exists the
+		-- source and context are matched against, not written. So there is no targeted call that
+		-- lands metadata at all, and a batch that changes any has to go through SetEntries --
+		-- see the merge in TranslatorService._mergePendingEntries.
+		localizationTable:SetEntryValue("k.one", "Uno", "ctx-b", "en", "Uno")
+
+		local entries = localizationTable:GetEntries()
+		expect(#entries).toBe(1)
+		expect(entries[1].Source).toBe("One")
+		expect(entries[1].Context).toBe("ctx-a")
+		expect(entries[1].Values["en"]).toBe("Uno")
 		localizationTable:Destroy()
 	end)
 

--- a/src/clienttranslator/src/Shared/TranslatorService.spec.lua
+++ b/src/clienttranslator/src/Shared/TranslatorService.spec.lua
@@ -315,6 +315,28 @@ describe("TranslatorService localization write cost", function()
 		controller:destroy()
 	end)
 
+	it("reports an entry registered whatever context it was registered under", function()
+		local controller = TranslatorTestUtils.setup()
+		local service = controller.translatorService
+
+		expect(service:IsEntryRegistered("k.one", "One", "en", "One")).toBe(false)
+
+		service:SetEntryValue("k.one", "One", "c1", "en", "One")
+		-- Mid-change: what the table holds now says nothing about what the flush will leave.
+		expect(service:IsEntryRegistered("k.one", "One", "en", "One")).toBe(false)
+		controller.awaitEntriesWritten()
+
+		-- Registered under "c1", and there is no context to ask about: a caller minting a key it
+		-- would describe differently is asking whether the entry is there, not whose it is.
+		expect(service:IsEntryRegistered("k.one", "One", "en", "One")).toBe(true)
+
+		-- Source and text still count. Both are what a reader sees.
+		expect(service:IsEntryRegistered("k.one", "Uno", "en", "One")).toBe(false)
+		expect(service:IsEntryRegistered("k.one", "One", "en", "Uno")).toBe(false)
+		expect(service:IsEntryRegistered("k.one", "One", "fr", "One")).toBe(false)
+		controller:destroy()
+	end)
+
 	it("writes when a queued entry changes an existing value", function()
 		local controller = TranslatorTestUtils.setup()
 		local service = controller.translatorService


### PR DESCRIPTION
This attempt targets rebuilding that occurs whenever any piece of text is seen for the first time.

The last fix dropped registrations the table already agreed with, but it counted context as part of the value, and an authored line is registered twice with two different contexts: once by the loader from the locale file, and again by `ToTranslationKey` when the line is first shown. So the second registration still went through, and because it changed nothing but metadata it could not be landed as a targeted write, which meant a full table rebuild for each new piece of text.