### PR TITLE
fix(gameproductservice): verify gamepass ownership before granting a client-reported purchase

### DIFF
--- a/src/gameproductservice/src/Server/GameProductService.spec.lua
+++ b/src/gameproductservice/src/Server/GameProductService.spec.lua
@@ -286,7 +286,7 @@ describe("GameProductServiceClient ownership for the designated mock", function(
 end)
 
 describe("client-initiated gamepass prompt", function()
-	it("resolves true on accept, replicates to the server, and fires both realms' purchase signals", function()
+	it("grants server ownership once the marketplace confirms the client's purchase", function()
 		local controller = setup()
 		PlayerMock.writeLookup(controller.playerMock, "MarketplaceService.PromptGamePassPurchase", GAME_PASS_ID, true)
 
@@ -295,8 +295,18 @@ describe("client-initiated gamepass prompt", function()
 		controller.gameProductService.GamePassPurchased:Connect(function(player, gamePassId)
 			table.insert(serverFired, { player = player, gamePassId = gamePassId })
 		end)
+		-- The pass is not owned when the prompt opens, so the client genuinely prompts. Model the
+		-- purchase going through by marking the marketplace as owning it the instant the client reports
+		-- success -- the same false-before / true-after transition a real purchase produces, and what
+		-- the server's verification then reads.
 		controller.gameProductServiceClient.GamePassPurchased:Connect(function(gamePassId)
 			table.insert(clientFired, gamePassId)
+			PlayerMock.writeLookup(
+				controller.playerMock,
+				"MarketplaceService.UserOwnsGamePassAsync",
+				GAME_PASS_ID,
+				true
+			)
 		end)
 
 		expect(
@@ -333,6 +343,53 @@ describe("client-initiated gamepass prompt", function()
 				)
 			)
 		).toEqual(true)
+
+		controller:destroy()
+	end)
+
+	it("does not grant server ownership for a purchase the marketplace never confirms", function()
+		local controller = setup()
+		-- The client reports the prompt succeeded, but the marketplace never shows the player owning the
+		-- pass (UserOwnsGamePassAsync stays at its false default). A client saying "I bought it" is an
+		-- unverified claim -- on its own it must grant nothing, or any client could fire this remote for
+		-- any gamepass id and be handed the pass for free.
+		PlayerMock.writeLookup(controller.playerMock, "MarketplaceService.PromptGamePassPurchase", GAME_PASS_ID, true)
+
+		local serverFired = {}
+		controller.gameProductService.GamePassPurchased:Connect(function(player, gamePassId)
+			table.insert(serverFired, { player = player, gamePassId = gamePassId })
+		end)
+
+		-- The client still resolves its own prompt as accepted: its local UX is not the trust boundary.
+		expect(
+			controller.awaitBool(
+				controller.gameProductServiceClient:PromisePromptPurchase(
+					controller.playerMock,
+					GameConfigAssetTypes.PASS,
+					GAME_PASS_ID
+				)
+			)
+		).toEqual(true)
+
+		-- The server rejects the unverified claim: no ownership, no session purchase, no purchase signal.
+		-- Awaiting the ownership query also lets the server's verification settle first.
+		expect(
+			controller.awaitBool(
+				controller.gameProductService:PromisePlayerOwnership(
+					controller.playerMock,
+					GameConfigAssetTypes.PASS,
+					GAME_PASS_ID
+				)
+			)
+		).toEqual(false)
+		expect(#serverFired).toEqual(0)
+		expect(
+			controller.gameProductService:HasPlayerPurchasedThisSession(
+				controller.playerMock,
+				GameConfigAssetTypes.PASS,
+				GAME_PASS_ID
+			)
+		).toEqual(false)
 
 		controller:destroy()
 	end)

--- a/src/gameproductservice/src/Server/Manager/PlayerProductManager.lua
+++ b/src/gameproductservice/src/Server/Manager/PlayerProductManager.lua
@@ -14,7 +14,9 @@ local Players = game:GetService("Players")
 local EnumUtils = require("EnumUtils")
 local GameConfigAssetTypes = require("GameConfigAssetTypes")
 local GameProductDataService = require("GameProductDataService")
+local MarketplaceUtils = require("MarketplaceUtils")
 local PlayerBinder = require("PlayerBinder")
+local PlayerMock = require("PlayerMock")
 local PlayerProductManagerBase = require("PlayerProductManagerBase")
 local PlayerProductManagerInterface = require("PlayerProductManagerInterface")
 local ReceiptProcessingService = require("ReceiptProcessingService")
@@ -136,9 +138,37 @@ function PlayerProductManager._setupPassTracker(self: PlayerProductManager): ()
 		assert(type(gamePassId) == "number", "Bad gamePassId")
 		assert(type(isPurchased) == "boolean", "Bad isPurchased")
 
-		-- TODO: Validate in purchased scenario
+		-- Closing the prompt is safe to take on the client's word: it only unblocks pending prompt
+		-- state and grants nothing.
 		tracker:HandlePromptClosedEvent(gamePassId)
-		tracker:HandlePurchaseEvent(gamePassId, isPurchased)
+
+		if not isPurchased then
+			tracker:HandlePurchaseEvent(gamePassId, false)
+			return
+		end
+
+		-- The purchase itself is not. This event is fired by the client, so `isPurchased == true` is an
+		-- unverified claim -- a client can fire it for any gamepass id without ever paying, and granting
+		-- ownership on it hands the pass out for free. Confirm against the marketplace before it counts,
+		-- so only a pass the player genuinely owns is recorded as purchased.
+		local userId = if PlayerMock.isMock(self._obj) then PlayerMock.read(self._obj, "UserId") else self._obj.UserId
+
+		self._maid:GivePromise(MarketplaceUtils.promiseUserOwnsGamePass(userId, gamePassId)):Then(function(ownsPass)
+			tracker:HandlePurchaseEvent(gamePassId, ownsPass == true)
+		end, function(err)
+			-- The ownership check could not answer (a marketplace hiccup, not a purchase). Grant nothing
+			-- on the failure, and resolve the pending prompt as unbought so a server-initiated caller is
+			-- not left waiting forever.
+			warn(
+				string.format(
+					"[PlayerProductManager] - Failed to verify gamepass %d ownership for %s: %s",
+					gamePassId,
+					tostring(self._obj),
+					tostring(err)
+				)
+			)
+			tracker:HandlePurchaseEvent(gamePassId, false)
+		end)
 	end))
 end
 


### PR DESCRIPTION
The server trusted the client-fired PromptGamePassPurchaseFinished remote, so firing it with isPurchased = true for any gamepass id granted ownership without the player ever paying (the standing "TODO: Validate in purchased scenario"). The pass purchase is now confirmed server-side with MarketplaceService.UserOwnsGamePassAsync before it is recorded, so an unverified or unconfirmed claim grants nothing, and a marketplace error grants nothing rather than trusting the client. Adds dual-realm spec coverage for both the confirmed-purchase and unconfirmed-claim paths.