### PR TITLE
fix(player-mock): Give PlayerMockService its own type so callers do not need a cast

### DIFF
--- a/src/player-mock/src/Server/PlayerMockService.lua
+++ b/src/player-mock/src/Server/PlayerMockService.lua
@@ -30,7 +30,11 @@ local Players = game:GetService("Players")
 local PlayerMock = require("PlayerMock")
 local PlayerMockServiceBase = require("PlayerMockServiceBase")
 
-local PlayerMockService = setmetatable({}, { __index = PlayerMockServiceBase })
+export type PlayerMockService = PlayerMockServiceBase.PlayerMockServiceBase & {
+	CreatePlayer: (self: PlayerMockService, overrides: { [string]: any }?) -> Player,
+}
+
+local PlayerMockService = (setmetatable({}, { __index = PlayerMockServiceBase }) :: any) :: PlayerMockService
 PlayerMockService.ServiceName = "PlayerMockService"
 PlayerMockService._consumedAttributeName = "PlayerMockConsumedServer"
 PlayerMockService._allowConcurrentConsumers = false
@@ -44,10 +48,7 @@ PlayerMockService._allowConcurrentConsumers = false
 	@param overrides { [string]: any }? -- Per-property seed values, e.g. `{ UserId = 12345 }` (see [PlayerMock.new]).
 	@return Player
 ]=]
-function PlayerMockService.CreatePlayer(
-	self: PlayerMockServiceBase.PlayerMockServiceBase,
-	overrides: { [string]: any }?
-): Player
+function PlayerMockService.CreatePlayer(self: PlayerMockService, overrides: { [string]: any }?): Player
 	local player = PlayerMock.new(overrides)
 	player.Parent = Players
 


### PR DESCRIPTION
PlayerMockService annotated CreatePlayer's self parameter as PlayerMockServiceBase, but the module table it is called on carries no instance fields of its own, so serviceBag:GetService(PlayerMockService):CreatePlayer() never typechecked and every call site in this repo and in consuming repos had to launder the service through `any` first. Declaring the module table as its own exported type, intersected with the base so the inherited methods still resolve, makes those calls typecheck directly without a cast.

This is types only and changes nothing at runtime. The same latent issue exists on PlayerMockServiceClient, but fixing it there means reshaping its Init override to keep the base signature, so I left it for a follow-up.
