### PR TITLE
feat(humanoidutils): observe whether a humanoid can jump

### DIFF
--- a/.claude/hooks/luau-lint-before-push.mjs
+++ b/.claude/hooks/luau-lint-before-push.mjs
@@ -14,6 +14,54 @@
 //   2  -> lint failed -> block the push and hand the errors back to Claude
 
 import { spawnSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+// A path argument, quoted or bare.
+const PATH_ARG = `"[^"]+"|'[^']+'|\\S+`;
+// Global options that may sit between `git` and the `push` subcommand, so
+// `git -C <dir> push` is recognized as a push and not waved through unchecked.
+const GIT_OPTS = `(?:-C\\s+(?:${PATH_ARG})\\s+|-c\\s+\\S+\\s+|--\\S+\\s+)*`;
+// `git push` in command position only -- at the start of the line or right
+// after a shell separator (; && || | ( { newline). This avoids firing on
+// commands that merely mention the string (echo, grep, comments, etc.).
+const pushRe = () => new RegExp(`(?:^|[\\n;&|({])\\s*git\\s+${GIT_OPTS}push\\b`);
+
+// Pull the directory the push actually targets out of the command: either a
+// `cd <dir>` earlier in the chain or `git -C <dir> push`. Falls back to the
+// payload cwd when there is none, or when the parsed path is not a directory.
+function resolvePushCwd(command, fallbackCwd) {
+  const unquote = (value) => value.replace(/^["']|["']$/g, "");
+
+  // `git -C <dir> push` wins -- it is the directory git itself will use.
+  const dashC = new RegExp(
+    `(?:^|[\\n;&|({])\\s*git\\s+${GIT_OPTS}-C\\s+(${PATH_ARG})\\s+${GIT_OPTS}push\\b`,
+  ).exec(command);
+  // Otherwise take the last `cd <dir>` that precedes the push.
+  const cd = /(?:^|[\n;&|({])\s*cd\s+("[^"]+"|'[^']+'|[^\n;&|]+?)\s*(?:&&|;|\|\||\n)/g;
+
+  let candidate;
+  if (dashC) {
+    candidate = unquote(dashC[1]);
+  } else {
+    const pushIndex = command.search(pushRe());
+    for (let match = cd.exec(command); match; match = cd.exec(command)) {
+      if (match.index < pushIndex) {
+        candidate = unquote(match[1].trim());
+      }
+    }
+  }
+
+  if (!candidate) {
+    return fallbackCwd;
+  }
+
+  const resolved = isAbsolute(candidate) ? candidate : resolve(fallbackCwd, candidate);
+  if (existsSync(resolved) && statSync(resolved).isDirectory()) {
+    return resolved;
+  }
+  return fallbackCwd;
+}
 
 let raw = "";
 process.stdin.setEncoding("utf8");
@@ -27,15 +75,16 @@ process.stdin.on("end", () => {
   }
 
   const command = payload?.tool_input?.command ?? "";
-  // Match `git push` only in command position -- at the start of the line or
-  // right after a shell separator (; && || | ( { newline). This avoids firing
-  // on commands that merely mention the string (echo, grep, comments, etc.).
-  if (!/(?:^|[\n;&|({])\s*git\s+push\b/.test(command)) {
+  if (!pushRe().test(command)) {
     process.exit(0); // not an actual git push invocation
   }
 
-  const cwd = payload.cwd || process.cwd();
-  process.stderr.write("pre-push: running luau type check (npm run lint:luau)...\n");
+  // Lint the tree that is actually being pushed. Pushes from a linked worktree
+  // are issued as `cd <worktree> && git push ...`, but the payload cwd is always
+  // the session's primary worktree -- linting that one would check the wrong
+  // branch entirely.
+  const cwd = resolvePushCwd(command, payload.cwd || process.cwd());
+  process.stderr.write(`pre-push: running luau type check (npm run lint:luau) in ${cwd}...\n`);
 
   const res = spawnSync("npm run lint:luau", {
     cwd,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2740,15 +2740,24 @@ importers:
 
   src/humanoidutils:
     dependencies:
+      '@quenty/instanceutils':
+        specifier: workspace:*
+        version: link:../instanceutils
       '@quenty/loader':
         specifier: workspace:*
         version: link:../loader
       '@quenty/maid':
         specifier: workspace:*
         version: link:../maid
+      '@quenty/nevermore-test-runner':
+        specifier: workspace:*
+        version: link:../nevermore-test-runner
       '@quenty/rx':
         specifier: workspace:*
         version: link:../rx
+      '@quentystudios/jest-lua':
+        specifier: 3.10.0-quenty.2
+        version: 3.10.0-quenty.2
 
   src/idleservice:
     dependencies:

--- a/src/humanoidutils/deploy.nevermore.json
+++ b/src/humanoidutils/deploy.nevermore.json
@@ -1,0 +1,10 @@
+{
+  "targets": {
+    "test": {
+      "universeId": 9716264427,
+      "placeId": 93472718408573,
+      "project": "test/default.project.json",
+      "scriptTemplate": "test/scripts/Server/ServerMain.server.lua"
+    }
+  }
+}

--- a/src/humanoidutils/package.json
+++ b/src/humanoidutils/package.json
@@ -31,8 +31,11 @@
     "access": "public"
   },
   "dependencies": {
+    "@quenty/instanceutils": "workspace:*",
     "@quenty/loader": "workspace:*",
     "@quenty/maid": "workspace:*",
-    "@quenty/rx": "workspace:*"
+    "@quenty/nevermore-test-runner": "workspace:*",
+    "@quenty/rx": "workspace:*",
+    "@quentystudios/jest-lua": "3.10.0-quenty.2"
   }
 }

--- a/src/humanoidutils/src/Shared/HumanoidUtils.lua
+++ b/src/humanoidutils/src/Shared/HumanoidUtils.lua
@@ -27,6 +27,42 @@ function HumanoidUtils.getHumanoid(descendant: Instance): Humanoid?
 end
 
 --[=[
+	Returns whether a humanoid state type is enabled on the humanoid.
+
+	@param humanoid Humanoid
+	@param stateType Enum.HumanoidStateType
+	@return boolean
+]=]
+function HumanoidUtils.isHumanoidStateEnabled(humanoid: Humanoid, stateType: Enum.HumanoidStateType): boolean
+	assert(typeof(humanoid) == "Instance" and humanoid:IsA("Humanoid"), "No humanoid")
+	assert(typeof(stateType) == "EnumItem", "No stateType")
+
+	return humanoid:GetStateEnabled(stateType)
+end
+
+--[=[
+	Returns whether the humanoid is allowed to jump. This is true when the jumping state is enabled
+	and the humanoid's jump strength is above zero, which is the strength Roblox reads for the
+	humanoid's [Humanoid.UseJumpPower] mode.
+
+	@param humanoid Humanoid
+	@return boolean
+]=]
+function HumanoidUtils.isJumpEnabled(humanoid: Humanoid): boolean
+	assert(typeof(humanoid) == "Instance" and humanoid:IsA("Humanoid"), "No humanoid")
+
+	if not humanoid:GetStateEnabled(Enum.HumanoidStateType.Jumping) then
+		return false
+	end
+
+	if humanoid.UseJumpPower then
+		return humanoid.JumpPower > 0
+	else
+		return humanoid.JumpHeight > 0
+	end
+end
+
+--[=[
 	Forcefully unseats the humanoid. Useful when teleporting humanoid.
 	Definitely a non-intuitive operation to do safely.
 

--- a/src/humanoidutils/src/Shared/HumanoidUtils.spec.lua
+++ b/src/humanoidutils/src/Shared/HumanoidUtils.spec.lua
@@ -1,0 +1,186 @@
+--!strict
+--[[
+	@class HumanoidUtils.spec.lua
+]]
+
+local require = require(script.Parent.loader).load(script)
+
+local HumanoidUtils = require("HumanoidUtils")
+local Jest = require("Jest")
+local Maid = require("Maid")
+
+local describe = Jest.Globals.describe
+local expect = Jest.Globals.expect
+local it = Jest.Globals.it
+
+local function setup(): any
+	local maid = Maid.new()
+
+	local controller = {
+		newHumanoid = function(): Humanoid
+			return maid:Add(Instance.new("Humanoid"))
+		end,
+		newRig = function(): (Model, Humanoid)
+			local rig = maid:Add(Instance.new("Model"))
+			local humanoid = Instance.new("Humanoid")
+			humanoid.Parent = rig
+			return rig, humanoid
+		end,
+		destroy = function()
+			maid:DoCleaning()
+		end,
+	}
+
+	return controller
+end
+
+describe("HumanoidUtils.getHumanoid", function()
+	it("finds the humanoid from a limb", function()
+		local controller = setup()
+		local rig, humanoid = controller.newRig()
+
+		local limb = Instance.new("Part")
+		limb.Parent = rig
+
+		expect(HumanoidUtils.getHumanoid(limb)).toBe(humanoid)
+
+		controller.destroy()
+	end)
+
+	it("finds the humanoid from a nested descendant", function()
+		local controller = setup()
+		local rig, humanoid = controller.newRig()
+
+		local accessory = Instance.new("Model")
+		accessory.Parent = rig
+
+		local handle = Instance.new("Part")
+		handle.Parent = accessory
+
+		expect(HumanoidUtils.getHumanoid(handle)).toBe(humanoid)
+
+		controller.destroy()
+	end)
+
+	it("returns nil outside of a humanoid model", function()
+		local controller = setup()
+
+		local part = Instance.new("Part")
+
+		expect(HumanoidUtils.getHumanoid(part)).toBeNil()
+
+		controller.destroy()
+	end)
+end)
+
+describe("HumanoidUtils.isHumanoidStateEnabled", function()
+	it("errors without a humanoid", function()
+		local controller = setup()
+
+		expect(function()
+			(HumanoidUtils :: any).isHumanoidStateEnabled(nil, Enum.HumanoidStateType.Jumping)
+		end).toThrow("No humanoid")
+
+		controller.destroy()
+	end)
+
+	it("errors without a state type", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		expect(function()
+			(HumanoidUtils :: any).isHumanoidStateEnabled(humanoid, nil)
+		end).toThrow("No stateType")
+
+		controller.destroy()
+	end)
+
+	it("reads the enabled state per state type", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Jumping, false)
+
+		expect(HumanoidUtils.isHumanoidStateEnabled(humanoid, Enum.HumanoidStateType.Jumping)).toBe(false)
+		expect(HumanoidUtils.isHumanoidStateEnabled(humanoid, Enum.HumanoidStateType.Climbing)).toBe(true)
+
+		controller.destroy()
+	end)
+end)
+
+describe("HumanoidUtils.isJumpEnabled", function()
+	it("errors without a humanoid", function()
+		local controller = setup()
+
+		expect(function()
+			(HumanoidUtils :: any).isJumpEnabled(nil)
+		end).toThrow("No humanoid")
+
+		controller.destroy()
+	end)
+
+	it("is enabled for a default humanoid", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		expect(HumanoidUtils.isJumpEnabled(humanoid)).toBe(true)
+
+		controller.destroy()
+	end)
+
+	it("is disabled while the jumping state is disabled", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Jumping, false)
+
+		expect(HumanoidUtils.isJumpEnabled(humanoid)).toBe(false)
+
+		controller.destroy()
+	end)
+
+	it("reads jump power while UseJumpPower is true", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		humanoid.UseJumpPower = true
+		humanoid.JumpHeight = 7
+		humanoid.JumpPower = 0
+
+		expect(HumanoidUtils.isJumpEnabled(humanoid)).toBe(false)
+
+		humanoid.JumpPower = 50
+		expect(HumanoidUtils.isJumpEnabled(humanoid)).toBe(true)
+
+		controller.destroy()
+	end)
+
+	it("reads jump height while UseJumpPower is false", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		humanoid.UseJumpPower = false
+		humanoid.JumpPower = 50
+		humanoid.JumpHeight = 0
+
+		expect(HumanoidUtils.isJumpEnabled(humanoid)).toBe(false)
+
+		humanoid.JumpHeight = 7
+		expect(HumanoidUtils.isJumpEnabled(humanoid)).toBe(true)
+
+		controller.destroy()
+	end)
+end)
+
+describe("HumanoidUtils.forceUnseatHumanoid", function()
+	it("leaves an unseated humanoid unseated", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		HumanoidUtils.forceUnseatHumanoid(humanoid)
+
+		expect(humanoid.Sit).toBe(false)
+
+		controller.destroy()
+	end)
+end)

--- a/src/humanoidutils/src/Shared/RxHumanoidUtils.lua
+++ b/src/humanoidutils/src/Shared/RxHumanoidUtils.lua
@@ -5,8 +5,11 @@
 
 local require = require(script.Parent.loader).load(script)
 
+local HumanoidUtils = require("HumanoidUtils")
 local Maid = require("Maid")
 local Observable = require("Observable")
+local Rx = require("Rx")
+local RxInstanceUtils = require("RxInstanceUtils")
 
 local RxHumanoidUtils = {}
 
@@ -88,6 +91,58 @@ function RxHumanoidUtils.observeHumanoidStateType(humanoid: Humanoid): Observabl
 
 		return maid
 	end) :: any
+end
+
+--[=[
+	Observes whether a humanoid state type is enabled on the humanoid.
+
+	@param humanoid Humanoid
+	@param stateType Enum.HumanoidStateType
+	@return Observable<boolean>
+]=]
+function RxHumanoidUtils.observeHumanoidStateEnabled(
+	humanoid: Humanoid,
+	stateType: Enum.HumanoidStateType
+): Observable.Observable<boolean>
+	assert(typeof(humanoid) == "Instance" and humanoid:IsA("Humanoid"), "No humanoid")
+	assert(typeof(stateType) == "EnumItem", "No stateType")
+
+	return Rx.fromSignal(humanoid.StateEnabledChanged):Pipe({
+		Rx.where(function(changedStateType)
+			return changedStateType == stateType
+		end) :: any,
+		Rx.map(function(_changedStateType, isEnabled)
+			return isEnabled
+		end) :: any,
+		Rx.startFrom(function()
+			return { HumanoidUtils.isHumanoidStateEnabled(humanoid, stateType) }
+		end) :: any,
+		Rx.distinct() :: any,
+	}) :: any
+end
+
+--[=[
+	Observes whether the humanoid is allowed to jump. This is true when the jumping state is enabled
+	and the humanoid's jump strength is above zero, which is the strength Roblox reads for the
+	humanoid's [Humanoid.UseJumpPower] mode.
+
+	@param humanoid Humanoid
+	@return Observable<boolean>
+]=]
+function RxHumanoidUtils.observeJumpEnabled(humanoid: Humanoid): Observable.Observable<boolean>
+	assert(typeof(humanoid) == "Instance" and humanoid:IsA("Humanoid"), "No humanoid")
+
+	return Rx.combineLatest({
+		isJumpStateEnabled = RxHumanoidUtils.observeHumanoidStateEnabled(humanoid, Enum.HumanoidStateType.Jumping),
+		useJumpPower = RxInstanceUtils.observeProperty(humanoid, "UseJumpPower"),
+		jumpPower = RxInstanceUtils.observeProperty(humanoid, "JumpPower"),
+		jumpHeight = RxInstanceUtils.observeProperty(humanoid, "JumpHeight"),
+	}):Pipe({
+		Rx.map(function()
+			return HumanoidUtils.isJumpEnabled(humanoid)
+		end) :: any,
+		Rx.distinct() :: any,
+	}) :: any
 end
 
 return RxHumanoidUtils

--- a/src/humanoidutils/src/Shared/RxHumanoidUtils.spec.lua
+++ b/src/humanoidutils/src/Shared/RxHumanoidUtils.spec.lua
@@ -1,0 +1,312 @@
+--!strict
+--[[
+	@class RxHumanoidUtils.spec.lua
+]]
+
+local require = require(script.Parent.loader).load(script)
+
+local Jest = require("Jest")
+local Maid = require("Maid")
+local RxHumanoidUtils = require("RxHumanoidUtils")
+
+local describe = Jest.Globals.describe
+local expect = Jest.Globals.expect
+local it = Jest.Globals.it
+
+local function setup(): any
+	local maid = Maid.new()
+
+	local controller = {
+		newHumanoid = function(): Humanoid
+			return maid:Add(Instance.new("Humanoid"))
+		end,
+		record = function(observable: any): { any }
+			local values = {}
+			maid:GiveTask(observable:Subscribe(function(value)
+				table.insert(values, value)
+			end))
+			return values
+		end,
+		recordUntilStopped = function(observable: any): ({ any }, () -> ())
+			local values = {}
+			local subscription = maid:Add(observable:Subscribe(function(value)
+				table.insert(values, value)
+			end))
+			return values, function()
+				subscription:Destroy()
+			end
+		end,
+		destroy = function()
+			maid:DoCleaning()
+		end,
+	}
+
+	return controller
+end
+
+describe("RxHumanoidUtils.observeRunningSpeed", function()
+	it("errors without a humanoid", function()
+		local controller = setup()
+
+		expect(function()
+			(RxHumanoidUtils :: any).observeRunningSpeed(nil)
+		end).toThrow("No humanoid")
+
+		controller.destroy()
+	end)
+
+	-- Cloud runs never step the humanoid state machine, so Running/Jumping/Seated never fire and only
+	-- the initial emission is observable here.
+	it("emits a stopped speed on subscribe", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		local speeds = controller.record(RxHumanoidUtils.observeRunningSpeed(humanoid))
+
+		expect(speeds).toEqual({ 0 })
+
+		controller.destroy()
+	end)
+end)
+
+describe("RxHumanoidUtils.observeHumanoidStateType", function()
+	it("emits the current state type on subscribe", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		local stateTypes = controller.record(RxHumanoidUtils.observeHumanoidStateType(humanoid))
+
+		expect(stateTypes).toEqual({ humanoid:GetState() })
+
+		controller.destroy()
+	end)
+end)
+
+describe("RxHumanoidUtils.observeHumanoidStateEnabled", function()
+	it("errors without a humanoid", function()
+		local controller = setup()
+
+		expect(function()
+			(RxHumanoidUtils :: any).observeHumanoidStateEnabled(nil, Enum.HumanoidStateType.Jumping)
+		end).toThrow("No humanoid")
+
+		controller.destroy()
+	end)
+
+	it("errors without a state type", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		expect(function()
+			(RxHumanoidUtils :: any).observeHumanoidStateEnabled(humanoid, nil)
+		end).toThrow("No stateType")
+
+		controller.destroy()
+	end)
+
+	it("emits the current enabled state on subscribe", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		local enabled =
+			controller.record(RxHumanoidUtils.observeHumanoidStateEnabled(humanoid, Enum.HumanoidStateType.Jumping))
+
+		expect(enabled).toEqual({ true })
+
+		controller.destroy()
+	end)
+
+	it("emits when the state is disabled and re-enabled", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		local enabled =
+			controller.record(RxHumanoidUtils.observeHumanoidStateEnabled(humanoid, Enum.HumanoidStateType.Jumping))
+
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Jumping, false)
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Jumping, true)
+
+		expect(enabled).toEqual({ true, false, true })
+
+		controller.destroy()
+	end)
+
+	it("only emits distinct values", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		local enabled =
+			controller.record(RxHumanoidUtils.observeHumanoidStateEnabled(humanoid, Enum.HumanoidStateType.Jumping))
+
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Jumping, true)
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Jumping, false)
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Jumping, false)
+
+		expect(enabled).toEqual({ true, false })
+
+		controller.destroy()
+	end)
+
+	it("ignores other state types", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		local enabled =
+			controller.record(RxHumanoidUtils.observeHumanoidStateEnabled(humanoid, Enum.HumanoidStateType.Jumping))
+
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Climbing, false)
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Seated, false)
+
+		expect(enabled).toEqual({ true })
+
+		controller.destroy()
+	end)
+
+	it("stops emitting once unsubscribed", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		local enabled, stop = controller.recordUntilStopped(
+			RxHumanoidUtils.observeHumanoidStateEnabled(humanoid, Enum.HumanoidStateType.Jumping)
+		)
+
+		stop()
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Jumping, false)
+
+		expect(enabled).toEqual({ true })
+
+		controller.destroy()
+	end)
+end)
+
+describe("RxHumanoidUtils.observeJumpEnabled", function()
+	it("errors without a humanoid", function()
+		local controller = setup()
+
+		expect(function()
+			(RxHumanoidUtils :: any).observeJumpEnabled(nil)
+		end).toThrow("No humanoid")
+
+		controller.destroy()
+	end)
+
+	it("is enabled for a default humanoid", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		local enabled = controller.record(RxHumanoidUtils.observeJumpEnabled(humanoid))
+
+		expect(enabled).toEqual({ true })
+
+		controller.destroy()
+	end)
+
+	it("is disabled while the jumping state is disabled", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		local enabled = controller.record(RxHumanoidUtils.observeJumpEnabled(humanoid))
+
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Jumping, false)
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Jumping, true)
+
+		expect(enabled).toEqual({ true, false, true })
+
+		controller.destroy()
+	end)
+
+	it("reads jump power while UseJumpPower is true", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+		humanoid.UseJumpPower = true
+		humanoid.JumpHeight = 0
+
+		local enabled = controller.record(RxHumanoidUtils.observeJumpEnabled(humanoid))
+
+		humanoid.JumpPower = 0
+		humanoid.JumpPower = 50
+
+		expect(enabled).toEqual({ true, false, true })
+
+		controller.destroy()
+	end)
+
+	it("reads jump height while UseJumpPower is false", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+		humanoid.UseJumpPower = false
+		humanoid.JumpPower = 0
+
+		local enabled = controller.record(RxHumanoidUtils.observeJumpEnabled(humanoid))
+
+		humanoid.JumpHeight = 0
+		humanoid.JumpHeight = 7
+
+		expect(enabled).toEqual({ true, false, true })
+
+		controller.destroy()
+	end)
+
+	it("switches which jump strength it reads with UseJumpPower", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+		humanoid.UseJumpPower = true
+		humanoid.JumpPower = 50
+		humanoid.JumpHeight = 0
+
+		local enabled = controller.record(RxHumanoidUtils.observeJumpEnabled(humanoid))
+
+		humanoid.UseJumpPower = false
+		humanoid.UseJumpPower = true
+
+		expect(enabled).toEqual({ true, false, true })
+
+		controller.destroy()
+	end)
+
+	it("ignores the unused jump strength", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+		humanoid.UseJumpPower = true
+		humanoid.JumpPower = 50
+
+		local enabled = controller.record(RxHumanoidUtils.observeJumpEnabled(humanoid))
+
+		humanoid.JumpHeight = 0
+		humanoid.JumpHeight = 12
+
+		expect(enabled).toEqual({ true })
+
+		controller.destroy()
+	end)
+
+	it("stays disabled while both the state and the jump power are disabled", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+		humanoid.JumpPower = 0
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Jumping, false)
+
+		local enabled = controller.record(RxHumanoidUtils.observeJumpEnabled(humanoid))
+
+		humanoid:SetStateEnabled(Enum.HumanoidStateType.Jumping, true)
+		humanoid.JumpPower = 50
+
+		expect(enabled).toEqual({ false, true })
+
+		controller.destroy()
+	end)
+
+	it("stops emitting once unsubscribed", function()
+		local controller = setup()
+		local humanoid = controller.newHumanoid()
+
+		local enabled, stop = controller.recordUntilStopped(RxHumanoidUtils.observeJumpEnabled(humanoid))
+
+		stop()
+		humanoid.JumpPower = 0
+
+		expect(enabled).toEqual({ true })
+
+		controller.destroy()
+	end)
+end)

--- a/src/humanoidutils/src/jest.config.lua
+++ b/src/humanoidutils/src/jest.config.lua
@@ -1,0 +1,3 @@
+return {
+	testMatch = { "**/*.spec" },
+}

--- a/src/humanoidutils/test/default.project.json
+++ b/src/humanoidutils/test/default.project.json
@@ -1,0 +1,25 @@
+{
+  "name": "HumanoidutilsTest",
+  "globIgnorePaths": [
+    "**/.package-lock.json",
+    "**/.pnpm",
+    "**/.pnpm-workspace-state-v1.json",
+    "**/.modules.yaml",
+    "**/.ignored",
+    "**/.ignored_*"
+  ],
+  "tree": {
+    "$className": "DataModel",
+    "ServerScriptService": {
+      "$properties": {
+        "LoadStringEnabled": true
+      },
+      "humanoidutils": {
+        "$path": ".."
+      },
+      "Script": {
+        "$path": "scripts/Server"
+      }
+    }
+  }
+}

--- a/src/humanoidutils/test/scripts/Server/ServerMain.server.lua
+++ b/src/humanoidutils/test/scripts/Server/ServerMain.server.lua
@@ -1,0 +1,13 @@
+--[[
+	@class ServerMain
+]]
+local ServerScriptService = game:GetService("ServerScriptService")
+
+local root = ServerScriptService.humanoidutils
+local loader = root:FindFirstChild("LoaderUtils", true).Parent
+local require = require(loader).bootstrapGame(root)
+
+local NevermoreTestRunnerUtils = require("NevermoreTestRunnerUtils")
+if NevermoreTestRunnerUtils.runTestsIfNeededAsync(root) then
+	return
+end


### PR DESCRIPTION
Adds HumanoidUtils.isHumanoidStateEnabled and HumanoidUtils.isJumpEnabled, along with RxHumanoidUtils.observeHumanoidStateEnabled and RxHumanoidUtils.observeJumpEnabled so callers can react to jump availability changing. Jump availability reads JumpPower or JumpHeight depending on the humanoid's UseJumpPower mode, so callers no longer have to branch on that themselves. This also makes humanoidutils testable, with a jest config, a test place, and specs covering both modules.

Separately, this fixes the Claude pre-push hook that runs the Luau type check. It linted the session's primary worktree rather than the worktree being pushed, so pushing a branch from a linked worktree failed on unrelated errors from whatever branch the primary had checked out. Fixing that also closed a hole where `git -C <dir> push` was not recognized as a push and skipped the type check entirely.