### PR TITLE
fix(nevermore-cli): stop failing a batch run whose tests all passed

### DIFF
--- a/tools/nevermore-cli/src/utils/open-cloud/open-cloud-client.ts
+++ b/tools/nevermore-cli/src/utils/open-cloud/open-cloud-client.ts
@@ -342,8 +342,10 @@ export class OpenCloudClient {
 
   private async _fetchRawLogsAsync(taskPath: string): Promise<string> {
     const apiKey = await this._resolveApiKeyAsync();
+    // Arrival order, deliberately. Do not sort by createTime: every print in a
+    // single frame shares one value, so it cannot order them anyway, and the
+    // fractional digit count varies, so comparing the strings reorders them.
     const messages: string[] = [];
-    const structured: { message: string; createTime: string }[] = [];
     let pageToken: string | undefined;
     let pagesFetched = 0;
     let entriesFetched = 0;
@@ -381,14 +383,7 @@ export class OpenCloudClient {
 
       for (const entry of data.luauExecutionSessionTaskLogs ?? []) {
         if (entry.structuredMessages?.length) {
-          // Keep createTime alongside the text: the API does not guarantee
-          // chronological order, and readers downstream assume it.
-          for (const msg of entry.structuredMessages) {
-            structured.push({
-              message: msg.message,
-              createTime: msg.createTime,
-            });
-          }
+          messages.push(...entry.structuredMessages.map((msg) => msg.message));
         } else if (entry.messages?.length) {
           messages.push(...entry.messages);
         }
@@ -398,12 +393,6 @@ export class OpenCloudClient {
       pagesFetched++;
       pageToken = data.nextPageToken || undefined;
     } while (pageToken);
-
-    // Out-of-order messages silently destroy marker-delimited parsing: a
-    // trailing summary that arrives early ends the scan before any of the
-    // output it summarizes has been read.
-    structured.sort((a, b) => a.createTime.localeCompare(b.createTime));
-    messages.push(...structured.map((m) => m.message));
 
     const text = messages.join('\n');
 

--- a/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.test.ts
+++ b/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.test.ts
@@ -99,6 +99,42 @@ describe('parseBatchTestLogs', () => {
     expect(result?.logs).toContain('PlayerBadgeHelper');
   });
 
+  it('closes a section whose END was delivered after the summary', () => {
+    const logs = [
+      '===BATCH_TEST_BEGIN egghunt2026===',
+      'Tests:  1014 passed, 1077 total',
+      '===BATCH_TEST_SUMMARY===',
+      '[{"slug":"egghunt2026","success":true,"durationMs":110467}]',
+      '===BATCH_TEST_END egghunt2026 PASS 110467===',
+    ].join('\n');
+
+    const result = parseBatchTestLogs(logs, SLUG_MAP).get('egghunt2026');
+
+    expect(result?.success).toBe(true);
+    expect(result?.error).toBeUndefined();
+    expect(result?.testCounts).toEqual({
+      passed: 1014,
+      failed: 0,
+      total: 1077,
+    });
+  });
+
+  it('keeps the summary payload out of the section it interrupts', () => {
+    const logs = [
+      '===BATCH_TEST_BEGIN egghunt2026===',
+      'Tests:  10 passed, 10 total',
+      '===BATCH_TEST_SUMMARY===',
+      '[{"slug":"egghunt2026","success":true},' +
+        '{"slug":"other","success":false,"error":"boom"}]',
+      '===BATCH_TEST_END egghunt2026 PASS 10===',
+    ].join('\n');
+
+    const result = parseBatchTestLogs(logs, SLUG_MAP).get('egghunt2026');
+
+    expect(result?.logs).not.toContain('boom');
+    expect(result?.success).toBe(true);
+  });
+
   it('counts tracebacks that jest reports as a clean pass', () => {
     const logs = buildLogs(
       [

--- a/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.ts
+++ b/tools/nevermore-cli/src/utils/testing/parsers/batch-log-parser.ts
@@ -70,6 +70,8 @@ export function parseBatchTestLogs(
   let currentSlug: string | null = null;
   let currentLines: string[] = [];
   let summaryLineIndex = -1;
+  /** True between the summary marker and its JSON payload. */
+  let summaryPayloadPending = false;
   let beginMarkersSeen = 0;
   let endMarkersSeen = 0;
   let strayEndMarkers = 0;
@@ -130,8 +132,19 @@ export function parseBatchTestLogs(
     }
 
     if (trimmed === SUMMARY_MARKER) {
-      summaryLineIndex = i;
-      break;
+      // Keep scanning: the summary prints last but is not always delivered last,
+      // and a section's END can follow it.
+      if (summaryLineIndex < 0) {
+        summaryLineIndex = i;
+      }
+      summaryPayloadPending = true;
+      continue;
+    }
+
+    // The summary's JSON payload belongs to no section.
+    if (summaryPayloadPending && trimmed.trimStart().startsWith('[')) {
+      summaryPayloadPending = false;
+      continue;
     }
 
     // Accumulate unconditionally: output that precedes the first surviving
@@ -209,7 +222,7 @@ export function parseBatchTestLogs(
     OutputHelper.warn(
       summaryLineIndex >= lines.length - 2
         ? '[batch-log-parser] Summary sits at the end of the log — consistent with the head being dropped by a log size/retention limit.'
-        : '[batch-log-parser] Summary sits early in the log — consistent with out-of-order messages ending the scan prematurely.'
+        : '[batch-log-parser] Summary sits early in the log — consistent with messages delivered out of order.'
     );
   }
 


### PR DESCRIPTION
A cloud batch run whose tests all passed could be reported as FAILED with "no output could be attributed to this package". The log scan stopped at the summary marker, so a section whose END arrived after the summary was thrown away, and the sort that put the END there compared timestamps as strings even though the API emits a variable number of fractional digits. The scan now continues past the summary, and the sort is removed rather than fixed, since probes show messages already arrive in order and a whole frame of prints shares one timestamp anyway.