### PR TITLE
chore(package): correct repository directory and url metadata

### DIFF
--- a/src/buffer-encoder/package.json
+++ b/src/buffer-encoder/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/Quenty/NevermoreEngine.git",
-    "directory": "src/bufferencoder/"
+    "directory": "src/buffer-encoder/"
   },
   "funding": {
     "type": "patreon",

--- a/src/queue/package.json
+++ b/src/queue/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/Quenty/NevermoreEngine.git",
-    "directory": "ssrc/queue/"
+    "directory": "src/queue/"
   },
   "funding": {
     "type": "patreon",

--- a/src/racketingropeconstraint/package.json
+++ b/src/racketingropeconstraint/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/Quenty/NevermoreEngine.git",
-    "directory": "ssrc/racketingropeconstraint/"
+    "directory": "src/racketingropeconstraint/"
   },
   "funding": {
     "type": "patreon",

--- a/tools/cli-output-helpers/package.json
+++ b/tools/cli-output-helpers/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Quenty/Nevermore.git",
+    "url": "https://github.com/Quenty/NevermoreEngine.git",
     "directory": "tools/cli-output-helpers/"
   },
   "license": "UNLICENSED",

--- a/tools/nevermore-claude/package.json
+++ b/tools/nevermore-claude/package.json
@@ -15,7 +15,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/Quenty/NevermoreEngine.git",
-    "directory": "tools/nevermore-claude"
+    "directory": "tools/nevermore-claude/"
   },
   "scripts": {
     "version": "node scripts/sync-plugin-version.mjs && git add .claude-plugin/plugin.json",

--- a/tools/nevermore-cli-helpers/package.json
+++ b/tools/nevermore-cli-helpers/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Quenty/Nevermore.git",
+    "url": "https://github.com/Quenty/NevermoreEngine.git",
     "directory": "tools/nevermore-cli-helpers/"
   },
   "license": "UNLICENSED",

--- a/tools/nevermore-cli/package.json
+++ b/tools/nevermore-cli/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Quenty/Nevermore.git",
+    "url": "https://github.com/Quenty/NevermoreEngine.git",
     "directory": "tools/nevermore-cli/"
   },
   "license": "MIT",

--- a/tools/nevermore-deploy/package.json
+++ b/tools/nevermore-deploy/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Quenty/Nevermore.git",
+    "url": "https://github.com/Quenty/NevermoreEngine.git",
     "directory": "tools/nevermore-deploy/"
   },
   "license": "UNLICENSED",

--- a/tools/nevermore-template-helpers/package.json
+++ b/tools/nevermore-template-helpers/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Quenty/Nevermore.git",
+    "url": "https://github.com/Quenty/NevermoreEngine.git",
     "directory": "tools/nevermore-template-helpers/"
   },
   "license": "UNLICENSED",

--- a/tools/nevermore-vscode/package.json
+++ b/tools/nevermore-vscode/package.json
@@ -11,8 +11,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Quenty/Nevermore.git",
-    "directory": "tools/nevermore-cli/"
+    "url": "https://github.com/Quenty/NevermoreEngine.git",
+    "directory": "tools/nevermore-vscode/"
   },
   "publisher": "Quenty",
   "scripts": {


### PR DESCRIPTION
Ten workspace packages declared a `repository` block that doesn't match where the package actually lives, so npm's source link on those pages points at a path that isn't there.

Four had a wrong directory: `queue` and `racketingropeconstraint` both said `ssrc/`, `buffer-encoder` said `src/bufferencoder/`, and `nevermore-vscode` pointed at `tools/nevermore-cli/` — a different package. `nevermore-claude` was missing the trailing slash that the other 288 packages use. Six tools packages still referenced `Quenty/Nevermore.git` from before the repo was renamed to NevermoreEngine.

Found by auditing every workspace package.json against its path on disk; the two conventions were confirmed by counting rather than assumed. This is metadata only, so it's a chore — releasing ten packages for a link typo, nevermore-cli included, is more churn than it's worth.